### PR TITLE
Faster union operations (fix)

### DIFF
--- a/core/commonMain/src/implementations/immutableMap/PersistentHashMapBuilder.kt
+++ b/core/commonMain/src/implementations/immutableMap/PersistentHashMapBuilder.kt
@@ -63,7 +63,11 @@ internal class PersistentHashMapBuilder<K, V>(private var map: PersistentHashMap
     }
 
     override fun putAll(from: Map<out K, V>) {
-        val map = from as? PersistentHashMap ?: (from as? PersistentHashMapBuilder)?.map
+        val map = when {
+            from is PersistentHashMap -> from
+            from is PersistentHashMapBuilder && from.node === from.map.node -> from.map
+            else -> null
+        }
         if (map != null) @Suppress("UNCHECKED_CAST") {
             val intersectionCounter = DeltaCounter()
             val oldSize = this.size

--- a/core/commonMain/src/implementations/immutableMap/PersistentHashMapBuilder.kt
+++ b/core/commonMain/src/implementations/immutableMap/PersistentHashMapBuilder.kt
@@ -63,11 +63,7 @@ internal class PersistentHashMapBuilder<K, V>(private var map: PersistentHashMap
     }
 
     override fun putAll(from: Map<out K, V>) {
-        val map = when {
-            from is PersistentHashMap -> from
-            from is PersistentHashMapBuilder && from.node === from.map.node -> from.map
-            else -> null
-        }
+        val map = from as? PersistentHashMap ?: (from as? PersistentHashMapBuilder)?.build()
         if (map != null) @Suppress("UNCHECKED_CAST") {
             val intersectionCounter = DeltaCounter()
             val oldSize = this.size

--- a/core/commonMain/src/implementations/immutableSet/PersistentHashSetBuilder.kt
+++ b/core/commonMain/src/implementations/immutableSet/PersistentHashSetBuilder.kt
@@ -24,7 +24,7 @@ internal class PersistentHashSetBuilder<E>(private var set: PersistentHashSet<E>
             modCount++
         }
 
-    override fun build(): PersistentSet<E> {
+    override fun build(): PersistentHashSet<E> {
         set = if (node === set.node) {
             set
         } else {
@@ -45,11 +45,7 @@ internal class PersistentHashSetBuilder<E>(private var set: PersistentHashSet<E>
     }
 
     override fun addAll(elements: Collection<E>): Boolean {
-        val set = when {
-            elements is PersistentHashSet -> elements
-            elements is PersistentHashSetBuilder && elements.node === elements.set.node -> elements.set
-            else -> null
-        }
+        val set = elements as? PersistentHashSet ?: (elements as? PersistentHashSetBuilder)?.build()
         if (set !== null) {
             val deltaCounter = DeltaCounter()
             val oldSize = this.size

--- a/core/commonMain/src/implementations/immutableSet/PersistentHashSetBuilder.kt
+++ b/core/commonMain/src/implementations/immutableSet/PersistentHashSetBuilder.kt
@@ -45,7 +45,11 @@ internal class PersistentHashSetBuilder<E>(private var set: PersistentHashSet<E>
     }
 
     override fun addAll(elements: Collection<E>): Boolean {
-        val set = elements as? PersistentHashSet ?: (elements as? PersistentHashSetBuilder)?.set
+        val set = when {
+            elements is PersistentHashSet -> elements
+            elements is PersistentHashSetBuilder && elements.node === elements.set.node -> elements.set
+            else -> null
+        }
         if (set !== null) {
             val deltaCounter = DeltaCounter()
             val oldSize = this.size

--- a/core/commonTest/src/contract/map/ImmutableMapTest.kt
+++ b/core/commonTest/src/contract/map/ImmutableMapTest.kt
@@ -52,6 +52,29 @@ class ImmutableHashMapTest : ImmutableMapTest() {
             assertSame(left, left + immutableMapOf())
         }
     }
+
+    @Test fun putAllElementsFromBuilder() {
+        val builder1 = immutableMapOf<String, Int>().builder()
+        val builder2 = immutableMapOf<String, Int>().builder()
+        val expected = mutableMapOf<String, Int>()
+        for(i in 300..400) {
+            builder1.put("$i", i)
+            expected.put("$i", i)
+        }
+        for(i in 0..200) {
+            builder2.put("$i", i)
+            expected.put("$i", i)
+        }
+        builder1.putAll(builder2)
+
+        // make sure we work with current state of builder2, not previous
+        compareMaps(expected, builder1)
+        builder2.put("200", 1000)
+        // make sure we can't modify builder1 through builder2
+        compareMaps(expected, builder1)
+        // make sure builder builds correct map
+        compareMaps(expected, builder1.build())
+    }
 }
 class ImmutableOrderedMapTest : ImmutableMapTest() {
     override fun <K, V> immutableMapOf(vararg pairs: Pair<K, V>): PersistentMap<K, V> = persistentMapOf(*pairs)

--- a/core/commonTest/src/contract/set/ImmutableSetTest.kt
+++ b/core/commonTest/src/contract/set/ImmutableSetTest.kt
@@ -54,6 +54,29 @@ class ImmutableHashSetTest : ImmutableSetTestBase() {
         }
     }
 
+    @Test fun addAllElementsFromBuilder() {
+        val builder1 = immutableSetOf<String>().builder()
+        val builder2 = immutableSetOf<String>().builder()
+        val expected = mutableSetOf<String>()
+        for(i in 300..400) {
+            builder1.add("$i")
+            expected.add("$i")
+        }
+        for(i in 0..200) {
+            builder2.add("$i")
+            expected.add("$i")
+        }
+        builder1.addAll(builder2)
+
+        // make sure we work with current state of builder2, not previous
+        compareSets(expected, builder1)
+        builder2.add("200")
+        // make sure we can't modify builder1 through builder2
+        compareSets(expected, builder1)
+        // make sure builder builds correct map
+        compareSets(expected, builder1.build())
+    }
+
 }
 class ImmutableOrderedSetTest : ImmutableSetTestBase() {
     override fun <T> immutableSetOf(vararg elements: T) = persistentSetOf(*elements)


### PR DESCRIPTION
https://github.com/Kotlin/kotlinx.collections.immutable/pull/86#discussion_r490582688 

Note that this is a conservative fix: we cannot use `map`/`set` fields cause they may be outdated, we also cannot use `node` fields because they allow undetectable concurrent modifications.
Alternative: just call `build()`, but commiting the build result of an argument seems not right to me.