### PR TITLE
Faster intersection operations

### DIFF
--- a/core/commonMain/src/ImmutableCollection.kt
+++ b/core/commonMain/src/ImmutableCollection.kt
@@ -68,6 +68,16 @@ public interface PersistentCollection<out E> : ImmutableCollection<E> {
     fun removeAll(predicate: (E) -> Boolean): PersistentCollection<E>
 
     /**
+     * Returns all elements in this collection that are also
+     * contained in the specified [elements] collection.
+     *
+     * @return a new persistent set with elements in this set that are also
+     * contained in the specified [elements] collection;
+     * or this instance if no modifications were made in the result of this operation.
+     */
+    fun retainAll(elements: Collection<@UnsafeVariance E>): PersistentCollection<E>
+
+    /**
      * Returns an empty persistent collection.
      */
     fun clear(): PersistentCollection<E>

--- a/core/commonMain/src/ImmutableList.kt
+++ b/core/commonMain/src/ImmutableList.kt
@@ -102,6 +102,16 @@ public interface PersistentList<out E> : ImmutableList<E>, PersistentCollection<
     override fun removeAll(predicate: (E) -> Boolean): PersistentList<E>
 
     /**
+     * Returns all elements in this list that are also
+     * contained in the specified [elements] collection.
+     *
+     * @return a new persistent list with elements in this list that are also
+     * contained in the specified [elements] collection;
+     * or this instance if no modifications were made in the result of this operation.
+     */
+    override fun retainAll(elements: Collection<@UnsafeVariance E>): PersistentList<E>
+
+    /**
      * Returns an empty persistent list.
      */
     override fun clear(): PersistentList<E>

--- a/core/commonMain/src/ImmutableSet.kt
+++ b/core/commonMain/src/ImmutableSet.kt
@@ -70,6 +70,16 @@ public interface PersistentSet<out E> : ImmutableSet<E>, PersistentCollection<E>
     override fun removeAll(predicate: (E) -> Boolean): PersistentSet<E>
 
     /**
+     * Returns all elements in this set that are also
+     * contained in the specified [elements] collection.
+     *
+     * @return a new persistent set with elements in this set that are also
+     * contained in the specified [elements] collection;
+     * or this instance if no modifications were made in the result of this operation.
+     */
+    override fun retainAll(elements: Collection<@UnsafeVariance E>): PersistentSet<E>
+
+    /**
      * Returns an empty persistent set.
      */
     override fun clear(): PersistentSet<E>

--- a/core/commonMain/src/extensions.kt
+++ b/core/commonMain/src/extensions.kt
@@ -291,6 +291,26 @@ operator fun <E> PersistentSet<E>.minus(elements: Array<out E>): PersistentSet<E
 operator fun <E> PersistentSet<E>.minus(elements: Sequence<E>): PersistentSet<E>
         = mutate { it.removeAll(elements) }
 
+/**
+ * Returns all elements in this set that are also
+ * contained in the specified [elements] collection.
+ *
+ * @return a new persistent set with elements in this set that are also
+ * contained in the specified [elements] collection;
+ * or this instance if no modifications were made in the result of this operation.
+ */
+infix fun <E> PersistentSet<E>.intersect(elements: Iterable<E>): PersistentSet<E>
+        = if (elements is Collection) retainAll(elements) else mutate { it.retainAll(elements) }
+
+/**
+ * Returns all elements in this collection that are also
+ * contained in the specified [elements] collection.
+ *
+ * @return a new persistent set with elements in this collection that are also
+ * contained in the specified [elements] collection
+ */
+infix fun <E> PersistentCollection<E>.intersect(elements: Iterable<E>): PersistentSet<E>
+        = this.toPersistentSet().intersect(elements)
 
 /**
  * Returns the result of adding an entry to this map from the specified key-value [pair].

--- a/core/commonMain/src/implementations/immutableList/AbstractPersistentList.kt
+++ b/core/commonMain/src/implementations/immutableList/AbstractPersistentList.kt
@@ -34,6 +34,10 @@ abstract class AbstractPersistentList<E> : PersistentList<E>, AbstractList<E>() 
         return removeAll { elements.contains(it) }
     }
 
+    override fun retainAll(elements: Collection<E>): PersistentList<E> {
+        return removeAll { !elements.contains(it) }
+    }
+
     override fun clear(): PersistentList<E> {
         return persistentVectorOf()
     }

--- a/core/commonMain/src/implementations/immutableSet/PersistentHashSet.kt
+++ b/core/commonMain/src/implementations/immutableSet/PersistentHashSet.kt
@@ -6,7 +6,6 @@
 package kotlinx.collections.immutable.implementations.immutableSet
 
 import kotlinx.collections.immutable.PersistentSet
-import kotlinx.collections.immutable.internal.DeltaCounter
 import kotlinx.collections.immutable.mutate
 
 internal class PersistentHashSet<E>(internal val node: TrieNode<E>,
@@ -37,6 +36,20 @@ internal class PersistentHashSet<E>(internal val node: TrieNode<E>,
 
     override fun removeAll(predicate: (E) -> Boolean): PersistentSet<E> {
         return mutate { it.removeAll(predicate) }
+    }
+
+    override fun retainAll(elements: Collection<E>): PersistentSet<E> {
+        return mutate { it.retainAll(elements) }
+    }
+
+    override fun containsAll(elements: Collection<E>): Boolean {
+        if (elements is PersistentHashSet) {
+            return node.containsAll(elements.node, 0)
+        }
+        if (elements is PersistentHashSetBuilder) {
+            return node.containsAll(elements.node, 0)
+        }
+        return super.containsAll(elements)
     }
 
     override fun clear(): PersistentSet<E> {

--- a/core/commonMain/src/implementations/immutableSet/PersistentHashSetBuilder.kt
+++ b/core/commonMain/src/implementations/immutableSet/PersistentHashSetBuilder.kt
@@ -48,15 +48,67 @@ internal class PersistentHashSetBuilder<E>(private var set: PersistentHashSet<E>
         val set = elements as? PersistentHashSet ?: (elements as? PersistentHashSetBuilder)?.build()
         if (set !== null) {
             val deltaCounter = DeltaCounter()
-            val oldSize = this.size
-            node = node.mutableAddAll(set.node, 0, deltaCounter, this)
-            val newSize = oldSize + elements.size - deltaCounter.count
-            if (oldSize != newSize) {
+            val size = this.size
+            val result = node.mutableAddAll(set.node, 0, deltaCounter, this)
+            val newSize = size + elements.size - deltaCounter.count
+            if (size != newSize) {
+                this.node = result
                 this.size = newSize
             }
-            return oldSize != this.size
+            return size != this.size
         }
         return super.addAll(elements)
+    }
+
+    override fun retainAll(elements: Collection<E>): Boolean {
+        val set = elements as? PersistentHashSet ?: (elements as? PersistentHashSetBuilder)?.build()
+        if (set !== null) {
+            val deltaCounter = DeltaCounter()
+            val size = this.size
+            val result = node.mutableRetainAll(set.node, 0, deltaCounter, this)
+            when (val newSize = deltaCounter.count) {
+                0 -> clear()
+                size -> {}
+                else -> {
+                    @Suppress("UNCHECKED_CAST")
+                    this.node = result as TrieNode<E>
+                    this.size = newSize
+                }
+            }
+            return size != this.size
+        }
+        return super.retainAll(elements)
+    }
+
+    override fun removeAll(elements: Collection<E>): Boolean {
+        val set = elements as? PersistentHashSet ?: (elements as? PersistentHashSetBuilder)?.build()
+        if (set !== null) {
+            val counter = DeltaCounter()
+            val size = this.size
+            val result = node.mutableRemoveAll(set.node, 0, counter, this)
+
+            when (val newSize = size - counter.count) {
+                0 -> clear()
+                size -> {}
+                else -> {
+                    @Suppress("UNCHECKED_CAST")
+                    this.node = result as TrieNode<E>
+                    this.size = newSize
+                }
+            }
+            return size != this.size
+        }
+        return super.removeAll(elements)
+    }
+
+    override fun containsAll(elements: Collection<E>): Boolean {
+        if (elements is PersistentHashSet) {
+            return node.containsAll(elements.node, 0)
+        }
+        if (elements is PersistentHashSetBuilder) {
+            return node.containsAll(elements.node, 0)
+        }
+        return super.containsAll(elements)
     }
 
     override fun remove(element: E): Boolean {

--- a/core/commonMain/src/implementations/persistentOrderedSet/PersistentOrderedSet.kt
+++ b/core/commonMain/src/implementations/persistentOrderedSet/PersistentOrderedSet.kt
@@ -85,6 +85,10 @@ internal class PersistentOrderedSet<E>(
         return mutate { it.removeAll(predicate) }
     }
 
+    override fun retainAll(elements: Collection<E>): PersistentSet<E> {
+        return mutate { it.retainAll(elements) }
+    }
+
     override fun clear(): PersistentSet<E> {
         return PersistentOrderedSet.emptyOf()
     }

--- a/core/commonTest/src/contract/set/ImmutableSetTest.kt
+++ b/core/commonTest/src/contract/set/ImmutableSetTest.kt
@@ -58,11 +58,11 @@ class ImmutableHashSetTest : ImmutableSetTestBase() {
         val builder1 = immutableSetOf<String>().builder()
         val builder2 = immutableSetOf<String>().builder()
         val expected = mutableSetOf<String>()
-        for(i in 300..400) {
+        for (i in 300..400) {
             builder1.add("$i")
             expected.add("$i")
         }
-        for(i in 0..200) {
+        for (i in 0..200) {
             builder2.add("$i")
             expected.add("$i")
         }
@@ -75,6 +75,125 @@ class ImmutableHashSetTest : ImmutableSetTestBase() {
         compareSets(expected, builder1)
         // make sure builder builds correct map
         compareSets(expected, builder1.build())
+    }
+
+    @Test fun containsAll() {
+        assertTrue(immutableSetOf(1).containsAll(immutableSetOf()))
+        assertTrue(immutableSetOf(1, 2).containsAll(immutableSetOf(1)))
+        assertTrue((immutableSetOf<Int>() + (1..2000)).containsAll(immutableSetOf<Int>() + (400..1000)))
+        assertFalse((immutableSetOf<Int>() + (1..2000)).containsAll(immutableSetOf<Int>() + (1999..2001)))
+    }
+
+    @Test fun retainAllElements() {
+        run {
+            val left = immutableSetOf<Int>() + (1..2000)
+            compareSets(immutableSetOf(), left.retainAll(immutableSetOf()))
+            compareSets(immutableSetOf(), immutableSetOf<Int>().retainAll(left))
+        }
+
+        run {
+            val left = immutableSetOf<Int>() + (1..2000)
+            val right = immutableSetOf<Int>() + (2000..3000)
+            compareSets(immutableSetOf(2000), left intersect right)
+            compareSets(immutableSetOf(2000), right intersect left)
+        }
+
+        run {
+            val left = immutableSetOf<Int>() + (1..2000)
+            val right = immutableSetOf<Int>() + (2001..3000)
+            compareSets(immutableSetOf(), left intersect right)
+            compareSets(immutableSetOf(), right intersect left)
+        }
+
+        run {
+            val left = immutableSetOf<Int>() + (1..2000)
+            val right = immutableSetOf<Int>() + (200..3000)
+            compareSets(left.toSet() intersect right.toSet(), left intersect right)
+        }
+
+        run {
+            val left = immutableSetOf<IntWrapper>() + (1..2000).map { IntWrapper(it, it % 200) }
+            val right = immutableSetOf<IntWrapper>() + (200..3000).map { IntWrapper(it, it % 200) }
+            compareSets(left.toSet() intersect right.toSet(), left intersect right)
+        }
+
+        run {
+            val left = immutableSetOf<IntWrapper>() + (1..2000).map { IntWrapper(it, it % 200) }
+            val right = immutableSetOf<IntWrapper>() + (2001..3000).map { IntWrapper(it, it % 200) }
+            compareSets(left.toSet() intersect right.toSet(), left intersect right)
+        }
+
+        run {
+            val left = immutableSetOf<String>() + (1..2000).map { "$it" }
+            val right = immutableSetOf<String>() + (200..3000).map { "$it" }
+            compareSets(left.toSet() intersect right.toSet(), left intersect right)
+        }
+
+        run {
+            val left = immutableSetOf<Int>() + (1..2000)
+            assertSame(left, left intersect left)
+            val right = immutableSetOf<Int>() + (1..2000)
+            assertSame(right, right intersect left)
+            assertSame(left, left intersect right)
+        }
+    }
+
+    @Test fun removeAllElements() {
+        run {
+            val left = immutableSetOf<Int>() + (1..2000)
+            assertSame(left, left.removeAll(immutableSetOf()))
+            assertSame(immutableSetOf(), immutableSetOf<Int>().removeAll(left))
+        }
+
+        run {
+            val left = immutableSetOf<Int>() + (1..2000)
+            val right = immutableSetOf<Int>() + (2000..3000)
+            compareSets((1..1999).toSet(), left - right)
+            compareSets((2001..3000).toSet(), right - left)
+        }
+
+        run {
+            val left = immutableSetOf<Int>() + (1..2000)
+            val right = immutableSetOf<Int>() + (2001..3000)
+            assertSame(left, left - right)
+            assertSame(right, right - left)
+        }
+
+        run {
+            val left = immutableSetOf<Int>() + (1..2000)
+            val right = immutableSetOf<Int>() + (200..3000)
+            compareSets(left.toSet() - right.toSet(), left - right)
+            compareSets(right.toSet() - left.toSet(), right - left)
+        }
+
+        run {
+            val left = immutableSetOf<IntWrapper>() + (1..2000).map { IntWrapper(it, it % 200) }
+            val right = immutableSetOf<IntWrapper>() + (200..3000).map { IntWrapper(it, it % 200) }
+            compareSets(left.toSet() - right.toSet(), left - right)
+            compareSets(right.toSet() - left.toSet(), right - left)
+        }
+
+        run {
+            val left = immutableSetOf<IntWrapper>() + (1..2000).map { IntWrapper(it, it % 200) }
+            val right = immutableSetOf<IntWrapper>() + (2001..3000).map { IntWrapper(it, it % 200) }
+            compareSets(left.toSet() - right.toSet(), left - right)
+            compareSets(right.toSet() - left.toSet(), right - left)
+        }
+
+        run {
+            val left = immutableSetOf<String>() + (1..2000).map { "$it" }
+            val right = immutableSetOf<String>() + (200..3000).map { "$it" }
+            compareSets(left.toSet() - right.toSet(), left - right)
+            compareSets(right.toSet() - left.toSet(), right - left)
+        }
+
+        run {
+            val left = immutableSetOf<Int>() + (1..2000)
+            compareSets(immutableSetOf<Int>(), left - left)
+            val right = immutableSetOf<Int>() + (1..2000)
+            compareSets(immutableSetOf<Int>(), right - left)
+            compareSets(immutableSetOf<Int>(), left - right)
+        }
     }
 
 }


### PR DESCRIPTION
Ok, this is a more major change than the previous one, but possibly more profitable. Also note that this changes public interface of `ImmutableSet`, adding `retainAll`/`intersect` pair that our domain is particularly interested in.

In addition to union, intersection, difference and containment bulk ops are all implemented using the same strategies.

`containsAll` is particularly desirable, because it has a significant speedup (up to 50x)

Benchmark results:
https://docs.google.com/spreadsheets/d/1NaMgasBhqyThazU-_TVWAK2fCcnztAQ9WCRxr9lNfUw/edit?usp=sharing