### PR TITLE
Split immutable and persistent interfaces

### DIFF
--- a/kotlinx-collections-immutable/src/main/kotlin/kotlinx/collections/immutable/AbstractImmutableMap.kt
+++ b/kotlinx-collections-immutable/src/main/kotlin/kotlinx/collections/immutable/AbstractImmutableMap.kt
@@ -165,20 +165,11 @@ internal fun <K, V> PMap<K, V>.contains(key: K, value: @UnsafeVariance V): Boole
     = this[key]?.let { candidate -> candidate == value } ?: (value == null && containsKey(key))
 
 
-private open class ImmutableCollectionWrapper<E>(protected val impl: Collection<E>) : ImmutableCollection<E> {
-    override val size: Int get() = impl.size
-    override fun isEmpty(): Boolean = impl.isEmpty()
-    override fun contains(element: @UnsafeVariance E): Boolean = impl.contains(element)
-    override fun containsAll(elements: Collection<@UnsafeVariance E>): Boolean = impl.containsAll(elements)
-    override fun iterator(): Iterator<E> = impl.iterator()
-
+private open class ImmutableCollectionWrapper<E>(protected val impl: Collection<E>) : ImmutableCollection<E>, Collection<E> by impl {
     override fun equals(other: Any?): Boolean = impl.equals(other)
     override fun hashCode(): Int = impl.hashCode()
     override fun toString(): String = impl.toString()
-
-    override fun builder(): ImmutableCollection.Builder<E> = ImmutableVectorList.emptyOf<E>().builder().apply { addAll(impl) }
 }
 
 private class ImmutableSetWrapper<E>(impl: Set<E>) : ImmutableSet<E>, ImmutableCollectionWrapper<E>(impl) {
-    override fun builder(): ImmutableSet.Builder<E> = ImmutableOrderedSet.emptyOf<E>().builder().apply { addAll(impl) }
 }

--- a/kotlinx-collections-immutable/src/main/kotlin/kotlinx/collections/immutable/AbstractImmutableMap.kt
+++ b/kotlinx-collections-immutable/src/main/kotlin/kotlinx/collections/immutable/AbstractImmutableMap.kt
@@ -16,6 +16,8 @@
 
 package kotlinx.collections.immutable
 
+import kotlinx.collections.immutable.adapters.ImmutableCollectionAdapter
+import kotlinx.collections.immutable.adapters.ImmutableSetAdapter
 import org.pcollections.PMap
 import java.util.ConcurrentModificationException
 
@@ -42,15 +44,15 @@ internal abstract class AbstractImmutableMap<K, out V> protected constructor(pro
     // should it be immutable set/collection or just read-only?
     private var _keys: ImmutableSet<K>? = null
     final override val keys: ImmutableSet<K> get() = _keys ?: createKeys().apply { _keys = this }
-    protected open fun createKeys(): ImmutableSet<K> = ImmutableSetWrapper(impl.keys)
+    protected open fun createKeys(): ImmutableSet<K> = ImmutableSetAdapter(impl.keys)
 
     private var _values: ImmutableCollection<V>? = null
     final override val values: ImmutableCollection<V> get() = _values ?: createValues().apply { _values = this }
-    protected open fun createValues(): ImmutableCollection<V> = ImmutableCollectionWrapper(impl.values)
+    protected open fun createValues(): ImmutableCollection<V> = ImmutableCollectionAdapter(impl.values)
 
     private var _entries: ImmutableSet<Map.Entry<K, V>>? = null
     final override val entries: ImmutableSet<Map.Entry<K, V>> get() = _entries ?: createEntries().apply { _entries = this }
-    protected open fun createEntries(): ImmutableSet<Map.Entry<K, V>> = ImmutableSetWrapper(impl.entries)
+    protected open fun createEntries(): ImmutableSet<Map.Entry<K, V>> = ImmutableSetAdapter(impl.entries)
 
     override fun put(key: K, value: @UnsafeVariance V): PersistentMap<K, V> = wrap(impl.plus(key, value))
     override fun putAll(m: Map<out K, @UnsafeVariance V>): PersistentMap<K, V> = wrap(impl.plusAll(m))
@@ -164,12 +166,3 @@ internal abstract class AbstractImmutableMap<K, out V> protected constructor(pro
 internal fun <K, V> PMap<K, V>.contains(key: K, value: @UnsafeVariance V): Boolean
     = this[key]?.let { candidate -> candidate == value } ?: (value == null && containsKey(key))
 
-
-private open class ImmutableCollectionWrapper<E>(protected val impl: Collection<E>) : ImmutableCollection<E>, Collection<E> by impl {
-    override fun equals(other: Any?): Boolean = impl.equals(other)
-    override fun hashCode(): Int = impl.hashCode()
-    override fun toString(): String = impl.toString()
-}
-
-private class ImmutableSetWrapper<E>(impl: Set<E>) : ImmutableSet<E>, ImmutableCollectionWrapper<E>(impl) {
-}

--- a/kotlinx-collections-immutable/src/main/kotlin/kotlinx/collections/immutable/AbstractImmutableSet.kt
+++ b/kotlinx-collections-immutable/src/main/kotlin/kotlinx/collections/immutable/AbstractImmutableSet.kt
@@ -19,7 +19,7 @@ package kotlinx.collections.immutable
 import org.pcollections.PSet
 import java.util.ConcurrentModificationException
 
-internal abstract class AbstractImmutableSet<out E> protected constructor(protected val impl: PSet<@UnsafeVariance E>) : ImmutableSet<E> {
+internal abstract class AbstractImmutableSet<out E> protected constructor(protected val impl: PSet<@UnsafeVariance E>) : PersistentSet<E> {
 
     override val size: Int get() = impl.size
     override fun isEmpty(): Boolean = impl.isEmpty()
@@ -31,15 +31,15 @@ internal abstract class AbstractImmutableSet<out E> protected constructor(protec
     override fun hashCode(): Int = impl.hashCode()
     override fun toString(): String = impl.toString()
 
-    override fun add(element: @UnsafeVariance E): ImmutableSet<E> = wrap(impl.plus(element))
+    override fun add(element: @UnsafeVariance E): PersistentSet<E> = wrap(impl.plus(element))
 
-    override fun addAll(elements: Collection<@UnsafeVariance E>): ImmutableSet<E> = wrap(impl.plusAll(elements))
+    override fun addAll(elements: Collection<@UnsafeVariance E>): PersistentSet<E> = wrap(impl.plusAll(elements))
 
-    override fun remove(element: @UnsafeVariance E): ImmutableSet<E> = wrap(impl.minus(element))
+    override fun remove(element: @UnsafeVariance E): PersistentSet<E> = wrap(impl.minus(element))
 
-    override fun removeAll(elements: Collection<@UnsafeVariance E>): ImmutableSet<E> = mutate { it.removeAll(elements) }
+    override fun removeAll(elements: Collection<@UnsafeVariance E>): PersistentSet<E> = mutate { it.removeAll(elements) }
 
-    override fun removeAll(predicate: (E) -> Boolean): ImmutableSet<E> = mutate { it.removeAll(predicate) }
+    override fun removeAll(predicate: (E) -> Boolean): PersistentSet<E> = mutate { it.removeAll(predicate) }
 
     override abstract fun clear(): AbstractImmutableSet<E>
 
@@ -47,7 +47,7 @@ internal abstract class AbstractImmutableSet<out E> protected constructor(protec
 
     protected abstract fun wrap(impl: PSet<@UnsafeVariance E>): AbstractImmutableSet<E>
 
-    abstract class Builder<E> internal constructor(protected var value: AbstractImmutableSet<E>, protected var impl: PSet<E>) : AbstractMutableSet<E>(), ImmutableSet.Builder<E> {
+    abstract class Builder<E> internal constructor(protected var value: AbstractImmutableSet<E>, protected var impl: PSet<E>) : AbstractMutableSet<E>(), PersistentSet.Builder<E> {
         override fun build(): AbstractImmutableSet<E> = value.wrap(impl).apply { value = this }
         // delegating to impl
         override val size: Int get() = impl.size

--- a/kotlinx-collections-immutable/src/main/kotlin/kotlinx/collections/immutable/ImmutableCollection.kt
+++ b/kotlinx-collections-immutable/src/main/kotlin/kotlinx/collections/immutable/ImmutableCollection.kt
@@ -16,31 +16,24 @@
 
 package kotlinx.collections.immutable
 
-public interface ImmutableCollection<out E>: Collection<E> {
+public interface ImmutableCollection<out E>: Collection<E>
+
+public interface PersistentCollection<out E> : ImmutableCollection<E> {
+    fun add(element: @UnsafeVariance E): PersistentCollection<E>
+
+    fun addAll(elements: Collection<@UnsafeVariance E>): PersistentCollection<E>
+
+    fun remove(element: @UnsafeVariance E): PersistentCollection<E>
+
+    fun removeAll(elements: Collection<@UnsafeVariance E>): PersistentCollection<E>
+
+    fun removeAll(predicate: (E) -> Boolean): PersistentCollection<E>
+
+    fun clear(): PersistentCollection<E>
 
     interface Builder<E>: MutableCollection<E> {
-        fun build(): ImmutableCollection<E>
+        fun build(): PersistentCollection<E>
     }
 
     fun builder(): Builder<@UnsafeVariance E>
-}
-
-public interface PersistentCollection<out E> : ImmutableCollection<E> {
-    fun add(element: @UnsafeVariance E): ImmutableCollection<E>
-
-    fun addAll(elements: Collection<@UnsafeVariance E>): ImmutableCollection<E>
-
-    fun remove(element: @UnsafeVariance E): ImmutableCollection<E>
-
-    fun removeAll(elements: Collection<@UnsafeVariance E>): ImmutableCollection<E>
-
-    fun removeAll(predicate: (E) -> Boolean): ImmutableCollection<E>
-
-    fun clear(): ImmutableCollection<E>
-
-    interface Builder<E>: ImmutableCollection.Builder<E> {
-        override fun build(): PersistentCollection<E>
-    }
-
-    override fun builder(): Builder<@UnsafeVariance E>
 }

--- a/kotlinx-collections-immutable/src/main/kotlin/kotlinx/collections/immutable/ImmutableCollection.kt
+++ b/kotlinx-collections-immutable/src/main/kotlin/kotlinx/collections/immutable/ImmutableCollection.kt
@@ -17,6 +17,15 @@
 package kotlinx.collections.immutable
 
 public interface ImmutableCollection<out E>: Collection<E> {
+
+    interface Builder<E>: MutableCollection<E> {
+        fun build(): ImmutableCollection<E>
+    }
+
+    fun builder(): Builder<@UnsafeVariance E>
+}
+
+public interface PersistentCollection<out E> : ImmutableCollection<E> {
     fun add(element: @UnsafeVariance E): ImmutableCollection<E>
 
     fun addAll(elements: Collection<@UnsafeVariance E>): ImmutableCollection<E>
@@ -29,9 +38,9 @@ public interface ImmutableCollection<out E>: Collection<E> {
 
     fun clear(): ImmutableCollection<E>
 
-    interface Builder<E>: MutableCollection<E> {
-        fun build(): ImmutableCollection<E>
+    interface Builder<E>: ImmutableCollection.Builder<E> {
+        override fun build(): PersistentCollection<E>
     }
 
-    fun builder(): Builder<@UnsafeVariance E>
+    override fun builder(): Builder<@UnsafeVariance E>
 }

--- a/kotlinx-collections-immutable/src/main/kotlin/kotlinx/collections/immutable/ImmutableHashMap.kt
+++ b/kotlinx-collections-immutable/src/main/kotlin/kotlinx/collections/immutable/ImmutableHashMap.kt
@@ -23,7 +23,7 @@ internal class ImmutableHashMap<K, out V> private constructor(impl: PMap<K, V>) 
     override fun wrap(impl: PMap<K, @UnsafeVariance V>): ImmutableHashMap<K, V>
             = if (this.impl === impl) this else ImmutableHashMap(impl)
 
-    override fun clear(): ImmutableMap<K, V> = emptyOf()
+    override fun clear(): PersistentMap<K, V> = emptyOf()
 
     override fun builder(): Builder<K, @UnsafeVariance V> = Builder(this, impl)
 

--- a/kotlinx-collections-immutable/src/main/kotlin/kotlinx/collections/immutable/ImmutableList.kt
+++ b/kotlinx-collections-immutable/src/main/kotlin/kotlinx/collections/immutable/ImmutableList.kt
@@ -16,9 +16,34 @@
 
 package kotlinx.collections.immutable
 
+import kotlinx.collections.immutable.internal.ListImplementation
+
 public interface ImmutableList<out E> : List<E>, ImmutableCollection<E> {
 
-    override fun subList(fromIndex: Int, toIndex: Int): ImmutableList<E>
+    override fun subList(fromIndex: Int, toIndex: Int): ImmutableList<E> = SubList(this, fromIndex, toIndex)
+
+    public class SubList<E>(private val source: ImmutableList<E>, private val fromIndex: Int, private val toIndex: Int) : ImmutableList<E>, AbstractList<E>() {
+        private var _size: Int = 0
+
+        init {
+            ListImplementation.checkRangeIndexes(fromIndex, toIndex, source.size)
+            this._size = toIndex - fromIndex
+        }
+
+        override fun get(index: Int): E {
+            ListImplementation.checkElementIndex(index, _size)
+
+            return source[fromIndex + index]
+        }
+
+        override val size: Int get() = _size
+
+        override fun subList(fromIndex: Int, toIndex: Int): ImmutableList<E> {
+            ListImplementation.checkRangeIndexes(fromIndex, toIndex, this._size)
+            return SubList(source, this.fromIndex + fromIndex, this.fromIndex + toIndex)
+        }
+
+    }
 }
 
 public interface PersistentList<out E> : ImmutableList<E>, PersistentCollection<E> {

--- a/kotlinx-collections-immutable/src/main/kotlin/kotlinx/collections/immutable/ImmutableList.kt
+++ b/kotlinx-collections-immutable/src/main/kotlin/kotlinx/collections/immutable/ImmutableList.kt
@@ -18,15 +18,7 @@ package kotlinx.collections.immutable
 
 public interface ImmutableList<out E> : List<E>, ImmutableCollection<E> {
 
-
-
     override fun subList(fromIndex: Int, toIndex: Int): ImmutableList<E>
-
-    interface Builder<E>: MutableList<E>, ImmutableCollection.Builder<E> {
-        override fun build(): ImmutableList<E>
-    }
-
-    override fun builder(): Builder<@UnsafeVariance E>
 }
 
 public interface PersistentList<out E> : ImmutableList<E>, PersistentCollection<E> {
@@ -54,7 +46,7 @@ public interface PersistentList<out E> : ImmutableList<E>, PersistentCollection<
 
     fun removeAt(index: Int): PersistentList<E>
 
-    interface Builder<E>: ImmutableList.Builder<E>, PersistentCollection.Builder<E> {
+    interface Builder<E>: MutableList<E>, PersistentCollection.Builder<E> {
         override fun build(): PersistentList<E>
     }
 

--- a/kotlinx-collections-immutable/src/main/kotlin/kotlinx/collections/immutable/ImmutableList.kt
+++ b/kotlinx-collections-immutable/src/main/kotlin/kotlinx/collections/immutable/ImmutableList.kt
@@ -16,36 +16,46 @@
 
 package kotlinx.collections.immutable
 
-public interface ImmutableList<out E>: List<E>, ImmutableCollection<E> {
-    override fun add(element: @UnsafeVariance E): ImmutableList<E>
+public interface ImmutableList<out E> : List<E>, ImmutableCollection<E> {
 
-    override fun addAll(elements: Collection<@UnsafeVariance E>): ImmutableList<E> // = super<ImmutableCollection>.addAll(elements) as ImmutableList
-
-    override fun remove(element: @UnsafeVariance E): ImmutableList<E>
-
-    override fun removeAll(elements: Collection<@UnsafeVariance E>): ImmutableList<E>
-
-    override fun removeAll(predicate: (E) -> Boolean): ImmutableList<E>
-
-    override fun clear(): ImmutableList<E>
-
-
-    fun addAll(index: Int, c: Collection<@UnsafeVariance E>): ImmutableList<E> // = builder().apply { addAll(index, c.toList()) }.build()
-
-    fun set(index: Int, element: @UnsafeVariance E): ImmutableList<E>
-
-    /**
-     * Inserts an element into the list at the specified [index].
-     */
-    fun add(index: Int, element: @UnsafeVariance E): ImmutableList<E>
-
-    fun removeAt(index: Int): ImmutableList<E>
 
 
     override fun subList(fromIndex: Int, toIndex: Int): ImmutableList<E>
 
     interface Builder<E>: MutableList<E>, ImmutableCollection.Builder<E> {
         override fun build(): ImmutableList<E>
+    }
+
+    override fun builder(): Builder<@UnsafeVariance E>
+}
+
+public interface PersistentList<out E> : ImmutableList<E>, PersistentCollection<E> {
+    override fun add(element: @UnsafeVariance E): PersistentList<E>
+
+    override fun addAll(elements: Collection<@UnsafeVariance E>): PersistentList<E> // = super<ImmutableCollection>.addAll(elements) as ImmutableList
+
+    override fun remove(element: @UnsafeVariance E): PersistentList<E>
+
+    override fun removeAll(elements: Collection<@UnsafeVariance E>): PersistentList<E>
+
+    override fun removeAll(predicate: (E) -> Boolean): PersistentList<E>
+
+    override fun clear(): PersistentList<E>
+
+
+    fun addAll(index: Int, c: Collection<@UnsafeVariance E>): PersistentList<E> // = builder().apply { addAll(index, c.toList()) }.build()
+
+    fun set(index: Int, element: @UnsafeVariance E): PersistentList<E>
+
+    /**
+     * Inserts an element into the list at the specified [index].
+     */
+    fun add(index: Int, element: @UnsafeVariance E): PersistentList<E>
+
+    fun removeAt(index: Int): PersistentList<E>
+
+    interface Builder<E>: ImmutableList.Builder<E>, PersistentCollection.Builder<E> {
+        override fun build(): PersistentList<E>
     }
 
     override fun builder(): Builder<@UnsafeVariance E>

--- a/kotlinx-collections-immutable/src/main/kotlin/kotlinx/collections/immutable/ImmutableMap.kt
+++ b/kotlinx-collections-immutable/src/main/kotlin/kotlinx/collections/immutable/ImmutableMap.kt
@@ -19,21 +19,11 @@ package kotlinx.collections.immutable
 
 public interface ImmutableMap<K, out V>: Map<K, V> {
 
-    override val keys: Set<K>
+    override val keys: ImmutableSet<K>
 
-    override val values: Collection<V>
+    override val values: ImmutableCollection<V>
 
-    override val entries: Set<Map.Entry<K, V>>
-
-    fun put(key: K, value: @UnsafeVariance V): ImmutableMap<K, V>
-
-    fun remove(key: K): ImmutableMap<K, V>
-
-    fun remove(key: K, value: @UnsafeVariance V): ImmutableMap<K, V>
-
-    fun putAll(m: Map<out K, @UnsafeVariance V>): ImmutableMap<K, V>  // m: Iterable<Map.Entry<K, V>> or Map<out K,V> or Iterable<Pair<K, V>>
-
-    fun clear(): ImmutableMap<K, V>
+    override val entries: ImmutableSet<Map.Entry<K, V>>
 
     interface Builder<K, V>: MutableMap<K, V> {
         fun build(): ImmutableMap<K, V>
@@ -44,3 +34,20 @@ public interface ImmutableMap<K, out V>: Map<K, V> {
 
 
 
+public interface PersistentMap<K, out V> : ImmutableMap<K, V> {
+    fun put(key: K, value: @UnsafeVariance V): PersistentMap<K, V>
+
+    fun remove(key: K): PersistentMap<K, V>
+
+    fun remove(key: K, value: @UnsafeVariance V): PersistentMap<K, V>
+
+    fun putAll(m: Map<out K, @UnsafeVariance V>): PersistentMap<K, V>  // m: Iterable<Map.Entry<K, V>> or Map<out K,V> or Iterable<Pair<K, V>>
+
+    fun clear(): PersistentMap<K, V>
+
+    interface Builder<K, V>: ImmutableMap.Builder<K, V> {
+        override fun build(): PersistentMap<K, V>
+    }
+
+    override fun builder(): Builder<K, @UnsafeVariance V>
+}

--- a/kotlinx-collections-immutable/src/main/kotlin/kotlinx/collections/immutable/ImmutableMap.kt
+++ b/kotlinx-collections-immutable/src/main/kotlin/kotlinx/collections/immutable/ImmutableMap.kt
@@ -24,12 +24,6 @@ public interface ImmutableMap<K, out V>: Map<K, V> {
     override val values: ImmutableCollection<V>
 
     override val entries: ImmutableSet<Map.Entry<K, V>>
-
-    interface Builder<K, V>: MutableMap<K, V> {
-        fun build(): ImmutableMap<K, V>
-    }
-
-    fun builder(): Builder<K, @UnsafeVariance V>
 }
 
 
@@ -45,9 +39,9 @@ public interface PersistentMap<K, out V> : ImmutableMap<K, V> {
 
     fun clear(): PersistentMap<K, V>
 
-    interface Builder<K, V>: ImmutableMap.Builder<K, V> {
-        override fun build(): PersistentMap<K, V>
+    interface Builder<K, V>: MutableMap<K, V> {
+        fun build(): PersistentMap<K, V>
     }
 
-    override fun builder(): Builder<K, @UnsafeVariance V>
+    fun builder(): Builder<K, @UnsafeVariance V>
 }

--- a/kotlinx-collections-immutable/src/main/kotlin/kotlinx/collections/immutable/ImmutableOrderedMap.kt
+++ b/kotlinx-collections-immutable/src/main/kotlin/kotlinx/collections/immutable/ImmutableOrderedMap.kt
@@ -21,7 +21,7 @@ import org.pcollections.PMap
 import java.util.ConcurrentModificationException
 
 
-internal class ImmutableOrderedMap<K, out V> private constructor(private val impl: PMap<K, LinkedEntry<K, V>>) : PersistentMap<K, V>, AbstractMap<K, V>() {
+internal class ImmutableOrderedMap<K, out V> private constructor(private val impl: PMap<K, LinkedEntry<K, V>>) : AbstractMap<K, V>(), PersistentMap<K, V> {
     // TODO: Keep reference to first/last entry
 
     protected class LinkedEntry<out K, out V>(val key: K, val value: @UnsafeVariance V, val prevKey: Any?, val nextKey: Any?) {
@@ -58,6 +58,10 @@ internal class ImmutableOrderedMap<K, out V> private constructor(private val imp
     private var _entries: ImmutableSet<Map.Entry<K, V>>? = null
     final override val entries: ImmutableSet<Map.Entry<K, V>> get() = _entries ?: createEntries().apply { _entries = this }
     private fun createEntries(): ImmutableSet<Map.Entry<K, V>> = OrderedEntrySet()
+
+    // TODO: compiler bug: this bridge should be generated automatically
+    @PublishedApi
+    internal fun getEntries(): Set<Map.Entry<K, V>> = _entries ?: createEntries().apply { _entries = this }
 
     override fun put(key: K, value: @UnsafeVariance V): PersistentMap<K, V> = wrap(impl.putEntry(impl[key], key, value))
     override fun putAll(m: Map<out K, @UnsafeVariance V>): PersistentMap<K, V> {
@@ -245,10 +249,6 @@ internal class ImmutableOrderedMap<K, out V> private constructor(private val imp
         override fun isEmpty(): Boolean = impl.isEmpty()
         private val mapped = entrySequence.map { it.mapEntry }
         override fun iterator(): Iterator<Map.Entry<K, V>> = mapped.iterator()
-
-        override fun builder(): ImmutableSet.Builder<Map.Entry<K, @UnsafeVariance V>> {
-            TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
-        }
     }
 
     private inner class OrderedKeySet : AbstractSet<K>(), ImmutableSet<K> {
@@ -260,10 +260,6 @@ internal class ImmutableOrderedMap<K, out V> private constructor(private val imp
 
         private val mapped = entrySequence.map { it.key }
         override fun iterator(): Iterator<K> = mapped.iterator()
-
-        override fun builder(): ImmutableSet.Builder<K> {
-            TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
-        }
     }
 
     private inner class OrderedValueCollection : AbstractCollection<V>(), ImmutableCollection<V> {
@@ -275,9 +271,6 @@ internal class ImmutableOrderedMap<K, out V> private constructor(private val imp
         private val mapped = entrySequence.map { it.value }
         override fun iterator(): Iterator<V> = mapped.iterator()
 
-        override fun builder(): ImmutableCollection.Builder<@UnsafeVariance V> {
-            TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
-        }
     }
 }
 

--- a/kotlinx-collections-immutable/src/main/kotlin/kotlinx/collections/immutable/ImmutableOrderedMap.kt
+++ b/kotlinx-collections-immutable/src/main/kotlin/kotlinx/collections/immutable/ImmutableOrderedMap.kt
@@ -21,7 +21,7 @@ import org.pcollections.PMap
 import java.util.ConcurrentModificationException
 
 
-internal class ImmutableOrderedMap<K, out V> private constructor(private val impl: PMap<K, LinkedEntry<K, V>>) : ImmutableMap<K, V>, AbstractMap<K, V>() {
+internal class ImmutableOrderedMap<K, out V> private constructor(private val impl: PMap<K, LinkedEntry<K, V>>) : PersistentMap<K, V>, AbstractMap<K, V>() {
     // TODO: Keep reference to first/last entry
 
     protected class LinkedEntry<out K, out V>(val key: K, val value: @UnsafeVariance V, val prevKey: Any?, val nextKey: Any?) {
@@ -47,42 +47,42 @@ internal class ImmutableOrderedMap<K, out V> private constructor(private val imp
 
 
     // should it be immutable set/collection or just read-only?
-    private var _keys: Set<K>? = null
-    final override val keys: Set<K> get() = _keys ?: createKeys().apply { _keys = this }
-    private fun createKeys(): Set<K> = OrderedKeySet()
+    private var _keys: ImmutableSet<K>? = null
+    final override val keys: ImmutableSet<K> get() = _keys ?: createKeys().apply { _keys = this }
+    private fun createKeys(): ImmutableSet<K> = OrderedKeySet()
 
-    private var _values: Collection<V>? = null
-    final override val values: Collection<V> get() = _values ?: createValues().apply { _values = this }
-    private fun createValues(): Collection<V> = OrderedValueCollection()
+    private var _values: ImmutableCollection<V>? = null
+    final override val values: ImmutableCollection<V> get() = _values ?: createValues().apply { _values = this }
+    private fun createValues(): ImmutableCollection<V> = OrderedValueCollection()
 
-    private var _entries: Set<Map.Entry<K, V>>? = null
-    final override val entries: Set<Map.Entry<K, V>> get() = _entries ?: createEntries().apply { _entries = this }
-    private fun createEntries(): Set<Map.Entry<K, V>> = OrderedEntrySet()
+    private var _entries: ImmutableSet<Map.Entry<K, V>>? = null
+    final override val entries: ImmutableSet<Map.Entry<K, V>> get() = _entries ?: createEntries().apply { _entries = this }
+    private fun createEntries(): ImmutableSet<Map.Entry<K, V>> = OrderedEntrySet()
 
-    override fun put(key: K, value: @UnsafeVariance V): ImmutableMap<K, V> = wrap(impl.putEntry(impl[key], key, value))
-    override fun putAll(m: Map<out K, @UnsafeVariance V>): ImmutableMap<K, V> {
+    override fun put(key: K, value: @UnsafeVariance V): PersistentMap<K, V> = wrap(impl.putEntry(impl[key], key, value))
+    override fun putAll(m: Map<out K, @UnsafeVariance V>): PersistentMap<K, V> {
         var newImpl = impl
         for ((k, v) in m)
             newImpl = newImpl.putEntry(newImpl[k], k, v)
 
         return wrap(newImpl)
     }
-    override fun remove(key: K): ImmutableMap<K, V> = wrap(impl.removeLinked(key))
+    override fun remove(key: K): PersistentMap<K, V> = wrap(impl.removeLinked(key))
 
-    override fun remove(key: K, value: @UnsafeVariance V): ImmutableMap<K, V>
+    override fun remove(key: K, value: @UnsafeVariance V): PersistentMap<K, V>
             = if (!impl.contains(key, value)) this else remove(key)
 
-    override fun clear(): ImmutableMap<K, V> = emptyOf()
+    override fun clear(): PersistentMap<K, V> = emptyOf()
 
-    override fun builder(): ImmutableMap.Builder<K, @UnsafeVariance V> = Builder(this, impl)
+    override fun builder(): PersistentMap.Builder<K, @UnsafeVariance V> = Builder(this, impl)
 
     protected fun wrap(impl: PMap<K, LinkedEntry<K, @UnsafeVariance V>>): ImmutableOrderedMap<K, V> {
         return if (impl === this.impl) this else ImmutableOrderedMap(impl)
     }
 
 
-    protected class Builder<K, V>(protected var value: ImmutableOrderedMap<K, V>, protected var impl: PMap<K, LinkedEntry<K, V>>) : ImmutableMap.Builder<K, V>, AbstractMutableMap<K, V>() {
-        override fun build(): ImmutableMap<K, V> = value.wrap(impl).apply { value = this }
+    protected class Builder<K, V>(protected var value: ImmutableOrderedMap<K, V>, protected var impl: PMap<K, LinkedEntry<K, V>>) : PersistentMap.Builder<K, V>, AbstractMutableMap<K, V>() {
+        override fun build(): PersistentMap<K, V> = value.wrap(impl).apply { value = this }
 
         override val size: Int get() = impl.size
         override fun isEmpty(): Boolean = impl.isEmpty()
@@ -238,16 +238,20 @@ internal class ImmutableOrderedMap<K, out V> private constructor(private val imp
 
     private val entrySequence = generateSequence(impl.firstEntry()) { e -> impl[e.nextKey] }
 
-    private inner class OrderedEntrySet : AbstractSet<Map.Entry<K, V>>() {
+    private inner class OrderedEntrySet : AbstractSet<Map.Entry<K, V>>(), ImmutableSet<Map.Entry<K, V>> {
         override val size: Int get() = impl.size
         override fun contains(element: Map.Entry<K, @UnsafeVariance V>): Boolean = impl.contains(element.key, element.value)
         override fun containsAll(elements: Collection<Map.Entry<K, @UnsafeVariance V>>): Boolean = elements.all { (k, v) -> impl.contains(k, v) }
         override fun isEmpty(): Boolean = impl.isEmpty()
         private val mapped = entrySequence.map { it.mapEntry }
         override fun iterator(): Iterator<Map.Entry<K, V>> = mapped.iterator()
+
+        override fun builder(): ImmutableSet.Builder<Map.Entry<K, @UnsafeVariance V>> {
+            TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+        }
     }
 
-    private inner class OrderedKeySet : AbstractSet<K>() {
+    private inner class OrderedKeySet : AbstractSet<K>(), ImmutableSet<K> {
         override val size: Int get() = impl.size
         override fun contains(element: K): Boolean = impl.containsKey(element)
         override fun containsAll(elements: Collection<K>): Boolean = impl.keys.containsAll(elements)
@@ -256,9 +260,13 @@ internal class ImmutableOrderedMap<K, out V> private constructor(private val imp
 
         private val mapped = entrySequence.map { it.key }
         override fun iterator(): Iterator<K> = mapped.iterator()
+
+        override fun builder(): ImmutableSet.Builder<K> {
+            TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+        }
     }
 
-    private inner class OrderedValueCollection : AbstractCollection<V>() {
+    private inner class OrderedValueCollection : AbstractCollection<V>(), ImmutableCollection<V> {
         override val size: Int get() = impl.size
         override fun contains(element: @UnsafeVariance V): Boolean = containsValue(element)
         override fun containsAll(elements: Collection<@UnsafeVariance V>): Boolean =  elements.all { v -> containsValue(v) }
@@ -266,6 +274,10 @@ internal class ImmutableOrderedMap<K, out V> private constructor(private val imp
 
         private val mapped = entrySequence.map { it.value }
         override fun iterator(): Iterator<V> = mapped.iterator()
+
+        override fun builder(): ImmutableCollection.Builder<@UnsafeVariance V> {
+            TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+        }
     }
 }
 

--- a/kotlinx-collections-immutable/src/main/kotlin/kotlinx/collections/immutable/ImmutableSet.kt
+++ b/kotlinx-collections-immutable/src/main/kotlin/kotlinx/collections/immutable/ImmutableSet.kt
@@ -17,20 +17,31 @@
 package kotlinx.collections.immutable
 
 public interface ImmutableSet<out E>: Set<E>, ImmutableCollection<E> {
-    override fun add(element: @UnsafeVariance E): ImmutableSet<E>
 
-    override fun addAll(elements: Collection<@UnsafeVariance E>): ImmutableSet<E>
-
-    override fun remove(element: @UnsafeVariance E): ImmutableSet<E>
-
-    override fun removeAll(elements: Collection<@UnsafeVariance E>): ImmutableSet<E>
-
-    override fun removeAll(predicate: (E) -> Boolean): ImmutableSet<E>
-
-    override fun clear(): ImmutableSet<E>
 
     interface Builder<E>: MutableSet<E>, ImmutableCollection.Builder<E> {
         override fun build(): ImmutableSet<E>
+    }
+
+    override fun builder(): Builder<@UnsafeVariance E>
+}
+
+public interface PersistentSet<out E> : ImmutableSet<E>, PersistentCollection<E> {
+    override fun add(element: @UnsafeVariance E): PersistentSet<E>
+
+    override fun addAll(elements: Collection<@UnsafeVariance E>): PersistentSet<E>
+
+    override fun remove(element: @UnsafeVariance E): PersistentSet<E>
+
+    override fun removeAll(elements: Collection<@UnsafeVariance E>): PersistentSet<E>
+
+    override fun removeAll(predicate: (E) -> Boolean): PersistentSet<E>
+
+    override fun clear(): PersistentSet<E>
+
+
+    interface Builder<E>: ImmutableSet.Builder<E>, PersistentCollection.Builder<E> {
+        override fun build(): PersistentSet<E>
     }
 
     override fun builder(): Builder<@UnsafeVariance E>

--- a/kotlinx-collections-immutable/src/main/kotlin/kotlinx/collections/immutable/ImmutableSet.kt
+++ b/kotlinx-collections-immutable/src/main/kotlin/kotlinx/collections/immutable/ImmutableSet.kt
@@ -16,15 +16,7 @@
 
 package kotlinx.collections.immutable
 
-public interface ImmutableSet<out E>: Set<E>, ImmutableCollection<E> {
-
-
-    interface Builder<E>: MutableSet<E>, ImmutableCollection.Builder<E> {
-        override fun build(): ImmutableSet<E>
-    }
-
-    override fun builder(): Builder<@UnsafeVariance E>
-}
+public interface ImmutableSet<out E>: Set<E>, ImmutableCollection<E>
 
 public interface PersistentSet<out E> : ImmutableSet<E>, PersistentCollection<E> {
     override fun add(element: @UnsafeVariance E): PersistentSet<E>
@@ -40,7 +32,7 @@ public interface PersistentSet<out E> : ImmutableSet<E>, PersistentCollection<E>
     override fun clear(): PersistentSet<E>
 
 
-    interface Builder<E>: ImmutableSet.Builder<E>, PersistentCollection.Builder<E> {
+    interface Builder<E>: MutableSet<E>, PersistentCollection.Builder<E> {
         override fun build(): PersistentSet<E>
     }
 

--- a/kotlinx-collections-immutable/src/main/kotlin/kotlinx/collections/immutable/ImmutableVectorList.kt
+++ b/kotlinx-collections-immutable/src/main/kotlin/kotlinx/collections/immutable/ImmutableVectorList.kt
@@ -58,9 +58,6 @@ internal class ImmutableVectorList<out E> private constructor(private val impl: 
 
     override fun removeAt(index: Int): PersistentList<E> = wrap(impl.minus(index))
 
-    // TODO: Make a view, not a copy
-    override fun subList(fromIndex: Int, toIndex: Int): ImmutableList<E> = wrap(impl.subList(fromIndex, toIndex))
-
     override fun clear(): PersistentList<E> = EMPTY
 
     override fun builder(): Builder<@UnsafeVariance E> = Builder(this, impl)

--- a/kotlinx-collections-immutable/src/main/kotlin/kotlinx/collections/immutable/ImmutableVectorList.kt
+++ b/kotlinx-collections-immutable/src/main/kotlin/kotlinx/collections/immutable/ImmutableVectorList.kt
@@ -18,7 +18,7 @@ package kotlinx.collections.immutable
 
 import org.pcollections.*
 
-internal class ImmutableVectorList<out E> private constructor(private val impl: PVector<E>) : ImmutableList<E> {
+internal class ImmutableVectorList<out E> private constructor(private val impl: PVector<E>) : PersistentList<E> {
 
     // delegating to impl
     override val size: Int get() = impl.size
@@ -37,30 +37,31 @@ internal class ImmutableVectorList<out E> private constructor(private val impl: 
 
 
 
-    override fun add(element: @UnsafeVariance E): ImmutableList<E> = wrap(impl.plus(element))
+    override fun add(element: @UnsafeVariance E): PersistentList<E> = wrap(impl.plus(element))
 
-    override fun add(index: Int, element: @UnsafeVariance E): ImmutableList<E> = wrap(impl.plus(index, element))
+    override fun add(index: Int, element: @UnsafeVariance E): PersistentList<E> = wrap(impl.plus(index, element))
 
-    override fun addAll(elements: Collection<@UnsafeVariance E>): ImmutableList<E> = wrap(impl.plusAll(elements))
+    override fun addAll(elements: Collection<@UnsafeVariance E>): PersistentList<E> = wrap(impl.plusAll(elements))
 
-    override fun addAll(index: Int, c: Collection<@UnsafeVariance E>): ImmutableList<E> = wrap(impl.plusAll(index, c))
+    override fun addAll(index: Int, c: Collection<@UnsafeVariance E>): PersistentList<E> = wrap(impl.plusAll(index, c))
 
-    override fun remove(element: @UnsafeVariance E): ImmutableList<E> = wrap(impl.minus(element))
+    override fun remove(element: @UnsafeVariance E): PersistentList<E> = wrap(impl.minus(element))
 
     // not minusAll
-    override fun removeAll(elements: Collection<@UnsafeVariance E>): ImmutableList<E> = mutate { it.removeAll(elements) }
+    override fun removeAll(elements: Collection<@UnsafeVariance E>): PersistentList<E> = mutate { it.removeAll(elements) }
 
-    override fun removeAll(predicate: (E) -> Boolean): ImmutableList<E> = mutate { it.removeAll(predicate) }
+    override fun removeAll(predicate: (E) -> Boolean): PersistentList<E> = mutate { it.removeAll(predicate) }
 
-    //    override fun retainAll(c: Collection<@UnsafeVariance E>): ImmutableList<E> = builder().apply { retainAll(c) }.build()
+    //    override fun retainAll(c: Collection<@UnsafeVariance E>): PersistentList<E> = builder().apply { retainAll(c) }.build()
 
-    override fun set(index: Int, element: @UnsafeVariance E): ImmutableList<E> = wrap(impl.with(index, element))
+    override fun set(index: Int, element: @UnsafeVariance E): PersistentList<E> = wrap(impl.with(index, element))
 
-    override fun removeAt(index: Int): ImmutableList<E> = wrap(impl.minus(index))
+    override fun removeAt(index: Int): PersistentList<E> = wrap(impl.minus(index))
 
+    // TODO: Make a view, not a copy
     override fun subList(fromIndex: Int, toIndex: Int): ImmutableList<E> = wrap(impl.subList(fromIndex, toIndex))
 
-    override fun clear(): ImmutableList<E> = EMPTY
+    override fun clear(): PersistentList<E> = EMPTY
 
     override fun builder(): Builder<@UnsafeVariance E> = Builder(this, impl)
 
@@ -74,7 +75,7 @@ internal class ImmutableVectorList<out E> private constructor(private val impl: 
         public fun <T> emptyOf(): ImmutableVectorList<T> = EMPTY
     }
 
-    class Builder<E> internal constructor(private var value: ImmutableVectorList<E>, private var impl: PVector<E>) : AbstractMutableList<E>(), ImmutableList.Builder<E> {
+    class Builder<E> internal constructor(private var value: ImmutableVectorList<E>, private var impl: PVector<E>) : AbstractMutableList<E>(), PersistentList.Builder<E> {
         override fun build(): ImmutableVectorList<E> = value.wrap(impl).apply { value = this }
         // delegating to impl
         override val size: Int get() = impl.size

--- a/kotlinx-collections-immutable/src/main/kotlin/kotlinx/collections/immutable/adapters/ReadOnlyCollectionAdapters.kt
+++ b/kotlinx-collections-immutable/src/main/kotlin/kotlinx/collections/immutable/adapters/ReadOnlyCollectionAdapters.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2016-2018 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kotlinx.collections.immutable.adapters
+
+import kotlinx.collections.immutable.*
+
+
+/*
+ These classes allow to expose read-only collection as immutable, if it's actually immutable one
+ Use with caution: wrapping mutable collection as immutable is a contract violation of the latter.
+ */
+
+public open class ImmutableCollectionAdapter<E>(private val impl: Collection<E>) : ImmutableCollection<E>, Collection<E> by impl {
+    override fun equals(other: Any?): Boolean = impl.equals(other)
+    override fun hashCode(): Int = impl.hashCode()
+    override fun toString(): String = impl.toString()
+}
+
+
+public class ImmutableListAdapter<E>(private val impl: List<E>) : ImmutableList<E>, List<E> by impl {
+
+    override fun subList(fromIndex: Int, toIndex: Int): ImmutableList<E> = ImmutableListAdapter(impl.subList(fromIndex, toIndex))
+
+    override fun equals(other: Any?): Boolean = impl.equals(other)
+    override fun hashCode(): Int = impl.hashCode()
+    override fun toString(): String = impl.toString()
+}
+
+
+public class ImmutableSetAdapter<E>(impl: Set<E>) : ImmutableSet<E>, ImmutableCollectionAdapter<E>(impl)
+
+
+public class ImmutableMapAdapter<K, out V>(private val impl: Map<K, V>) : ImmutableMap<K, V>, Map<K, V> by impl {
+    // TODO: Lazy initialize these properties?
+    override val keys: ImmutableSet<K> = ImmutableSetAdapter(impl.keys)
+    override val values: ImmutableCollection<V> = ImmutableCollectionAdapter(impl.values)
+    override val entries: ImmutableSet<Map.Entry<K, V>> = ImmutableSetAdapter(impl.entries)
+
+    override fun equals(other: Any?): Boolean = impl.equals(other)
+    override fun hashCode(): Int = impl.hashCode()
+    override fun toString(): String = impl.toString()
+}

--- a/kotlinx-collections-immutable/src/main/kotlin/kotlinx/collections/immutable/extensions.kt
+++ b/kotlinx-collections-immutable/src/main/kotlin/kotlinx/collections/immutable/extensions.kt
@@ -120,21 +120,41 @@ public operator fun <K, V> PersistentMap<out K, V>.minus(keys: Sequence<K>): Per
         = mutate { it.minusAssign(keys) }
 
 
-fun <E> immutableListOf(vararg elements: E): PersistentList<E> = ImmutableVectorList.emptyOf<E>().addAll(elements.asList())
-fun <E> immutableListOf(): PersistentList<E> = ImmutableVectorList.emptyOf<E>()
+fun <E> persistentListOf(vararg elements: E): PersistentList<E> = ImmutableVectorList.emptyOf<E>().addAll(elements.asList())
+fun <E> persistentListOf(): PersistentList<E> = ImmutableVectorList.emptyOf<E>()
 
-fun <E> immutableSetOf(vararg elements: E): PersistentSet<E> = ImmutableOrderedSet.emptyOf<E>().addAll(elements.asList())
-fun <E> immutableSetOf(): PersistentSet<E> = ImmutableOrderedSet.emptyOf<E>()
+fun <E> persistentSetOf(vararg elements: E): PersistentSet<E> = ImmutableOrderedSet.emptyOf<E>().addAll(elements.asList())
+fun <E> persistentSetOf(): PersistentSet<E> = ImmutableOrderedSet.emptyOf<E>()
 
-fun <E> immutableHashSetOf(vararg elements: E): PersistentSet<E> = ImmutableHashSet.emptyOf<E>().addAll(elements.asList())
+fun <E> persistentHashSetOf(vararg elements: E): PersistentSet<E> = ImmutableHashSet.emptyOf<E>().addAll(elements.asList())
 
-fun <K, V> immutableMapOf(vararg pairs: Pair<K, V>): PersistentMap<K, V> = ImmutableOrderedMap.emptyOf<K,V>().mutate { it += pairs }
-fun <K, V> immutableHashMapOf(vararg pairs: Pair<K, V>): PersistentMap<K, V> = ImmutableHashMap.emptyOf<K,V>().mutate { it += pairs }
+fun <K, V> persistentMapOf(vararg pairs: Pair<K, V>): PersistentMap<K, V> = ImmutableOrderedMap.emptyOf<K,V>().mutate { it += pairs }
+fun <K, V> persistentHashMapOf(vararg pairs: Pair<K, V>): PersistentMap<K, V> = ImmutableHashMap.emptyOf<K,V>().mutate { it += pairs }
+
+@Deprecated("Use persistentListOf instead.", ReplaceWith("persistentListOf(*elements)"))
+fun <E> immutableListOf(vararg elements: E): PersistentList<E> = persistentListOf(*elements)
+@Deprecated("Use persistentListOf instead.", ReplaceWith("persistentListOf()"))
+fun <E> immutableListOf(): PersistentList<E> = persistentListOf()
+
+@Deprecated("Use persistentSetOf instead.", ReplaceWith("persistentSetOf(*elements)"))
+fun <E> immutableSetOf(vararg elements: E): PersistentSet<E> = persistentSetOf(*elements)
+@Deprecated("Use persistentSetOf instead.", ReplaceWith("persistentSetOf()"))
+fun <E> immutableSetOf(): PersistentSet<E> = persistentSetOf()
+
+@Deprecated("Use persistentHashSetOf instead.", ReplaceWith("persistentHashSetOf(*elements)"))
+fun <E> immutableHashSetOf(vararg elements: E): PersistentSet<E> = persistentHashSetOf(*elements)
+
+@Deprecated("Use persistentMapOf instead.", ReplaceWith("persistentMapOf(*pairs)"))
+fun <K, V> immutableMapOf(vararg pairs: Pair<K, V>): PersistentMap<K, V> = persistentMapOf(*pairs)
+@Deprecated("Use persistentHashMapOf instead.", ReplaceWith("persistentHashMapOf(*pairs)"))
+fun <K, V> immutableHashMapOf(vararg pairs: Pair<K, V>): PersistentMap<K, V> = persistentHashMapOf(*pairs)
+
+
 
 fun <T> Iterable<T>.toImmutableList(): ImmutableList<T> =
         this as? ImmutableList
         ?: (this as? PersistentList.Builder)?.build()
-        ?: immutableListOf<T>() + this
+        ?: persistentListOf<T>() + this
 
 fun <T> Iterable<T>.toPersistentList(): PersistentList<T> =
         this as? PersistentList
@@ -147,21 +167,21 @@ fun <T> Iterable<T>.toPersistentList(): PersistentList<T> =
 fun CharSequence.toImmutableList(): ImmutableList<Char> = toPersistentList()
 
 fun CharSequence.toPersistentList(): PersistentList<Char> =
-    immutableListOf<Char>().mutate { this.toCollection(it) }
+    persistentListOf<Char>().mutate { this.toCollection(it) }
 
 fun CharSequence.toPersistentSet(): PersistentSet<Char> =
-    immutableSetOf<Char>().mutate { this.toCollection(it) }
+    persistentSetOf<Char>().mutate { this.toCollection(it) }
 
 
 fun <T> Iterable<T>.toImmutableSet(): ImmutableSet<T> =
         this as? ImmutableSet<T>
         ?: (this as? PersistentSet.Builder)?.build()
-        ?: immutableSetOf<T>() + this
+        ?: persistentSetOf<T>() + this
 
 fun <T> Iterable<T>.toPersistentSet(): PersistentSet<T> =
         this as? PersistentSet<T>
         ?: (this as? PersistentSet.Builder)?.build()
-        ?: immutableSetOf<T>() + this
+        ?: persistentSetOf<T>() + this
 
 fun <T> Set<T>.toPersistentHashSet(): PersistentSet<T>
     = this as? ImmutableHashSet

--- a/kotlinx-collections-immutable/src/main/kotlin/kotlinx/collections/immutable/extensions.kt
+++ b/kotlinx-collections-immutable/src/main/kotlin/kotlinx/collections/immutable/extensions.kt
@@ -21,116 +21,119 @@ package kotlinx.collections.immutable
 //@Suppress("INVISIBLE_MEMBER", "INVISIBLE_REFERENCE")
 //inline fun <T> @kotlin.internal.Exact ImmutableCollection<T>.mutate(mutator: (MutableCollection<T>) -> Unit): ImmutableCollection<T> = builder().apply(mutator).build()
 // it or this?
-inline fun <T, C : ImmutableSet<T>> C.mutate(mutator: (MutableSet<T>) -> Unit): C = builder().apply(mutator).build() as C
-inline fun <T, C : ImmutableList<T>> C.mutate(mutator: (MutableList<T>) -> Unit): C = builder().apply(mutator).build() as C
+inline fun <T> PersistentSet<T>.mutate(mutator: (MutableSet<T>) -> Unit): PersistentSet<T> = builder().apply(mutator).build()
+inline fun <T> PersistentList<T>.mutate(mutator: (MutableList<T>) -> Unit): PersistentList<T> = builder().apply(mutator).build()
 
-inline fun <K, V, M : ImmutableMap<out K, V>> M.mutate(mutator: (MutableMap<K, V>) -> Unit): M = (this as ImmutableMap<K, V>).builder().apply(mutator).build() as M
-
-
-operator fun <E, C : ImmutableCollection<E>> C.plus(element: E): C = builder().apply { add(element) }.build() as C
-operator fun <E, C : ImmutableCollection<E>> C.minus(element: E): C = builder().apply { remove(element) }.build() as C
+inline fun <K, V> PersistentMap<out K, V>.mutate(mutator: (MutableMap<K, V>) -> Unit): PersistentMap<K, V> =
+        (this as PersistentMap<K, V>).builder().apply(mutator).build()
 
 
-operator fun <E, C : ImmutableCollection<E>> C.plus(elements: Iterable<E>): C
-        = builder().also { it.addAll(elements) }.build() as C
-operator fun <E, C : ImmutableCollection<E>> C.plus(elements: Array<out E>): C
-        = builder().also { it.addAll(elements) }.build() as C
-operator fun <E, C : ImmutableCollection<E>> C.plus(elements: Sequence<E>): C
-        = builder().also { it.addAll(elements) }.build() as C
+inline operator fun <E> PersistentCollection<E>.plus(element: E): PersistentCollection<E> = add(element)
+inline operator fun <E> PersistentCollection<E>.minus(element: E): PersistentCollection<E> = remove(element)
 
 
-operator fun <E, C : ImmutableCollection<E>> C.minus(elements: Iterable<E>): C
-        = builder().also { it.removeAll(elements) }.build() as C
-operator fun <E, C : ImmutableCollection<E>> C.minus(elements: Array<out E>): C
-        = builder().also { it.removeAll(elements) }.build() as C
-operator fun <E, C : ImmutableCollection<E>> C.minus(elements: Sequence<E>): C
-        =  builder().also { it.removeAll(elements) }.build() as C
+operator fun <E> PersistentCollection<E>.plus(elements: Iterable<E>): PersistentCollection<E>
+        = if (elements is Collection) addAll(elements) else builder().also { it.addAll(elements) }.build()
+operator fun <E> PersistentCollection<E>.plus(elements: Array<out E>): PersistentCollection<E>
+        = builder().also { it.addAll(elements) }.build()
+operator fun <E> PersistentCollection<E>.plus(elements: Sequence<E>): PersistentCollection<E>
+        = builder().also { it.addAll(elements) }.build()
 
 
-//inline operator fun <E> ImmutableList<E>.plus(element: E): ImmutableList<E> = add(element)
-//inline operator fun <E> ImmutableList<E>.minus(element: E): ImmutableList<E> = remove(element)
+operator fun <E> PersistentCollection<E>.minus(elements: Iterable<E>): PersistentCollection<E>
+        = if (elements is Collection) removeAll(elements) else builder().also { it.removeAll(elements) }.build()
+operator fun <E> PersistentCollection<E>.minus(elements: Array<out E>): PersistentCollection<E>
+        = builder().also { it.removeAll(elements) }.build()
+operator fun <E> PersistentCollection<E>.minus(elements: Sequence<E>): PersistentCollection<E>
+        =  builder().also { it.removeAll(elements) }.build()
 
 
-//operator fun <E> ImmutableList<E>.plus(elements: Iterable<E>): ImmutableList<E>
-//        = if (elements is Collection) addAll(elements) else mutate { it.addAll(elements) }
-//operator fun <E> ImmutableList<E>.plus(elements: Array<out E>): ImmutableList<E>
-//        = mutate { it.addAll(elements) }
-//operator fun <E> ImmutableList<E>.plus(elements: Sequence<E>): ImmutableList<E>
-//        = mutate { it.addAll(elements) }
+inline operator fun <E> PersistentList<E>.plus(element: E): PersistentList<E> = add(element)
+inline operator fun <E> PersistentList<E>.minus(element: E): PersistentList<E> = remove(element)
 
 
-//operator fun <E> ImmutableList<E>.minus(elements: Iterable<E>): ImmutableList<E>
-//        = if (elements is Collection) removeAll(elements) else mutate { it.removeAll(elements) }
-//operator fun <E> ImmutableList<E>.minus(elements: Array<out E>): ImmutableList<E>
-//        = mutate { it.removeAll(elements) }
-//operator fun <E> ImmutableList<E>.minus(elements: Sequence<E>): ImmutableList<E>
-//        = mutate { it.removeAll(elements) }
+operator fun <E> PersistentList<E>.plus(elements: Iterable<E>): PersistentList<E>
+        = if (elements is Collection) addAll(elements) else mutate { it.addAll(elements) }
+operator fun <E> PersistentList<E>.plus(elements: Array<out E>): PersistentList<E>
+        = mutate { it.addAll(elements) }
+operator fun <E> PersistentList<E>.plus(elements: Sequence<E>): PersistentList<E>
+        = mutate { it.addAll(elements) }
 
 
-//inline operator fun <E> ImmutableSet<E>.plus(element: E): ImmutableSet<E> = add(element)
-//inline operator fun <E> ImmutableSet<E>.minus(element: E): ImmutableSet<E> = remove(element)
-//
-//operator fun <E> ImmutableSet<E>.plus(elements: Iterable<E>): ImmutableSet<E>
-//        = if (elements is Collection) addAll(elements) else mutate { it.addAll(elements) }
-//operator fun <E> ImmutableSet<E>.plus(elements: Array<out E>): ImmutableSet<E>
-//        = mutate { it.addAll(elements) }
-//operator fun <E> ImmutableSet<E>.plus(elements: Sequence<E>): ImmutableSet<E>
-//        = mutate { it.addAll(elements) }
+operator fun <E> PersistentList<E>.minus(elements: Iterable<E>): PersistentList<E>
+        = if (elements is Collection) removeAll(elements) else mutate { it.removeAll(elements) }
+operator fun <E> PersistentList<E>.minus(elements: Array<out E>): PersistentList<E>
+        = mutate { it.removeAll(elements) }
+operator fun <E> PersistentList<E>.minus(elements: Sequence<E>): PersistentList<E>
+        = mutate { it.removeAll(elements) }
 
 
-//operator fun <E> ImmutableSet<E>.minus(elements: Iterable<E>): ImmutableSet<E>
-//        = if (elements is Collection) removeAll(elements) else mutate { it.removeAll(elements) }
-//operator fun <E> ImmutableSet<E>.minus(elements: Array<out E>): ImmutableSet<E>
-//        = mutate { it.removeAll(elements) }
-//operator fun <E> ImmutableSet<E>.minus(elements: Sequence<E>): ImmutableSet<E>
-//        = mutate { it.removeAll(elements) }
+inline operator fun <E> PersistentSet<E>.plus(element: E): PersistentSet<E> = add(element)
+inline operator fun <E> PersistentSet<E>.minus(element: E): PersistentSet<E> = remove(element)
+
+operator fun <E> PersistentSet<E>.plus(elements: Iterable<E>): PersistentSet<E>
+        = if (elements is Collection) addAll(elements) else mutate { it.addAll(elements) }
+operator fun <E> PersistentSet<E>.plus(elements: Array<out E>): PersistentSet<E>
+        = mutate { it.addAll(elements) }
+operator fun <E> PersistentSet<E>.plus(elements: Sequence<E>): PersistentSet<E>
+        = mutate { it.addAll(elements) }
 
 
-operator fun <K, V, M : ImmutableMap<out K, V>> M.plus(pair: Pair<K, V>): M
-        = mutate { it.put(pair.first, pair.second) }
+operator fun <E> PersistentSet<E>.minus(elements: Iterable<E>): PersistentSet<E>
+        = if (elements is Collection) removeAll(elements) else mutate { it.removeAll(elements) }
+operator fun <E> PersistentSet<E>.minus(elements: Array<out E>): PersistentSet<E>
+        = mutate { it.removeAll(elements) }
+operator fun <E> PersistentSet<E>.minus(elements: Sequence<E>): PersistentSet<E>
+        = mutate { it.removeAll(elements) }
 
-operator fun <K, V, M : ImmutableMap<out K, V>> M.plus(pairs: Iterable<Pair<K, V>>): M = putAll(pairs)
-operator fun <K, V, M : ImmutableMap<out K, V>> M.plus(pairs: Array<out Pair<K, V>>): M = putAll(pairs)
-operator fun <K, V, M : ImmutableMap<out K, V>> M.plus(pairs: Sequence<Pair<K, V>>): M = putAll(pairs)
-operator fun <K, V, M : ImmutableMap<out K, V>> M.plus(map: Map<out K, V>): M = mutate { it.putAll(map) }
 
-public fun <K, V, M : ImmutableMap<out K, V>> M.putAll(pairs: Iterable<Pair<K, V>>): M
+inline operator fun <K, V> PersistentMap<out K, V>.plus(pair: Pair<K, V>): PersistentMap<K, V>
+        = (this as PersistentMap<K, V>).put(pair.first, pair.second)
+inline operator fun <K, V> PersistentMap<out K, V>.plus(pairs: Iterable<Pair<K, V>>): PersistentMap<K, V> = putAll(pairs)
+inline operator fun <K, V> PersistentMap<out K, V>.plus(pairs: Array<out Pair<K, V>>): PersistentMap<K, V> = putAll(pairs)
+inline operator fun <K, V> PersistentMap<out K, V>.plus(pairs: Sequence<Pair<K, V>>): PersistentMap<K, V> = putAll(pairs)
+inline operator fun <K, V> PersistentMap<out K, V>.plus(map: Map<out K, V>): PersistentMap<K, V> = putAll(map)
+
+public fun <K, V> PersistentMap<out K, V>.putAll(map: Map<out K, V>): PersistentMap<K, V> =
+        (this as PersistentMap<K, V>).putAll(map)
+
+public fun <K, V> PersistentMap<out K, V>.putAll(pairs: Iterable<Pair<K, V>>): PersistentMap<K, V>
         = mutate { it.putAll(pairs) }
 
-public fun <K, V, M : ImmutableMap<out K, V>> M.putAll(pairs: Array<out Pair<K, V>>): M
+public fun <K, V> PersistentMap<out K, V>.putAll(pairs: Array<out Pair<K, V>>): PersistentMap<K, V>
         = mutate { it.putAll(pairs) }
 
-public fun <K, V, M : ImmutableMap<out K, V>> M.putAll(pairs: Sequence<Pair<K, V>>): M
+public fun <K, V> PersistentMap<out K, V>.putAll(pairs: Sequence<Pair<K, V>>): PersistentMap<K, V>
         = mutate { it.putAll(pairs) }
 
 
-public operator fun <K, V, M : ImmutableMap<out K, V>> M.minus(key: K): M
-        = mutate { it.remove(key) }
+public operator fun <K, V> PersistentMap<out K, V>.minus(key: K): PersistentMap<K, V>
+        = (this as PersistentMap<K, V>).remove(key)
 
-public operator fun <K, V, M : ImmutableMap<out K, V>> M.minus(keys: Iterable<K>): M
+public operator fun <K, V> PersistentMap<out K, V>.minus(keys: Iterable<K>): PersistentMap<K, V>
         = mutate { it.minusAssign(keys) }
 
-public operator fun <K, V, M : ImmutableMap<out K, V>> M.minus(keys: Array<out K>): M
+public operator fun <K, V> PersistentMap<out K, V>.minus(keys: Array<out K>): PersistentMap<K, V>
         = mutate { it.minusAssign(keys) }
 
-public operator fun <K, V, M : ImmutableMap<out K, V>> M.minus(keys: Sequence<K>): M
+public operator fun <K, V> PersistentMap<out K, V>.minus(keys: Sequence<K>): PersistentMap<K, V>
         = mutate { it.minusAssign(keys) }
 
 
-fun <E> immutableListOf(vararg elements: E): ImmutableList<E> = ImmutableVectorList.emptyOf<E>().addAll(elements.asList())
-fun <E> immutableListOf(): ImmutableList<E> = ImmutableVectorList.emptyOf<E>()
+fun <E> immutableListOf(vararg elements: E): PersistentList<E> = ImmutableVectorList.emptyOf<E>().addAll(elements.asList())
+fun <E> immutableListOf(): PersistentList<E> = ImmutableVectorList.emptyOf<E>()
 
-fun <E> immutableSetOf(vararg elements: E): ImmutableSet<E> = ImmutableOrderedSet.emptyOf<E>().addAll(elements.asList())
-fun <E> immutableSetOf(): ImmutableSet<E> = ImmutableOrderedSet.emptyOf<E>()
+fun <E> immutableSetOf(vararg elements: E): PersistentSet<E> = ImmutableOrderedSet.emptyOf<E>().addAll(elements.asList())
+fun <E> immutableSetOf(): PersistentSet<E> = ImmutableOrderedSet.emptyOf<E>()
 
-fun <E> immutableHashSetOf(vararg elements: E): ImmutableSet<E> = ImmutableHashSet.emptyOf<E>().addAll(elements.asList())
+fun <E> immutableHashSetOf(vararg elements: E): PersistentSet<E> = ImmutableHashSet.emptyOf<E>().addAll(elements.asList())
 
-fun <K, V> immutableMapOf(vararg pairs: Pair<K, V>): ImmutableMap<K, V> = ImmutableOrderedMap.emptyOf<K,V>().mutate { it += pairs }
-fun <K, V> immutableHashMapOf(vararg pairs: Pair<K, V>): ImmutableMap<K, V> = ImmutableHashMap.emptyOf<K,V>().mutate { it += pairs }
+fun <K, V> immutableMapOf(vararg pairs: Pair<K, V>): PersistentMap<K, V> = ImmutableOrderedMap.emptyOf<K,V>().mutate { it += pairs }
+fun <K, V> immutableHashMapOf(vararg pairs: Pair<K, V>): PersistentMap<K, V> = ImmutableHashMap.emptyOf<K,V>().mutate { it += pairs }
 
 fun <T> Iterable<T>.toImmutableList(): ImmutableList<T> =
         this as? ImmutableList
-        ?: (this as? ImmutableList.Builder)?.build()
+        ?: (this as? PersistentList.Builder)?.build()
         ?: immutableListOf<T>() + this
 
 fun <T> Iterable<T>.toPersistentList(): PersistentList<T> =
@@ -141,15 +144,26 @@ fun <T> Iterable<T>.toPersistentList(): PersistentList<T> =
 
 // fun <T> Array<T>.toImmutableList(): ImmutableList<T> = immutableListOf<T>() + this.asList()
 
-fun CharSequence.toImmutableList(): ImmutableList<Char> =
-        immutableListOf<Char>().mutate { this.toCollection(it) }
+fun CharSequence.toImmutableList(): ImmutableList<Char> = toPersistentList()
+
+fun CharSequence.toPersistentList(): PersistentList<Char> =
+    immutableListOf<Char>().mutate { this.toCollection(it) }
+
+fun CharSequence.toPersistentSet(): PersistentSet<Char> =
+    immutableSetOf<Char>().mutate { this.toCollection(it) }
+
 
 fun <T> Iterable<T>.toImmutableSet(): ImmutableSet<T> =
         this as? ImmutableSet<T>
-        ?: (this as? ImmutableSet.Builder)?.build()
+        ?: (this as? PersistentSet.Builder)?.build()
         ?: immutableSetOf<T>() + this
 
-fun <T> Set<T>.toImmutableHashSet(): ImmutableSet<T>
+fun <T> Iterable<T>.toPersistentSet(): PersistentSet<T> =
+        this as? PersistentSet<T>
+        ?: (this as? PersistentSet.Builder)?.build()
+        ?: immutableSetOf<T>() + this
+
+fun <T> Set<T>.toPersistentHashSet(): PersistentSet<T>
     = this as? ImmutableHashSet
         ?: (this as? ImmutableHashSet.Builder)?.build()
         ?: ImmutableHashSet.emptyOf<T>() + this
@@ -157,15 +171,16 @@ fun <T> Set<T>.toImmutableHashSet(): ImmutableSet<T>
 
 fun <K, V> Map<K, V>.toImmutableMap(): ImmutableMap<K, V>
     = this as? ImmutableMap
-        ?: (this as? ImmutableMap.Builder)?.build()
+        ?: (this as? PersistentMap.Builder)?.build()
         ?: ImmutableOrderedMap.emptyOf<K, V>().putAll(this)
 
-fun <K, V> Map<K, V>.toImmutableHashMap(): ImmutableMap<K, V>
-    = this as? ImmutableMap
-        ?: (this as? ImmutableHashMap.Builder)?.build()
-        ?: ImmutableHashMap.emptyOf<K, V>().putAll(this)
 
 fun <K, V> Map<K, V>.toPersistentMap(): PersistentMap<K, V>
     = this as? PersistentMap<K, V>
         ?: (this as? PersistentMap.Builder<K, V>)?.build()
         ?: ImmutableOrderedMap.emptyOf<K, V>().putAll(this)
+
+fun <K, V> Map<K, V>.toPersistentHashMap(): PersistentMap<K, V>
+        = this as? PersistentMap
+        ?: (this as? ImmutableHashMap.Builder)?.build()
+        ?: ImmutableHashMap.emptyOf<K, V>().putAll(this)

--- a/kotlinx-collections-immutable/src/main/kotlin/kotlinx/collections/immutable/extensions.kt
+++ b/kotlinx-collections-immutable/src/main/kotlin/kotlinx/collections/immutable/extensions.kt
@@ -21,100 +21,100 @@ package kotlinx.collections.immutable
 //@Suppress("INVISIBLE_MEMBER", "INVISIBLE_REFERENCE")
 //inline fun <T> @kotlin.internal.Exact ImmutableCollection<T>.mutate(mutator: (MutableCollection<T>) -> Unit): ImmutableCollection<T> = builder().apply(mutator).build()
 // it or this?
-inline fun <T> ImmutableSet<T>.mutate(mutator: (MutableSet<T>) -> Unit): ImmutableSet<T> = builder().apply(mutator).build()
-inline fun <T> ImmutableList<T>.mutate(mutator: (MutableList<T>) -> Unit): ImmutableList<T> = builder().apply(mutator).build()
+inline fun <T, C : ImmutableSet<T>> C.mutate(mutator: (MutableSet<T>) -> Unit): C = builder().apply(mutator).build() as C
+inline fun <T, C : ImmutableList<T>> C.mutate(mutator: (MutableList<T>) -> Unit): C = builder().apply(mutator).build() as C
 
-inline fun <K, V> ImmutableMap<K, V>.mutate(mutator: (MutableMap<K, V>) -> Unit): ImmutableMap<K, V> = builder().apply(mutator).build()
-
-
-inline operator fun <E> ImmutableCollection<E>.plus(element: E): ImmutableCollection<E> = add(element)
-inline operator fun <E> ImmutableCollection<E>.minus(element: E): ImmutableCollection<E> = remove(element)
+inline fun <K, V, M : ImmutableMap<out K, V>> M.mutate(mutator: (MutableMap<K, V>) -> Unit): M = (this as ImmutableMap<K, V>).builder().apply(mutator).build() as M
 
 
-operator fun <E> ImmutableCollection<E>.plus(elements: Iterable<E>): ImmutableCollection<E>
-        = if (elements is Collection) addAll(elements) else builder().also { it.addAll(elements) }.build()
-operator fun <E> ImmutableCollection<E>.plus(elements: Array<out E>): ImmutableCollection<E>
-        = builder().also { it.addAll(elements) }.build()
-operator fun <E> ImmutableCollection<E>.plus(elements: Sequence<E>): ImmutableCollection<E>
-        = builder().also { it.addAll(elements) }.build()
+operator fun <E, C : ImmutableCollection<E>> C.plus(element: E): C = builder().apply { add(element) }.build() as C
+operator fun <E, C : ImmutableCollection<E>> C.minus(element: E): C = builder().apply { remove(element) }.build() as C
 
 
-operator fun <E> ImmutableCollection<E>.minus(elements: Iterable<E>): ImmutableCollection<E>
-        = if (elements is Collection) removeAll(elements) else builder().also { it.removeAll(elements) }.build()
-operator fun <E> ImmutableCollection<E>.minus(elements: Array<out E>): ImmutableCollection<E>
-        = builder().also { it.removeAll(elements) }.build()
-operator fun <E> ImmutableCollection<E>.minus(elements: Sequence<E>): ImmutableCollection<E>
-        =  builder().also { it.removeAll(elements) }.build()
+operator fun <E, C : ImmutableCollection<E>> C.plus(elements: Iterable<E>): C
+        = builder().also { it.addAll(elements) }.build() as C
+operator fun <E, C : ImmutableCollection<E>> C.plus(elements: Array<out E>): C
+        = builder().also { it.addAll(elements) }.build() as C
+operator fun <E, C : ImmutableCollection<E>> C.plus(elements: Sequence<E>): C
+        = builder().also { it.addAll(elements) }.build() as C
 
 
-inline operator fun <E> ImmutableList<E>.plus(element: E): ImmutableList<E> = add(element)
-inline operator fun <E> ImmutableList<E>.minus(element: E): ImmutableList<E> = remove(element)
+operator fun <E, C : ImmutableCollection<E>> C.minus(elements: Iterable<E>): C
+        = builder().also { it.removeAll(elements) }.build() as C
+operator fun <E, C : ImmutableCollection<E>> C.minus(elements: Array<out E>): C
+        = builder().also { it.removeAll(elements) }.build() as C
+operator fun <E, C : ImmutableCollection<E>> C.minus(elements: Sequence<E>): C
+        =  builder().also { it.removeAll(elements) }.build() as C
 
 
-operator fun <E> ImmutableList<E>.plus(elements: Iterable<E>): ImmutableList<E>
-        = if (elements is Collection) addAll(elements) else mutate { it.addAll(elements) }
-operator fun <E> ImmutableList<E>.plus(elements: Array<out E>): ImmutableList<E>
-        = mutate { it.addAll(elements) }
-operator fun <E> ImmutableList<E>.plus(elements: Sequence<E>): ImmutableList<E>
-        = mutate { it.addAll(elements) }
+//inline operator fun <E> ImmutableList<E>.plus(element: E): ImmutableList<E> = add(element)
+//inline operator fun <E> ImmutableList<E>.minus(element: E): ImmutableList<E> = remove(element)
 
 
-operator fun <E> ImmutableList<E>.minus(elements: Iterable<E>): ImmutableList<E>
-        = if (elements is Collection) removeAll(elements) else mutate { it.removeAll(elements) }
-operator fun <E> ImmutableList<E>.minus(elements: Array<out E>): ImmutableList<E>
-        = mutate { it.removeAll(elements) }
-operator fun <E> ImmutableList<E>.minus(elements: Sequence<E>): ImmutableList<E>
-        = mutate { it.removeAll(elements) }
+//operator fun <E> ImmutableList<E>.plus(elements: Iterable<E>): ImmutableList<E>
+//        = if (elements is Collection) addAll(elements) else mutate { it.addAll(elements) }
+//operator fun <E> ImmutableList<E>.plus(elements: Array<out E>): ImmutableList<E>
+//        = mutate { it.addAll(elements) }
+//operator fun <E> ImmutableList<E>.plus(elements: Sequence<E>): ImmutableList<E>
+//        = mutate { it.addAll(elements) }
 
 
-inline operator fun <E> ImmutableSet<E>.plus(element: E): ImmutableSet<E> = add(element)
-inline operator fun <E> ImmutableSet<E>.minus(element: E): ImmutableSet<E> = remove(element)
-
-operator fun <E> ImmutableSet<E>.plus(elements: Iterable<E>): ImmutableSet<E>
-        = if (elements is Collection) addAll(elements) else mutate { it.addAll(elements) }
-operator fun <E> ImmutableSet<E>.plus(elements: Array<out E>): ImmutableSet<E>
-        = mutate { it.addAll(elements) }
-operator fun <E> ImmutableSet<E>.plus(elements: Sequence<E>): ImmutableSet<E>
-        = mutate { it.addAll(elements) }
+//operator fun <E> ImmutableList<E>.minus(elements: Iterable<E>): ImmutableList<E>
+//        = if (elements is Collection) removeAll(elements) else mutate { it.removeAll(elements) }
+//operator fun <E> ImmutableList<E>.minus(elements: Array<out E>): ImmutableList<E>
+//        = mutate { it.removeAll(elements) }
+//operator fun <E> ImmutableList<E>.minus(elements: Sequence<E>): ImmutableList<E>
+//        = mutate { it.removeAll(elements) }
 
 
-operator fun <E> ImmutableSet<E>.minus(elements: Iterable<E>): ImmutableSet<E>
-        = if (elements is Collection) removeAll(elements) else mutate { it.removeAll(elements) }
-operator fun <E> ImmutableSet<E>.minus(elements: Array<out E>): ImmutableSet<E>
-        = mutate { it.removeAll(elements) }
-operator fun <E> ImmutableSet<E>.minus(elements: Sequence<E>): ImmutableSet<E>
-        = mutate { it.removeAll(elements) }
+//inline operator fun <E> ImmutableSet<E>.plus(element: E): ImmutableSet<E> = add(element)
+//inline operator fun <E> ImmutableSet<E>.minus(element: E): ImmutableSet<E> = remove(element)
+//
+//operator fun <E> ImmutableSet<E>.plus(elements: Iterable<E>): ImmutableSet<E>
+//        = if (elements is Collection) addAll(elements) else mutate { it.addAll(elements) }
+//operator fun <E> ImmutableSet<E>.plus(elements: Array<out E>): ImmutableSet<E>
+//        = mutate { it.addAll(elements) }
+//operator fun <E> ImmutableSet<E>.plus(elements: Sequence<E>): ImmutableSet<E>
+//        = mutate { it.addAll(elements) }
 
 
-inline operator fun <K, V> ImmutableMap<out K, V>.plus(pair: Pair<K, V>): ImmutableMap<K, V>
-        = (this as ImmutableMap<K, V>).put(pair.first, pair.second)
-inline operator fun <K, V> ImmutableMap<out K, V>.plus(pairs: Iterable<Pair<K, V>>): ImmutableMap<K, V> = putAll(pairs)
-inline operator fun <K, V> ImmutableMap<out K, V>.plus(pairs: Array<out Pair<K, V>>): ImmutableMap<K, V> = putAll(pairs)
-inline operator fun <K, V> ImmutableMap<out K, V>.plus(pairs: Sequence<Pair<K, V>>): ImmutableMap<K, V> = putAll(pairs)
-inline operator fun <K, V> ImmutableMap<out K, V>.plus(map: Map<out K, V>): ImmutableMap<K, V>
-        = (this as ImmutableMap<K, V>).putAll(map)
-
-public fun <K, V> ImmutableMap<out K, V>.putAll(pairs: Iterable<Pair<K, V>>): ImmutableMap<K, V>
-        = (this as ImmutableMap<K, V>).mutate { it.putAll(pairs) }
-
-public fun <K, V> ImmutableMap<out K, V>.putAll(pairs: Array<out Pair<K, V>>): ImmutableMap<K, V>
-        = (this as ImmutableMap<K, V>).mutate { it.putAll(pairs) }
-
-public fun <K, V> ImmutableMap<out K, V>.putAll(pairs: Sequence<Pair<K, V>>): ImmutableMap<K, V>
-        = (this as ImmutableMap<K, V>).mutate { it.putAll(pairs) }
+//operator fun <E> ImmutableSet<E>.minus(elements: Iterable<E>): ImmutableSet<E>
+//        = if (elements is Collection) removeAll(elements) else mutate { it.removeAll(elements) }
+//operator fun <E> ImmutableSet<E>.minus(elements: Array<out E>): ImmutableSet<E>
+//        = mutate { it.removeAll(elements) }
+//operator fun <E> ImmutableSet<E>.minus(elements: Sequence<E>): ImmutableSet<E>
+//        = mutate { it.removeAll(elements) }
 
 
-public operator fun <K, V> ImmutableMap<out K, V>.minus(key: K): ImmutableMap<K, V>
-        = (this as ImmutableMap<K, V>).remove(key)
+operator fun <K, V, M : ImmutableMap<out K, V>> M.plus(pair: Pair<K, V>): M
+        = mutate { it.put(pair.first, pair.second) }
 
-public operator fun <K, V> ImmutableMap<out K, V>.minus(keys: Iterable<K>): ImmutableMap<K, V>
-        = (this as ImmutableMap<K, V>).mutate { it.minusAssign(keys) }
+operator fun <K, V, M : ImmutableMap<out K, V>> M.plus(pairs: Iterable<Pair<K, V>>): M = putAll(pairs)
+operator fun <K, V, M : ImmutableMap<out K, V>> M.plus(pairs: Array<out Pair<K, V>>): M = putAll(pairs)
+operator fun <K, V, M : ImmutableMap<out K, V>> M.plus(pairs: Sequence<Pair<K, V>>): M = putAll(pairs)
+operator fun <K, V, M : ImmutableMap<out K, V>> M.plus(map: Map<out K, V>): M = mutate { it.putAll(map) }
 
-public operator fun <K, V> ImmutableMap<out K, V>.minus(keys: Array<out K>): ImmutableMap<K, V>
-        = (this as ImmutableMap<K, V>).mutate { it.minusAssign(keys) }
+public fun <K, V, M : ImmutableMap<out K, V>> M.putAll(pairs: Iterable<Pair<K, V>>): M
+        = mutate { it.putAll(pairs) }
 
-public operator fun <K, V> ImmutableMap<out K, V>.minus(keys: Sequence<K>): ImmutableMap<K, V>
-        = (this as ImmutableMap<K, V>).mutate { it.minusAssign(keys) }
+public fun <K, V, M : ImmutableMap<out K, V>> M.putAll(pairs: Array<out Pair<K, V>>): M
+        = mutate { it.putAll(pairs) }
+
+public fun <K, V, M : ImmutableMap<out K, V>> M.putAll(pairs: Sequence<Pair<K, V>>): M
+        = mutate { it.putAll(pairs) }
+
+
+public operator fun <K, V, M : ImmutableMap<out K, V>> M.minus(key: K): M
+        = mutate { it.remove(key) }
+
+public operator fun <K, V, M : ImmutableMap<out K, V>> M.minus(keys: Iterable<K>): M
+        = mutate { it.minusAssign(keys) }
+
+public operator fun <K, V, M : ImmutableMap<out K, V>> M.minus(keys: Array<out K>): M
+        = mutate { it.minusAssign(keys) }
+
+public operator fun <K, V, M : ImmutableMap<out K, V>> M.minus(keys: Sequence<K>): M
+        = mutate { it.minusAssign(keys) }
 
 
 fun <E> immutableListOf(vararg elements: E): ImmutableList<E> = ImmutableVectorList.emptyOf<E>().addAll(elements.asList())
@@ -132,6 +132,11 @@ fun <T> Iterable<T>.toImmutableList(): ImmutableList<T> =
         this as? ImmutableList
         ?: (this as? ImmutableList.Builder)?.build()
         ?: immutableListOf<T>() + this
+
+fun <T> Iterable<T>.toPersistentList(): PersistentList<T> =
+        this as? PersistentList
+        ?: (this as? PersistentList.Builder)?.build()
+        ?: ImmutableVectorList.emptyOf<T>() + this
 
 
 // fun <T> Array<T>.toImmutableList(): ImmutableList<T> = immutableListOf<T>() + this.asList()
@@ -159,3 +164,8 @@ fun <K, V> Map<K, V>.toImmutableHashMap(): ImmutableMap<K, V>
     = this as? ImmutableMap
         ?: (this as? ImmutableHashMap.Builder)?.build()
         ?: ImmutableHashMap.emptyOf<K, V>().putAll(this)
+
+fun <K, V> Map<K, V>.toPersistentMap(): PersistentMap<K, V>
+    = this as? PersistentMap<K, V>
+        ?: (this as? PersistentMap.Builder<K, V>)?.build()
+        ?: ImmutableOrderedMap.emptyOf<K, V>().putAll(this)

--- a/kotlinx-collections-immutable/src/main/kotlin/kotlinx/collections/immutable/internal/ListImplementation.kt
+++ b/kotlinx-collections-immutable/src/main/kotlin/kotlinx/collections/immutable/internal/ListImplementation.kt
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2016-2018 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kotlinx.collections.immutable.internal
+
+internal object ListImplementation {
+
+    internal fun checkElementIndex(index: Int, size: Int) {
+        if (index < 0 || index >= size) {
+            throw IndexOutOfBoundsException("index: $index, size: $size")
+        }
+    }
+
+    internal fun checkPositionIndex(index: Int, size: Int) {
+        if (index < 0 || index > size) {
+            throw IndexOutOfBoundsException("index: $index, size: $size")
+        }
+    }
+
+    internal fun checkRangeIndexes(fromIndex: Int, toIndex: Int, size: Int) {
+        if (fromIndex < 0 || toIndex > size) {
+            throw IndexOutOfBoundsException("fromIndex: $fromIndex, toIndex: $toIndex, size: $size")
+        }
+        if (fromIndex > toIndex) {
+            throw IllegalArgumentException("fromIndex: $fromIndex > toIndex: $toIndex")
+        }
+    }
+
+    internal fun orderedHashCode(c: Collection<*>): Int {
+        var hashCode = 1
+        for (e in c) {
+            hashCode = 31 * hashCode + (e?.hashCode() ?: 0)
+        }
+        return hashCode
+    }
+
+    internal fun orderedEquals(c: Collection<*>, other: Collection<*>): Boolean {
+        if (c.size != other.size) return false
+
+        val otherIterator = other.iterator()
+        for (elem in c) {
+            val elemOther = otherIterator.next()
+            if (elem != elemOther) {
+                return false
+            }
+        }
+        return true
+    }
+}

--- a/kotlinx-collections-immutable/src/test/kotlin/kotlinx.collections.immutable/Main.kt
+++ b/kotlinx-collections-immutable/src/test/kotlin/kotlinx.collections.immutable/Main.kt
@@ -34,14 +34,14 @@ fun main(args: Array<String>) {
 
 
 fun mapOfMap() {
-    var map = immutableHashMapOf(1 to immutableHashMapOf("x" to 2 as Any)).put(1, immutableHashMapOf())
+    var map = immutableHashMapOf(1 to immutableHashMapOf("x" to 2 as Any)).toPersistentMap().put(1, immutableHashMapOf())
 
     println(map)
 }
 
 
 fun foo() {
-    var list: ImmutableList<String> = ImmutableVectorList.emptyOf()
+    var list: PersistentList<String> = ImmutableVectorList.emptyOf()
 
     list = list.mutate { it.removeAll { it.length > 2 } }
     list = list.removeAll { it.length >  2}

--- a/kotlinx-collections-immutable/src/test/kotlin/kotlinx.collections.immutable/Main.kt
+++ b/kotlinx-collections-immutable/src/test/kotlin/kotlinx.collections.immutable/Main.kt
@@ -3,14 +3,14 @@ package kotlinx.collections.immutable
 fun main(args: Array<String>) {
 
     mapOfMap()
-    val set = immutableHashSetOf("d", "b", "c") + null as String?
+    val set = persistentHashSetOf("d", "b", "c") + null as String?
     set.run {
         val builder = set.builder()
         builder.removeAll { it.orEmpty() > "b" }
         println(builder)
     }
 
-    var map = immutableHashMapOf(1 to "a", 2 to "b", -1 to "d", 3 to "c", null to "z")
+    var map = persistentHashMapOf(1 to "a", 2 to "b", -1 to "d", 3 to "c", null to "z")
 
     println(map.entries)
 
@@ -34,7 +34,7 @@ fun main(args: Array<String>) {
 
 
 fun mapOfMap() {
-    var map = immutableHashMapOf(1 to immutableHashMapOf("x" to 2 as Any)).toPersistentMap().put(1, immutableHashMapOf())
+    var map = persistentHashMapOf(1 to persistentHashMapOf("x" to 2 as Any)).toPersistentMap().put(1, persistentHashMapOf())
 
     println(map)
 }

--- a/kotlinx-collections-immutable/tests/src/main/kotlin/ImmutableArrayList.kt
+++ b/kotlinx-collections-immutable/tests/src/main/kotlin/ImmutableArrayList.kt
@@ -18,7 +18,7 @@ public class ImmutableArrayList<out E> internal constructor(private val impl: Ar
 
     override fun iterator(): Iterator<E> = impl.iterator()
 
-    override fun subList(fromIndex: Int, toIndex: Int): ImmutableList<E> = ImmutableArrayList(impl.copyOfRange(fromIndex, toIndex))
+    override fun subList(fromIndex: Int, toIndex: Int): ImmutableList<E> = super<PersistentList>.subList(fromIndex, toIndex)
 
     override fun add(element: @UnsafeVariance E): PersistentList<E> = ImmutableArrayList(impl + element)
 

--- a/kotlinx-collections-immutable/tests/src/main/kotlin/ImmutableArrayList.kt
+++ b/kotlinx-collections-immutable/tests/src/main/kotlin/ImmutableArrayList.kt
@@ -3,7 +3,9 @@ package kotlinx.collections.immutable
 import java.util.*
 import kotlin.collections.AbstractList
 
-public class ImmutableArrayList<out E> private constructor(private val impl: Array<E>): ImmutableList<E>, AbstractList<E>() {
+public class ImmutableArrayList<out E> internal constructor(private val impl: Array<E>): PersistentList<E>, AbstractList<E>() {
+
+    public constructor(source: Collection<E>) : this(source.toTypedArray<Any?>() as Array<E>)
 
     override val size: Int get() = impl.size
     override fun isEmpty(): Boolean = impl.isEmpty()
@@ -18,41 +20,53 @@ public class ImmutableArrayList<out E> private constructor(private val impl: Arr
 
     override fun subList(fromIndex: Int, toIndex: Int): ImmutableList<E> = ImmutableArrayList(impl.copyOfRange(fromIndex, toIndex))
 
- /*
-    override fun add(element: @UnsafeVariance E): ImmutableList<E> = ImmutableArrayList(impl + element)
+    override fun add(element: @UnsafeVariance E): PersistentList<E> = ImmutableArrayList(impl + element)
 
-    override fun addAll(elements: Collection<@UnsafeVariance E>): ImmutableList<E> = ImmutableArrayList(impl + elements)
+    override fun addAll(elements: Collection<@UnsafeVariance E>): PersistentList<E> = ImmutableArrayList(impl + elements)
 
-    override fun remove(element: @UnsafeVariance  E): ImmutableList<E> {
+    override fun remove(element: @UnsafeVariance  E): PersistentList<E> {
         val index = indexOf(element).takeUnless { it < 0 } ?: return this
         return removeAt(index)
     }
 
-    override fun removeAll(elements: Collection<@UnsafeVariance E>): ImmutableList<E> {
+    override fun removeAll(elements: Collection<@UnsafeVariance E>): PersistentList<E> {
         val values = impl.filter { it in elements }
-        return if (values.size < impl.size) ImmutableArrayList(values.toTypedArray<Any?>() as Array<E>) else this
+        return if (values.size < impl.size) values.toImmutableArrayList() else this
     }
 
-    override fun removeAll(predicate: (E) -> Boolean): ImmutableList<E> {
+    override fun removeAll(predicate: (E) -> Boolean): PersistentList<E> {
         val values = impl.filterNot(predicate)
-        return if (values.size < impl.size) ImmutableArrayList(values.toTypedArray<Any?>() as Array<E>) else this
+        return if (values.size < impl.size) values.toImmutableArrayList() else this
     }
 
-    override fun clear(): ImmutableList<E> = if (impl.isEmpty()) this else EMPTY
+    override fun clear(): PersistentList<E> = if (impl.isEmpty()) this else EMPTY
 
-    override fun addAll(index: Int, c: Collection<@UnsafeVariance E>): ImmutableList<E> = mutate { it.addAll(index, c) }
+    override fun addAll(index: Int, c: Collection<@UnsafeVariance E>): PersistentList<E> = mutate { it.addAll(index, c) }
 
-    override fun set(index: Int, element: @UnsafeVariance E): ImmutableList<E> = ImmutableArrayList(impl.copyOf().apply { set(index, element) })
+    override fun set(index: Int, element: @UnsafeVariance E): PersistentList<E> = ImmutableArrayList(impl.copyOf().apply { set(index, element) })
 
-    override fun add(index: Int, element: @UnsafeVariance E): ImmutableList<E> = mutate { it.add(index, element) }
+    override fun add(index: Int, element: @UnsafeVariance E): PersistentList<E> = mutate { it.add(index, element) }
 
-    override fun removeAt(index: Int): ImmutableList<E> = mutate { it.removeAt(index) }
-*/
-    override fun builder(): ImmutableList.Builder<@UnsafeVariance E> = object : ArrayList<E>(impl.asList()), ImmutableList.Builder<E> {
-        override fun build(): ImmutableList<E> = if (this.modCount == 0) this@ImmutableArrayList else ImmutableArrayList(this.toArray() as Array<E>)
+    override fun removeAt(index: Int): PersistentList<E> = mutate { it.removeAt(index) }
+
+
+    override fun builder(): PersistentList.Builder<@UnsafeVariance E> = object : ArrayList<E>(impl.asList()), PersistentList.Builder<E> {
+        override fun build(): ImmutableArrayList<E> = if (this.modCount == 0) this@ImmutableArrayList else ImmutableArrayList(this.toArray() as Array<E>)
     }
 
     companion object {
         public val EMPTY: ImmutableArrayList<Nothing> = ImmutableArrayList(emptyArray<Any?>()) as ImmutableArrayList<Nothing>
     }
 }
+
+public fun <E> immutableArrayListOf(vararg elements: E) = ImmutableArrayList(elements)
+
+fun <E> Collection<E>.toImmutableArrayList(): ImmutableArrayList<E> =
+    this as? ImmutableArrayList
+            ?: ImmutableArrayList(this)
+
+fun <E> Iterable<E>.toImmutableArrayList(): ImmutableArrayList<E> =
+    ((this as? Collection) ?: this.toList()).toImmutableArrayList()
+
+fun <E> Array<E>.toImmutableArrayList(): ImmutableArrayList<E> =
+    ImmutableArrayList(this.asList())

--- a/kotlinx-collections-immutable/tests/src/main/kotlin/ImmutableArrayList.kt
+++ b/kotlinx-collections-immutable/tests/src/main/kotlin/ImmutableArrayList.kt
@@ -18,6 +18,7 @@ public class ImmutableArrayList<out E> private constructor(private val impl: Arr
 
     override fun subList(fromIndex: Int, toIndex: Int): ImmutableList<E> = ImmutableArrayList(impl.copyOfRange(fromIndex, toIndex))
 
+ /*
     override fun add(element: @UnsafeVariance E): ImmutableList<E> = ImmutableArrayList(impl + element)
 
     override fun addAll(elements: Collection<@UnsafeVariance E>): ImmutableList<E> = ImmutableArrayList(impl + elements)
@@ -46,7 +47,7 @@ public class ImmutableArrayList<out E> private constructor(private val impl: Arr
     override fun add(index: Int, element: @UnsafeVariance E): ImmutableList<E> = mutate { it.add(index, element) }
 
     override fun removeAt(index: Int): ImmutableList<E> = mutate { it.removeAt(index) }
-
+*/
     override fun builder(): ImmutableList.Builder<@UnsafeVariance E> = object : ArrayList<E>(impl.asList()), ImmutableList.Builder<E> {
         override fun build(): ImmutableList<E> = if (this.modCount == 0) this@ImmutableArrayList else ImmutableArrayList(this.toArray() as Array<E>)
     }

--- a/kotlinx-collections-immutable/tests/src/test/kotlin/kotlinx.collections.immutable/ImmutableListJavaTest.java
+++ b/kotlinx-collections-immutable/tests/src/test/kotlin/kotlinx.collections.immutable/ImmutableListJavaTest.java
@@ -11,7 +11,7 @@ public class ImmutableListJavaTest {
 
     @Test
     public void immutableList() {
-        ImmutableList<String> list = immutableListOf("x");
+        PersistentList<String> list = immutableListOf("x");
 
         Assert.assertEquals(listOf("x"), list);
 

--- a/kotlinx-collections-immutable/tests/src/test/kotlin/kotlinx.collections.immutable/ImmutableListJavaTest.java
+++ b/kotlinx-collections-immutable/tests/src/test/kotlin/kotlinx.collections.immutable/ImmutableListJavaTest.java
@@ -4,19 +4,19 @@ import org.junit.Assert;
 import org.junit.Test;
 
 
-import static kotlinx.collections.immutable.ExtensionsKt.immutableListOf;
+import static kotlinx.collections.immutable.ExtensionsKt.persistentListOf;
 import static kotlin.collections.CollectionsKt.listOf;
 
 public class ImmutableListJavaTest {
 
     @Test
     public void immutableList() {
-        PersistentList<String> list = immutableListOf("x");
+        PersistentList<String> list = ExtensionsKt.persistentListOf("x");
 
         Assert.assertEquals(listOf("x"), list);
 
         list = list.clear();
-        Assert.assertEquals(immutableListOf(), list);
+        Assert.assertEquals(persistentListOf(), list);
 
         list = list.add("x").add("z").set(0, "y");
         Assert.assertEquals(listOf("y", "z"), list);

--- a/kotlinx-collections-immutable/tests/src/test/kotlin/kotlinx.collections.immutable/ImmutableListTest.kt
+++ b/kotlinx-collections-immutable/tests/src/test/kotlin/kotlinx.collections.immutable/ImmutableListTest.kt
@@ -45,12 +45,12 @@ class ImmutableListTest {
         list.removeAt(0)
         assertNotEquals<List<*>>(list, immList)
 
-        immList = immList.removeAt(0)
+        immList = immList.toPersistentList().removeAt(0)
         compareLists(list, immList)
     }
 
     @Test fun addElements() {
-        var list = immutableListOf<String>()
+        var list = immutableListOf<String>().toPersistentList()
         list = list.add("x")
         list = list.add(0, "a")
         list = list.addAll(list)
@@ -62,7 +62,7 @@ class ImmutableListTest {
     }
 
     @Test fun replaceElements() {
-        var list = "abcxaxab12".toImmutableList()
+        var list = "abcxaxab12".toImmutableList().toPersistentList()
 
         for (i in list.indices) {
             list = list.set(i, list[i] as Char + i)
@@ -74,7 +74,7 @@ class ImmutableListTest {
     }
 
     @Test fun removeElements() {
-        val list = "abcxaxyz12".toImmutableList()
+        val list = "abcxaxyz12".toImmutableList().toPersistentList()
         fun expectList(content: String, list: ImmutableList<Char>) {
             compareLists(content.toList(), list)
         }
@@ -149,9 +149,9 @@ class ImmutableListTest {
     }
 
     @Test fun noOperation() {
-        immutableListOf<Int>().testNoOperation({ clear() }, { clear() })
+        immutableListOf<Int>().toPersistentList().testNoOperation({ clear() }, { clear() })
 
-        val list = "abcxaxyz12".toImmutableList()
+        val list = "abcxaxyz12".toImmutableList().toPersistentList()
         with(list) {
             testNoOperation({ remove('d') }, { remove('d') })
             testNoOperation({ removeAll(listOf('d', 'e')) }, { removeAll(listOf('d', 'e')) })
@@ -159,7 +159,7 @@ class ImmutableListTest {
         }
     }
 
-    fun <T> ImmutableList<T>.testNoOperation(persistent: ImmutableList<T>.() -> ImmutableList<T>, mutating: MutableList<T>.() -> Unit) {
+    fun <T> PersistentList<T>.testNoOperation(persistent: PersistentList<T>.() -> PersistentList<T>, mutating: MutableList<T>.() -> Unit) {
         val result = this.persistent()
         val buildResult = this.mutate(mutating)
         // Ensure non-mutating operations return the same instance

--- a/kotlinx-collections-immutable/tests/src/test/kotlin/kotlinx.collections.immutable/ImmutableListTest.kt
+++ b/kotlinx-collections-immutable/tests/src/test/kotlin/kotlinx.collections.immutable/ImmutableListTest.kt
@@ -50,7 +50,7 @@ class ImmutableListTest {
     }
 
     @Test fun addElements() {
-        var list = immutableListOf<String>().toPersistentList()
+        var list = immutableListOf<String>()
         list = list.add("x")
         list = list.add(0, "a")
         list = list.addAll(list)
@@ -127,7 +127,7 @@ class ImmutableListTest {
     }
 
     @Test fun subListOfBuilder() {
-        val list = "abcxaxyz12".toImmutableList()
+        val list = "abcxaxyz12".toImmutableList().toPersistentList()
         val builder = list.builder()
         val subList = builder.subList(2, 5)
         builder[4] = 'b'
@@ -137,7 +137,7 @@ class ImmutableListTest {
         assertEquals("abxbxyz12", builder.joinToString(""))
     }
 
-    fun <T> ImmutableList<T>.testMutation(operation: MutableList<T>.() -> Unit) {
+    fun <T> PersistentList<T>.testMutation(operation: MutableList<T>.() -> Unit) {
         val mutable = this.toMutableList()
         val builder = this.builder()
 
@@ -170,9 +170,9 @@ class ImmutableListTest {
     @Test fun covariantTyping() {
         val listNothing = immutableListOf<Nothing>()
 
-        val listS: ImmutableList<String> = listNothing + "x"
-        val listSN: ImmutableList<String?> = listS + (null as String?)
-        val listAny: ImmutableList<Any?> = listSN + 1
+        val listS: PersistentList<String> = listNothing + "x"
+        val listSN: PersistentList<String?> = listS + (null as String?)
+        val listAny: PersistentList<Any?> = listSN + 1
 
         assertEquals(listOf("x", null, 1), listAny)
     }

--- a/kotlinx-collections-immutable/tests/src/test/kotlin/kotlinx.collections.immutable/ImmutableListTest.kt
+++ b/kotlinx-collections-immutable/tests/src/test/kotlin/kotlinx.collections.immutable/ImmutableListTest.kt
@@ -11,8 +11,8 @@ class ImmutableListTest {
 
 
     @Test fun empty() {
-        val empty1 = immutableListOf<Int>()
-        val empty2 = immutableListOf<String>()
+        val empty1 = persistentListOf<Int>()
+        val empty2 = persistentListOf<String>()
         assertEquals<ImmutableList<Any>>(empty1, empty2)
         assertEquals<List<Any>>(listOf(), empty1)
         assertTrue(empty1 === empty2)
@@ -25,8 +25,8 @@ class ImmutableListTest {
 
     @Test fun ofElements() {
         val list0 = listOf("a", "d", 1, null)
-        val list1 = immutableListOf("a", "d", 1, null)
-        val list2 = immutableListOf("a", "d", 1, null)
+        val list1 = persistentListOf("a", "d", 1, null)
+        val list2 = persistentListOf("a", "d", 1, null)
 
         compareLists(list0, list1)
         assertEquals(list1, list2)
@@ -50,7 +50,7 @@ class ImmutableListTest {
     }
 
     @Test fun addElements() {
-        var list = immutableListOf<String>()
+        var list = persistentListOf<String>()
         list = list.add("x")
         list = list.add(0, "a")
         list = list.addAll(list)
@@ -101,7 +101,7 @@ class ImmutableListTest {
     }
 
     @Test fun builder() {
-        val builder = immutableListOf<Char>().builder()
+        val builder = persistentListOf<Char>().builder()
         "abcxaxyz12".toCollection(builder)
         val list = builder.build()
         assertEquals<List<*>>(list, builder)
@@ -149,9 +149,9 @@ class ImmutableListTest {
     }
 
     @Test fun noOperation() {
-        immutableListOf<Int>().toPersistentList().testNoOperation({ clear() }, { clear() })
+        persistentListOf<Int>().testNoOperation({ clear() }, { clear() })
 
-        val list = "abcxaxyz12".toImmutableList().toPersistentList()
+        val list = "abcxaxyz12".toPersistentList()
         with(list) {
             testNoOperation({ remove('d') }, { remove('d') })
             testNoOperation({ removeAll(listOf('d', 'e')) }, { removeAll(listOf('d', 'e')) })
@@ -168,7 +168,7 @@ class ImmutableListTest {
     }
 
     @Test fun covariantTyping() {
-        val listNothing = immutableListOf<Nothing>()
+        val listNothing = persistentListOf<Nothing>()
 
         val listS: PersistentList<String> = listNothing + "x"
         val listSN: PersistentList<String?> = listS + (null as String?)

--- a/kotlinx-collections-immutable/tests/src/test/kotlin/kotlinx.collections.immutable/ImmutableMapTest.kt
+++ b/kotlinx-collections-immutable/tests/src/test/kotlin/kotlinx.collections.immutable/ImmutableMapTest.kt
@@ -7,10 +7,10 @@ import java.util.*
 import kotlin.test.*
 
 class ImmutableHashMapTest : ImmutableMapTest() {
-    override fun <K, V> immutableMapOf(vararg pairs: Pair<K, V>): ImmutableMap<K, V> = kotlinx.collections.immutable.immutableHashMapOf(*pairs)
+    override fun <K, V> immutableMapOf(vararg pairs: Pair<K, V>): PersistentMap<K, V> = kotlinx.collections.immutable.immutableHashMapOf(*pairs)
 }
 class ImmutableOrderedMapTest : ImmutableMapTest() {
-    override fun <K, V> immutableMapOf(vararg pairs: Pair<K, V>): ImmutableMap<K, V> = kotlinx.collections.immutable.immutableMapOf(*pairs)
+    override fun <K, V> immutableMapOf(vararg pairs: Pair<K, V>): PersistentMap<K, V> = kotlinx.collections.immutable.immutableMapOf(*pairs)
     override fun <K, V> compareMaps(expected: Map<K, V>, actual: Map<K, V>) = compare(expected, actual) { mapBehavior(ordered = true) }
 
     @Test fun iterationOrder() {
@@ -30,7 +30,7 @@ class ImmutableOrderedMapTest : ImmutableMapTest() {
 
 abstract class ImmutableMapTest {
 
-    abstract fun <K, V> immutableMapOf(vararg pairs: Pair<K, V>): ImmutableMap<K, V>
+    abstract fun <K, V> immutableMapOf(vararg pairs: Pair<K, V>): PersistentMap<K, V>
 
     open fun <K, V> compareMaps(expected: Map<K, V>, actual: Map<K, V>) = compareMapsUnordered(expected, actual)
     fun <K, V> compareMapsUnordered(expected: Map<K, V>, actual: Map<K, V>) = compare(expected, actual) { mapBehavior(ordered = false) }
@@ -64,7 +64,7 @@ abstract class ImmutableMapTest {
 
 
         val map = HashMap(original) // copy
-        var immMap = map.toImmutableMap().toPersistentMap()
+        var immMap = map.toPersistentMap()
         val immMap2 = immMap.toImmutableMap()
         assertTrue(immMap2 === immMap)
 
@@ -144,7 +144,7 @@ abstract class ImmutableMapTest {
         }
     }
 
-    fun <K, V> ImmutableMap<K, V>.testMutation(operation: MutableMap<K, V>.() -> Unit) {
+    fun <K, V> PersistentMap<K, V>.testMutation(operation: MutableMap<K, V>.() -> Unit) {
         val mutable = HashMap(this) as MutableMap<K, V>
         val builder = this.builder()
 
@@ -180,9 +180,9 @@ abstract class ImmutableMapTest {
     @Test
     fun covariantTyping() {
         val mapNothing = immutableMapOf<Nothing, Nothing>()
-        val mapSI: ImmutableMap<String, Int> = mapNothing + ("x" to 1)
-        val mapSNI: ImmutableMap<String, Int?> = mapSI + mapOf("y" to null)
-        val mapANA: ImmutableMap<Any, Any?> = mapSNI + listOf(1 to "x")
+        val mapSI: PersistentMap<String, Int> = mapNothing + ("x" to 1)
+        val mapSNI: PersistentMap<String, Int?> = mapSI + mapOf("y" to null)
+        val mapANA: PersistentMap<Any, Any?> = mapSNI + listOf(1 to "x")
 
         assertEquals(mapOf(1 to "x", "x" to 1, "y" to null), mapANA)
     }

--- a/kotlinx-collections-immutable/tests/src/test/kotlin/kotlinx.collections.immutable/ImmutableMapTest.kt
+++ b/kotlinx-collections-immutable/tests/src/test/kotlin/kotlinx.collections.immutable/ImmutableMapTest.kt
@@ -7,10 +7,10 @@ import java.util.*
 import kotlin.test.*
 
 class ImmutableHashMapTest : ImmutableMapTest() {
-    override fun <K, V> immutableMapOf(vararg pairs: Pair<K, V>): PersistentMap<K, V> = kotlinx.collections.immutable.immutableHashMapOf(*pairs)
+    override fun <K, V> immutableMapOf(vararg pairs: Pair<K, V>): PersistentMap<K, V> = kotlinx.collections.immutable.persistentHashMapOf(*pairs)
 }
 class ImmutableOrderedMapTest : ImmutableMapTest() {
-    override fun <K, V> immutableMapOf(vararg pairs: Pair<K, V>): PersistentMap<K, V> = kotlinx.collections.immutable.immutableMapOf(*pairs)
+    override fun <K, V> immutableMapOf(vararg pairs: Pair<K, V>): PersistentMap<K, V> = kotlinx.collections.immutable.persistentMapOf(*pairs)
     override fun <K, V> compareMaps(expected: Map<K, V>, actual: Map<K, V>) = compare(expected, actual) { mapBehavior(ordered = true) }
 
     @Test fun iterationOrder() {

--- a/kotlinx-collections-immutable/tests/src/test/kotlin/kotlinx.collections.immutable/ImmutableMapTest.kt
+++ b/kotlinx-collections-immutable/tests/src/test/kotlin/kotlinx.collections.immutable/ImmutableMapTest.kt
@@ -14,7 +14,7 @@ class ImmutableOrderedMapTest : ImmutableMapTest() {
     override fun <K, V> compareMaps(expected: Map<K, V>, actual: Map<K, V>) = compare(expected, actual) { mapBehavior(ordered = true) }
 
     @Test fun iterationOrder() {
-        var map = immutableMapOf("x" to null, "y" to 1)
+        var map = immutableMapOf("x" to null, "y" to 1).toPersistentMap()
         compare(setOf("x", "y"), map.keys) { setBehavior(ordered = true) }
 
         map += "x" to 1
@@ -64,7 +64,7 @@ abstract class ImmutableMapTest {
 
 
         val map = HashMap(original) // copy
-        var immMap = map.toImmutableMap()
+        var immMap = map.toImmutableMap().toPersistentMap()
         val immMap2 = immMap.toImmutableMap()
         assertTrue(immMap2 === immMap)
 
@@ -80,7 +80,7 @@ abstract class ImmutableMapTest {
 
 
     @Test fun putElements() {
-        var map = immutableMapOf<String, Int?>()
+        var map = immutableMapOf<String, Int?>().toPersistentMap()
         map = map.put("x", 0)
         map = map.put("x", 1)
         map = map.putAll(arrayOf("x" to null))
@@ -97,7 +97,7 @@ abstract class ImmutableMapTest {
     }
 
     @Test fun removeElements() {
-        val map = immutableMapOf("x" to 1, null to "x")
+        val map = immutableMapOf("x" to 1, null to "x").toPersistentMap()
 
         fun <K, V> assertEquals(expected: Map<out K, V>, actual: Map<out K, V>) = kotlin.test.assertEquals(expected, actual)
 
@@ -156,9 +156,9 @@ abstract class ImmutableMapTest {
     }
 
     @Test fun noOperation() {
-        immutableMapOf<Int, String>().testNoOperation({ clear() }, { clear() })
+        immutableMapOf<Int, String>().toPersistentMap().testNoOperation({ clear() }, { clear() })
 
-        val map = immutableMapOf("x" to 1, null to "x")
+        val map = immutableMapOf("x" to 1, null to "x").toPersistentMap()
         with(map) {
             testNoOperation({ remove("y") }, { remove("y") })
             testNoOperation({ remove("x", 2) }, { remove("x", 2) })
@@ -168,7 +168,7 @@ abstract class ImmutableMapTest {
         }
     }
 
-    fun <K, V> ImmutableMap<K, V>.testNoOperation(persistent: ImmutableMap<K, V>.() -> ImmutableMap<K, V>, mutating: MutableMap<K, V>.() -> Unit) {
+    fun <K, V> PersistentMap<K, V>.testNoOperation(persistent: PersistentMap<K, V>.() -> PersistentMap<K, V>, mutating: MutableMap<K, V>.() -> Unit) {
         val result = this.persistent()
         val buildResult = this.mutate(mutating)
         // Ensure non-mutating operations return the same instance

--- a/kotlinx-collections-immutable/tests/src/test/kotlin/kotlinx.collections.immutable/ImmutableSetTest.kt
+++ b/kotlinx-collections-immutable/tests/src/test/kotlin/kotlinx.collections.immutable/ImmutableSetTest.kt
@@ -4,11 +4,11 @@ import org.junit.Test
 import kotlin.test.*
 
 class ImmutableSetTest : ImmutableSetTestBase() {
-    override fun <T> immutableSetOf(vararg elements: T) = kotlinx.collections.immutable.immutableSetOf(*elements)
+    override fun <T> immutableSetOf(vararg elements: T) = kotlinx.collections.immutable.persistentSetOf(*elements)
 }
 
 class ImmutableHashSetTest : ImmutableSetTestBase() {
-    override fun <T> immutableSetOf(vararg elements: T) = kotlinx.collections.immutable.immutableHashSetOf(*elements)
+    override fun <T> immutableSetOf(vararg elements: T) = kotlinx.collections.immutable.persistentHashSetOf(*elements)
 
     override fun empty() {
         val empty1 = immutableSetOf<Int>()

--- a/kotlinx-collections-immutable/tests/src/test/kotlin/kotlinx.collections.immutable/ImmutableSetTest.kt
+++ b/kotlinx-collections-immutable/tests/src/test/kotlin/kotlinx.collections.immutable/ImmutableSetTest.kt
@@ -21,7 +21,7 @@ class ImmutableHashSetTest : ImmutableSetTestBase() {
     override fun noOperation() {
         // immutableSetOf<Int>().testNoOperation({ clear() }, { clear() })  // fails to implement this property
 
-        val list = "abcxyz12".toList().toImmutableSet()
+        val list = "abcxyz12".toList().toPersistentSet()
         with(list) {
             testNoOperation({ add('a') }, { add('a') })
             testNoOperation({ addAll(listOf('a', 'b')) }, { addAll(listOf('a', 'b')) })
@@ -34,7 +34,7 @@ class ImmutableHashSetTest : ImmutableSetTestBase() {
 
 abstract class ImmutableSetTestBase {
 
-    abstract fun <T> immutableSetOf(vararg elements: T): ImmutableSet<T>
+    abstract fun <T> immutableSetOf(vararg elements: T): PersistentSet<T>
 
     @Test open fun empty() {
         val empty1 = immutableSetOf<Int>()
@@ -57,7 +57,7 @@ abstract class ImmutableSetTestBase {
         val original = setOf("a", "bar", "cat", null)
 
         val set = original.toMutableSet() // copy
-        var immSet = set.toImmutableSet()
+        var immSet = set.toPersistentSet()
         val immSet2 = immSet.toImmutableSet()
         assertTrue(immSet2 === immSet)
 
@@ -84,7 +84,7 @@ abstract class ImmutableSetTestBase {
 
 
     @Test fun removeElements() {
-        val set = "abcxyz12".toList().toImmutableSet()
+        val set = "abcxyz12".toList().toPersistentSet()
         fun expectSet(content: String, set: ImmutableSet<Char>) {
             assertEquals(content.toSet(), set)
         }
@@ -121,7 +121,7 @@ abstract class ImmutableSetTestBase {
         }
     }
 
-    fun <T> ImmutableSet<T>.testMutation(operation: MutableSet<T>.() -> Unit) {
+    fun <T> PersistentSet<T>.testMutation(operation: MutableSet<T>.() -> Unit) {
         val mutable = this.toMutableSet()
         val builder = this.builder()
 
@@ -137,7 +137,7 @@ abstract class ImmutableSetTestBase {
     @Test open fun noOperation() {
         immutableSetOf<Int>().testNoOperation({ clear() }, { clear() })
 
-        val set = "abcxyz12".asIterable().toImmutableSet()
+        val set = "abcxyz12".asIterable().toPersistentSet()
         with(set) {
             testNoOperation({ add('a') }, { add('a') })
             testNoOperation({ addAll(listOf('a', 'b')) }, { addAll(listOf('a', 'b')) })
@@ -147,7 +147,7 @@ abstract class ImmutableSetTestBase {
         }
     }
 
-    fun <T> ImmutableSet<T>.testNoOperation(persistent: ImmutableSet<T>.() -> ImmutableSet<T>, mutating: MutableSet<T>.() -> Unit) {
+    fun <T> PersistentSet<T>.testNoOperation(persistent: PersistentSet<T>.() -> PersistentSet<T>, mutating: MutableSet<T>.() -> Unit) {
         val result = this.persistent()
         val buildResult = this.mutate(mutating)
         // Ensure non-mutating operations return the same instance


### PR DESCRIPTION
This PR splits immutable collection interfaces each into two parts: immutable interface which just declares collection immutability, and persistent one which adds modification operations and builder on top of that.

We faced several times when it would be advantageous to declare that a collection is immutable, however the need to implement all the modification operations made us desist from that.

For example `ImmutableList.subList` definitely returns an immutable list, however it could be not an easy task to implement all the modifications and builder in that sublist. Same for `ImmutableMap.keys/values/entries` collections.

If merged this will fix #1