### PR TITLE
Rename Marker to MutabilityOwnership

### DIFF
--- a/kotlinx-collections-immutable/src/main/kotlin/kotlinx/collections/immutable/implementations/immutableList/PersistentVectorBuilder.kt
+++ b/kotlinx-collections-immutable/src/main/kotlin/kotlinx/collections/immutable/implementations/immutableList/PersistentVectorBuilder.kt
@@ -19,8 +19,7 @@ package kotlinx.collections.immutable.implementations.immutableList
 import kotlinx.collections.immutable.PersistentList
 import kotlinx.collections.immutable.internal.ListImplementation.checkElementIndex
 import kotlinx.collections.immutable.internal.ListImplementation.checkPositionIndex
-
-private class MutabilityOwnership // TODO: Rename to MutabilityOwnership?
+import kotlinx.collections.immutable.internal.MutabilityOwnership
 
 class PersistentVectorBuilder<E>(private var vector: PersistentList<E>,
                                  private var vectorRoot: Array<Any?>?,

--- a/kotlinx-collections-immutable/src/main/kotlin/kotlinx/collections/immutable/implementations/immutableList/PersistentVectorBuilder.kt
+++ b/kotlinx-collections-immutable/src/main/kotlin/kotlinx/collections/immutable/implementations/immutableList/PersistentVectorBuilder.kt
@@ -20,13 +20,13 @@ import kotlinx.collections.immutable.PersistentList
 import kotlinx.collections.immutable.internal.ListImplementation.checkElementIndex
 import kotlinx.collections.immutable.internal.ListImplementation.checkPositionIndex
 
-private class Marker // TODO: Rename to MutabilityOwnership?
+private class MutabilityOwnership // TODO: Rename to MutabilityOwnership?
 
 class PersistentVectorBuilder<E>(private var vector: PersistentList<E>,
                                  private var vectorRoot: Array<Any?>?,
                                  private var vectorTail: Array<Any?>,
                                  internal var rootShift: Int) : AbstractMutableList<E>(), PersistentList.Builder<E> {
-    private var marker = Marker()
+    private var ownership = MutabilityOwnership()
     internal var root = vectorRoot
         private set
     internal var tail = vectorTail
@@ -40,7 +40,7 @@ class PersistentVectorBuilder<E>(private var vector: PersistentList<E>,
         vector = if (root === vectorRoot && tail === vectorTail) {
             vector
         } else {
-            marker = Marker()
+            ownership = MutabilityOwnership()
             vectorRoot = root
             vectorTail = tail
             if (root == null) {
@@ -69,13 +69,13 @@ class PersistentVectorBuilder<E>(private var vector: PersistentList<E>,
     private fun makeMutable(buffer: Array<Any?>?): Array<Any?> {
         if (buffer == null) {
             val newBuffer = arrayOfNulls<Any?>(MUTABLE_BUFFER_SIZE)
-            newBuffer[MUTABLE_BUFFER_SIZE - 1] = marker
+            newBuffer[MUTABLE_BUFFER_SIZE - 1] = ownership
             return newBuffer
         }
-        if (buffer.size != MUTABLE_BUFFER_SIZE || buffer[MUTABLE_BUFFER_SIZE - 1] !== marker) {
+        if (buffer.size != MUTABLE_BUFFER_SIZE || buffer[MUTABLE_BUFFER_SIZE - 1] !== ownership) {
             val newBuffer = arrayOfNulls<Any?>(MUTABLE_BUFFER_SIZE)
             buffer.copyInto(newBuffer, endIndex = buffer.size.coerceAtMost(MAX_BUFFER_SIZE))
-            newBuffer[MUTABLE_BUFFER_SIZE - 1] = marker
+            newBuffer[MUTABLE_BUFFER_SIZE - 1] = ownership
             return newBuffer
         }
         return buffer
@@ -84,7 +84,7 @@ class PersistentVectorBuilder<E>(private var vector: PersistentList<E>,
     private fun mutableBufferWith(element: Any?): Array<Any?> {
         val buffer = arrayOfNulls<Any?>(MUTABLE_BUFFER_SIZE)
         buffer[0] = element
-        buffer[MUTABLE_BUFFER_SIZE - 1] = marker
+        buffer[MUTABLE_BUFFER_SIZE - 1] = ownership
         return buffer
     }
 

--- a/kotlinx-collections-immutable/src/main/kotlin/kotlinx/collections/immutable/implementations/immutableMap/PersistentHashMapBuilder.kt
+++ b/kotlinx-collections-immutable/src/main/kotlin/kotlinx/collections/immutable/implementations/immutableMap/PersistentHashMapBuilder.kt
@@ -18,10 +18,11 @@ package kotlinx.collections.immutable.implementations.immutableMap
 
 import kotlinx.collections.immutable.PersistentMap
 
-internal class Marker
+internal class MutabilityOwnership
 
 internal class PersistentHashMapBuilder<K, V>(private var map: PersistentHashMap<K, V>) : PersistentMap.Builder<K, V>, AbstractMutableMap<K, V>() {
-    internal var marker = Marker()
+    internal var ownership = MutabilityOwnership()
+        private set
     internal var node = map.node
     internal var operationResult: V? = null
     internal var modCount = 0
@@ -37,7 +38,7 @@ internal class PersistentHashMapBuilder<K, V>(private var map: PersistentHashMap
         map = if (node === map.node) {
             map
         } else {
-            marker = Marker()
+            ownership = MutabilityOwnership()
             PersistentHashMap(node, size)
         }
         return map

--- a/kotlinx-collections-immutable/src/main/kotlin/kotlinx/collections/immutable/implementations/immutableMap/PersistentHashMapBuilder.kt
+++ b/kotlinx-collections-immutable/src/main/kotlin/kotlinx/collections/immutable/implementations/immutableMap/PersistentHashMapBuilder.kt
@@ -17,8 +17,7 @@
 package kotlinx.collections.immutable.implementations.immutableMap
 
 import kotlinx.collections.immutable.PersistentMap
-
-internal class MutabilityOwnership
+import kotlinx.collections.immutable.internal.MutabilityOwnership
 
 internal class PersistentHashMapBuilder<K, V>(private var map: PersistentHashMap<K, V>) : PersistentMap.Builder<K, V>, AbstractMutableMap<K, V>() {
     internal var ownership = MutabilityOwnership()

--- a/kotlinx-collections-immutable/src/main/kotlin/kotlinx/collections/immutable/implementations/immutableMap/TrieNode.kt
+++ b/kotlinx-collections-immutable/src/main/kotlin/kotlinx/collections/immutable/implementations/immutableMap/TrieNode.kt
@@ -16,6 +16,8 @@
 
 package kotlinx.collections.immutable.implementations.immutableMap
 
+import kotlinx.collections.immutable.internal.MutabilityOwnership
+
 
 internal const val MAX_BRANCHING_FACTOR = 32
 internal const val LOG_MAX_BRANCHING_FACTOR = 5

--- a/kotlinx-collections-immutable/src/main/kotlin/kotlinx/collections/immutable/implementations/immutableSet/PersistentHashSetBuilder.kt
+++ b/kotlinx-collections-immutable/src/main/kotlin/kotlinx/collections/immutable/implementations/immutableSet/PersistentHashSetBuilder.kt
@@ -17,8 +17,7 @@
 package kotlinx.collections.immutable.implementations.immutableSet
 
 import kotlinx.collections.immutable.PersistentSet
-
-internal class MutabilityOwnership
+import kotlinx.collections.immutable.internal.MutabilityOwnership
 
 internal class PersistentHashSetBuilder<E>(private var set: PersistentHashSet<E>) : AbstractMutableSet<E>(), PersistentSet.Builder<E> {
     internal var ownership = MutabilityOwnership()

--- a/kotlinx-collections-immutable/src/main/kotlin/kotlinx/collections/immutable/implementations/immutableSet/PersistentHashSetBuilder.kt
+++ b/kotlinx-collections-immutable/src/main/kotlin/kotlinx/collections/immutable/implementations/immutableSet/PersistentHashSetBuilder.kt
@@ -18,12 +18,15 @@ package kotlinx.collections.immutable.implementations.immutableSet
 
 import kotlinx.collections.immutable.PersistentSet
 
-internal class Marker
+internal class MutabilityOwnership
 
 internal class PersistentHashSetBuilder<E>(private var set: PersistentHashSet<E>) : AbstractMutableSet<E>(), PersistentSet.Builder<E> {
-    internal var marker = Marker()
+    internal var ownership = MutabilityOwnership()
+        private set
     internal var node = set.node
+        private set
     internal var modCount = 0
+        private set
 
     // Size change implies structural changes.
     override var size = set.size
@@ -36,7 +39,7 @@ internal class PersistentHashSetBuilder<E>(private var set: PersistentHashSet<E>
         set = if (node === set.node) {
             set
         } else {
-            marker = Marker()
+            ownership = MutabilityOwnership()
             PersistentHashSet(node, size)
         }
         return set

--- a/kotlinx-collections-immutable/src/main/kotlin/kotlinx/collections/immutable/implementations/immutableSet/TrieNode.kt
+++ b/kotlinx-collections-immutable/src/main/kotlin/kotlinx/collections/immutable/implementations/immutableSet/TrieNode.kt
@@ -16,6 +16,8 @@
 
 package kotlinx.collections.immutable.implementations.immutableSet
 
+import kotlinx.collections.immutable.internal.MutabilityOwnership
+
 
 internal const val MAX_BRANCHING_FACTOR = 32
 internal const val LOG_MAX_BRANCHING_FACTOR = 5

--- a/kotlinx-collections-immutable/src/main/kotlin/kotlinx/collections/immutable/implementations/persistentOrderedMap/PersistentOrderedMap.kt
+++ b/kotlinx-collections-immutable/src/main/kotlin/kotlinx/collections/immutable/implementations/persistentOrderedMap/PersistentOrderedMap.kt
@@ -20,9 +20,8 @@ import kotlinx.collections.immutable.ImmutableCollection
 import kotlinx.collections.immutable.ImmutableSet
 import kotlinx.collections.immutable.PersistentMap
 import kotlinx.collections.immutable.implementations.immutableMap.PersistentHashMap
+import kotlinx.collections.immutable.internal.EndOfChain
 import kotlinx.collections.immutable.mutate
-
-internal object EndOfChain
 
 internal class LinkedValue<V>(val value: V, val previous: Any?, val next: Any?) {
     /** Constructs LinkedValue for a new single entry */

--- a/kotlinx-collections-immutable/src/main/kotlin/kotlinx/collections/immutable/implementations/persistentOrderedMap/PersistentOrderedMapBuilder.kt
+++ b/kotlinx-collections-immutable/src/main/kotlin/kotlinx/collections/immutable/implementations/persistentOrderedMap/PersistentOrderedMapBuilder.kt
@@ -17,6 +17,7 @@
 package kotlinx.collections.immutable.implementations.persistentOrderedMap
 
 import kotlinx.collections.immutable.PersistentMap
+import kotlinx.collections.immutable.internal.EndOfChain
 
 internal class PersistentOrderedMapBuilder<K, V>(private var map: PersistentOrderedMap<K, V>) : AbstractMutableMap<K, V>(), PersistentMap.Builder<K, V> {
     internal var firstKey = map.firstKey

--- a/kotlinx-collections-immutable/src/main/kotlin/kotlinx/collections/immutable/implementations/persistentOrderedMap/PersistentOrderedMapBuilderContentIterators.kt
+++ b/kotlinx-collections-immutable/src/main/kotlin/kotlinx/collections/immutable/implementations/persistentOrderedMap/PersistentOrderedMapBuilderContentIterators.kt
@@ -17,6 +17,7 @@
 package kotlinx.collections.immutable.implementations.persistentOrderedMap
 
 import kotlinx.collections.immutable.implementations.immutableMap.MapEntry
+import kotlinx.collections.immutable.internal.EndOfChain
 
 internal open class PersistentOrderedMapBuilderLinksIterator<K, V>(
         private var nextKey: Any?,

--- a/kotlinx-collections-immutable/src/main/kotlin/kotlinx/collections/immutable/implementations/persistentOrderedSet/PersistentOrderedSet.kt
+++ b/kotlinx-collections-immutable/src/main/kotlin/kotlinx/collections/immutable/implementations/persistentOrderedSet/PersistentOrderedSet.kt
@@ -18,7 +18,7 @@ package kotlinx.collections.immutable.implementations.persistentOrderedSet
 
 import kotlinx.collections.immutable.PersistentSet
 import kotlinx.collections.immutable.implementations.immutableMap.PersistentHashMap
-import kotlinx.collections.immutable.implementations.persistentOrderedMap.EndOfChain
+import kotlinx.collections.immutable.internal.EndOfChain
 import kotlinx.collections.immutable.mutate
 
 internal class Links(val previous: Any?, val next: Any?) {

--- a/kotlinx-collections-immutable/src/main/kotlin/kotlinx/collections/immutable/implementations/persistentOrderedSet/PersistentOrderedSetBuilder.kt
+++ b/kotlinx-collections-immutable/src/main/kotlin/kotlinx/collections/immutable/implementations/persistentOrderedSet/PersistentOrderedSetBuilder.kt
@@ -17,7 +17,7 @@
 package kotlinx.collections.immutable.implementations.persistentOrderedSet
 
 import kotlinx.collections.immutable.PersistentSet
-import kotlinx.collections.immutable.implementations.persistentOrderedMap.EndOfChain
+import kotlinx.collections.immutable.internal.EndOfChain
 
 internal class PersistentOrderedSetBuilder<E>(private var set: PersistentOrderedSet<E>) : AbstractMutableSet<E>(), PersistentSet.Builder<E> {
     internal var firstElement = set.firstElement

--- a/kotlinx-collections-immutable/src/main/kotlin/kotlinx/collections/immutable/internal/EndOfChain.kt
+++ b/kotlinx-collections-immutable/src/main/kotlin/kotlinx/collections/immutable/internal/EndOfChain.kt
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2016-2019 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kotlinx.collections.immutable.internal
+
+internal object EndOfChain

--- a/kotlinx-collections-immutable/src/main/kotlin/kotlinx/collections/immutable/internal/MutabilityOwnership.kt
+++ b/kotlinx-collections-immutable/src/main/kotlin/kotlinx/collections/immutable/internal/MutabilityOwnership.kt
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2016-2019 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kotlinx.collections.immutable.internal
+
+/**
+ * The mutability ownership token of a persistent collection builder.
+ *
+ * Used to mark persistent data structures, that are owned by a collection builder and can be mutated by it.
+ */
+internal class MutabilityOwnership


### PR DESCRIPTION
The idea is to rename `Marker` class, `marker` parameter and unify these classes of persistent List, Set and Map.