### PR TITLE
Optimized equals() for all maps and sets

### DIFF
--- a/benchmarks/commonMain/src/benchmarks/immutableMap/Equals.kt
+++ b/benchmarks/commonMain/src/benchmarks/immutableMap/Equals.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2016-2021 JetBrains s.r.o.
+ * Use of this source code is governed by the Apache 2.0 License that can be found in the LICENSE.txt file.
+ */
+
+package benchmarks.immutableMap
+
+import benchmarks.*
+import kotlinx.benchmark.*
+import kotlinx.collections.immutable.persistentMapOf
+
+@State(Scope.Benchmark)
+open class Equals {
+    @Param(BM_1, BM_10, BM_100, BM_1000, BM_10000, BM_100000, BM_1000000)
+    var size: Int = 0
+
+    @Param(HASH_IMPL, ORDERED_IMPL)
+    var implementation = ""
+
+    @Param(ASCENDING_HASH_CODE, RANDOM_HASH_CODE, COLLISION_HASH_CODE, NON_EXISTING_HASH_CODE)
+    var hashCodeType = ""
+
+    private var persistentMap = persistentMapOf<IntWrapper, String>()
+    private var sameMap = persistentMapOf<IntWrapper, String>()
+    private var slightlyDifferentMap = persistentMapOf<IntWrapper, String>()
+    private var veryDifferentMap = persistentMapOf<IntWrapper, String>()
+
+    @Setup
+    fun prepare() {
+        val keys = generateKeys(hashCodeType, size * 2)
+        persistentMap = persistentMapPut(implementation, keys.take(size))
+        sameMap = persistentMapPut(implementation, keys.take(size))
+        slightlyDifferentMap = sameMap.put(keys[size + 1], "different value").remove(keys[0])
+        veryDifferentMap = persistentMapPut(implementation, keys.drop(size))
+    }
+
+    @Benchmark
+    fun equalsTrue() = persistentMap == sameMap
+    @Benchmark
+    fun nearlyEquals() = persistentMap == slightlyDifferentMap
+    @Benchmark
+    fun notEquals() = persistentMap == veryDifferentMap
+}

--- a/benchmarks/commonMain/src/benchmarks/immutableMap/builder/Equals.kt
+++ b/benchmarks/commonMain/src/benchmarks/immutableMap/builder/Equals.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2016-2021 JetBrains s.r.o.
+ * Use of this source code is governed by the Apache 2.0 License that can be found in the LICENSE.txt file.
+ */
+
+package benchmarks.immutableMap.builder
+
+import benchmarks.*
+import kotlinx.benchmark.*
+import kotlinx.collections.immutable.persistentMapOf
+
+@State(Scope.Benchmark)
+open class Equals {
+    @Param(BM_1, BM_10, BM_100, BM_1000, BM_10000, BM_100000, BM_1000000)
+    var size: Int = 0
+
+    @Param(HASH_IMPL, ORDERED_IMPL)
+    var implementation = ""
+
+    @Param(ASCENDING_HASH_CODE, RANDOM_HASH_CODE, COLLISION_HASH_CODE, NON_EXISTING_HASH_CODE)
+    var hashCodeType = ""
+
+    private var persistentMap = persistentMapOf<IntWrapper, String>().builder()
+    private var sameMap = persistentMapOf<IntWrapper, String>().builder()
+    private var slightlyDifferentMap = persistentMapOf<IntWrapper, String>().builder()
+    private var veryDifferentMap = persistentMapOf<IntWrapper, String>().builder()
+
+    @Setup
+    fun prepare() {
+        val keys = generateKeys(hashCodeType, size * 2)
+        persistentMap = persistentMapBuilderPut(implementation, keys.take(size), 0.0)
+        sameMap = persistentMapBuilderPut(implementation, keys.take(size), 0.0)
+        slightlyDifferentMap = sameMap.build().builder()
+        slightlyDifferentMap.put(keys[size + 1], "different value")
+        slightlyDifferentMap.remove(keys[0])
+        veryDifferentMap = persistentMapBuilderPut(implementation, keys.drop(size), 0.0)
+    }
+
+    @Benchmark
+    fun equalsTrue() = persistentMap == sameMap
+    @Benchmark
+    fun nearlyEquals() = persistentMap == slightlyDifferentMap
+    @Benchmark
+    fun notEquals() = persistentMap == veryDifferentMap
+
+}

--- a/benchmarks/commonMain/src/benchmarks/immutableSet/Equals.kt
+++ b/benchmarks/commonMain/src/benchmarks/immutableSet/Equals.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2016-2021 JetBrains s.r.o.
+ * Use of this source code is governed by the Apache 2.0 License that can be found in the LICENSE.txt file.
+ */
+
+package benchmarks.immutableSet
+
+import benchmarks.*
+import kotlinx.benchmark.*
+import kotlinx.collections.immutable.persistentSetOf
+
+@State(Scope.Benchmark)
+open class Equals {
+    @Param(BM_1, BM_10, BM_100, BM_1000, BM_10000, BM_100000, BM_1000000)
+    var size: Int = 0
+
+    @Param(HASH_IMPL, ORDERED_IMPL)
+    var implementation = ""
+
+    @Param(ASCENDING_HASH_CODE, RANDOM_HASH_CODE, COLLISION_HASH_CODE, NON_EXISTING_HASH_CODE)
+    var hashCodeType = ""
+
+    private var persistentSet = persistentSetOf<IntWrapper>()
+    private var sameSet = persistentSetOf<IntWrapper>()
+    private var slightlyDifferentSet = persistentSetOf<IntWrapper>()
+    private var veryDifferentSet = persistentSetOf<IntWrapper>()
+
+    @Setup
+    fun prepare() {
+        val keys = generateKeys(hashCodeType, size * 2)
+        persistentSet = persistentSetAdd(implementation, keys.take(size))
+        sameSet = persistentSetAdd(implementation, keys.take(size))
+        slightlyDifferentSet = sameSet.add(keys[size + 1]).remove(keys[0])
+        veryDifferentSet = persistentSetAdd(implementation, keys.drop(size))
+    }
+
+    @Benchmark
+    fun equalsTrue() = persistentSet == sameSet
+    @Benchmark
+    fun nearlyEquals() = persistentSet == slightlyDifferentSet
+    @Benchmark
+    fun notEquals() = persistentSet == veryDifferentSet
+}

--- a/benchmarks/commonMain/src/benchmarks/immutableSet/builder/Equals.kt
+++ b/benchmarks/commonMain/src/benchmarks/immutableSet/builder/Equals.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2016-2021 JetBrains s.r.o.
+ * Use of this source code is governed by the Apache 2.0 License that can be found in the LICENSE.txt file.
+ */
+
+package benchmarks.immutableSet.builder
+
+import benchmarks.*
+import kotlinx.benchmark.*
+import kotlinx.collections.immutable.persistentSetOf
+
+@State(Scope.Benchmark)
+open class Equals {
+    @Param(BM_1, BM_10, BM_100, BM_1000, BM_10000, BM_100000, BM_1000000)
+    var size: Int = 0
+
+    @Param(HASH_IMPL, ORDERED_IMPL)
+    var implementation = ""
+
+    @Param(ASCENDING_HASH_CODE, RANDOM_HASH_CODE, COLLISION_HASH_CODE, NON_EXISTING_HASH_CODE)
+    var hashCodeType = ""
+
+    private var persistentSet = persistentSetOf<IntWrapper>().builder()
+    private var sameSet = persistentSetOf<IntWrapper>().builder()
+    private var slightlyDifferentSet = persistentSetOf<IntWrapper>().builder()
+    private var veryDifferentSet = persistentSetOf<IntWrapper>().builder()
+
+    @Setup
+    fun prepare() {
+        val keys = generateKeys(hashCodeType, size * 2)
+        persistentSet = persistentSetBuilderAdd(implementation, keys.take(size), 0.0)
+        sameSet = persistentSetBuilderAdd(implementation, keys.take(size), 0.0)
+        slightlyDifferentSet = sameSet.build().builder()
+        slightlyDifferentSet.add(keys[size + 1])
+        slightlyDifferentSet.remove(keys[0])
+        veryDifferentSet = persistentSetBuilderAdd(implementation, keys.drop(size), 0.0)
+    }
+
+    @Benchmark
+    fun equalsTrue() = persistentSet == sameSet
+    @Benchmark
+    fun nearlyEquals() = persistentSet == slightlyDifferentSet
+    @Benchmark
+    fun notEquals() = persistentSet == veryDifferentSet
+}

--- a/core/commonMain/src/implementations/immutableMap/PersistentHashMap.kt
+++ b/core/commonMain/src/implementations/immutableMap/PersistentHashMap.kt
@@ -104,6 +104,12 @@ internal class PersistentHashMap<K, V>(internal val node: TrieNode<K, V>,
         }
     }
 
+    /**
+     * We provide [equals], so as a matter of style, we should also provide [hashCode].
+     * However, the implementation from [AbstractMap] is enough.
+     */
+    override fun hashCode(): Int = super<AbstractMap>.hashCode()
+
     internal companion object {
         private val EMPTY = PersistentHashMap(TrieNode.EMPTY, 0)
         @Suppress("UNCHECKED_CAST")

--- a/core/commonMain/src/implementations/immutableMap/PersistentHashMap.kt
+++ b/core/commonMain/src/implementations/immutableMap/PersistentHashMap.kt
@@ -8,6 +8,8 @@ package kotlinx.collections.immutable.implementations.immutableMap
 import kotlinx.collections.immutable.ImmutableCollection
 import kotlinx.collections.immutable.ImmutableSet
 import kotlinx.collections.immutable.PersistentMap
+import kotlinx.collections.immutable.implementations.persistentOrderedMap.PersistentOrderedMap
+import kotlinx.collections.immutable.implementations.persistentOrderedMap.PersistentOrderedMapBuilder
 import kotlinx.collections.immutable.mutate
 
 internal class PersistentHashMap<K, V>(internal val node: TrieNode<K, V>,
@@ -75,6 +77,28 @@ internal class PersistentHashMap<K, V>(internal val node: TrieNode<K, V>,
 
     override fun builder(): PersistentHashMapBuilder<K, V> {
         return PersistentHashMapBuilder(this)
+    }
+
+    override fun equals(other: Any?): Boolean {
+        return when (other) {
+            is PersistentOrderedMap<*, *> -> {
+                node.equalsWith(other.hashMap.node) { a, b ->
+                    a == b.value
+                }
+            }
+            is PersistentOrderedMapBuilder<*, *> -> {
+                node.equalsWith(other.hashMapBuilder.node) { a, b ->
+                    a == b.value
+                }
+            }
+            is PersistentHashMap<*, *> -> {
+                node.equalsWith(other.node) { a, b -> a == b }
+            }
+            is PersistentHashMapBuilder<*, *> -> {
+                node.equalsWith(other.node) { a, b -> a == b }
+            }
+            else -> super.equals(other)
+        }
     }
 
     internal companion object {

--- a/core/commonMain/src/implementations/immutableMap/PersistentHashMap.kt
+++ b/core/commonMain/src/implementations/immutableMap/PersistentHashMap.kt
@@ -80,6 +80,9 @@ internal class PersistentHashMap<K, V>(internal val node: TrieNode<K, V>,
     }
 
     override fun equals(other: Any?): Boolean {
+        if (other === this) return true
+        if (other !is Map<*, *>) return false
+        if (size != other.size) return false
         return when (other) {
             is PersistentOrderedMap<*, *> -> {
                 node.equalsWith(other.hashMap.node) { a, b ->

--- a/core/commonMain/src/implementations/immutableMap/PersistentHashMapBuilder.kt
+++ b/core/commonMain/src/implementations/immutableMap/PersistentHashMapBuilder.kt
@@ -130,7 +130,7 @@ internal class PersistentHashMapBuilder<K, V>(private var map: PersistentHashMap
             }
 
             // should be super.equals(other), but https://youtrack.jetbrains.com/issue/KT-45673
-            else -> return other.entries.all { entry -> containsEntry(entry) }
+            else -> return other.all { entry -> containsEntry(entry) }
         }
 
     }

--- a/core/commonMain/src/implementations/immutableMap/PersistentHashMapBuilderContentViews.kt
+++ b/core/commonMain/src/implementations/immutableMap/PersistentHashMapBuilderContentViews.kt
@@ -5,6 +5,8 @@
 
 package kotlinx.collections.immutable.implementations.immutableMap
 
+import kotlinx.collections.immutable.internal.MapImplementation
+
 // intermediate abstract class to workaround KT-43321
 internal abstract class AbstractMapBuilderEntries<E : Map.Entry<K, V>, K, V> : AbstractMutableSet<E>() {
     final override fun contains(element: E): Boolean {
@@ -44,8 +46,7 @@ internal class PersistentHashMapBuilderEntries<K, V>(private val builder: Persis
         get() = builder.size
 
     override fun containsEntry(element: Map.Entry<K, V>): Boolean {
-        return builder[element.key]?.let { candidate -> candidate == element.value }
-                ?: (element.value == null && builder.containsKey(element.key))
+        return MapImplementation.containsEntry(builder, element)
     }
 }
 

--- a/core/commonMain/src/implementations/immutableMap/TrieNode.kt
+++ b/core/commonMain/src/implementations/immutableMap/TrieNode.kt
@@ -881,7 +881,7 @@ internal class TrieNode<K, V>(
                 val keyIndex = collisionKeyIndex(thatKey)
                 if (keyIndex != -1) {
                     val value = valueAtKeyIndex(keyIndex)
-                    equalityComparator(value, thatValue)
+                    equalityComparator(value, thatValue) || return false
                 } else false
             }
         }

--- a/core/commonMain/src/implementations/immutableMap/TrieNode.kt
+++ b/core/commonMain/src/implementations/immutableMap/TrieNode.kt
@@ -881,7 +881,7 @@ internal class TrieNode<K, V>(
                 val keyIndex = collisionKeyIndex(thatKey)
                 if (keyIndex != -1) {
                     val value = valueAtKeyIndex(keyIndex)
-                    equalityComparator(value, thatValue) || return false
+                    equalityComparator(value, thatValue)
                 } else false
             }
         }

--- a/core/commonMain/src/implementations/persistentOrderedMap/PersistentOrderedMap.kt
+++ b/core/commonMain/src/implementations/persistentOrderedMap/PersistentOrderedMap.kt
@@ -9,6 +9,8 @@ import kotlinx.collections.immutable.ImmutableCollection
 import kotlinx.collections.immutable.ImmutableSet
 import kotlinx.collections.immutable.PersistentMap
 import kotlinx.collections.immutable.implementations.immutableMap.PersistentHashMap
+import kotlinx.collections.immutable.implementations.immutableMap.PersistentHashMapBuilder
+import kotlinx.collections.immutable.implementations.persistentOrderedSet.Links
 import kotlinx.collections.immutable.internal.EndOfChain
 import kotlinx.collections.immutable.mutate
 
@@ -125,6 +127,32 @@ internal class PersistentOrderedMap<K, V>(
 
     override fun builder(): PersistentMap.Builder<K, V> {
         return PersistentOrderedMapBuilder(this)
+    }
+
+    override fun equals(other: Any?): Boolean {
+        return when (other) {
+            is PersistentOrderedMap<*, *> -> {
+                hashMap.node.equalsWith(other.hashMap.node) { a, b ->
+                    a.value == b.value
+                }
+            }
+            is PersistentOrderedMapBuilder<*, *> -> {
+                hashMap.node.equalsWith(other.hashMapBuilder.node) { a, b ->
+                    a.value == b.value
+                }
+            }
+            is PersistentHashMap<*, *> -> {
+                hashMap.node.equalsWith(other.node) { a, b ->
+                    a.value == b
+                }
+            }
+            is PersistentHashMapBuilder<*, *> -> {
+                hashMap.node.equalsWith(other.node) { a, b ->
+                    a.value == b
+                }
+            }
+            else -> super.equals(other)
+        }
     }
 
     internal companion object {

--- a/core/commonMain/src/implementations/persistentOrderedMap/PersistentOrderedMap.kt
+++ b/core/commonMain/src/implementations/persistentOrderedMap/PersistentOrderedMap.kt
@@ -130,6 +130,9 @@ internal class PersistentOrderedMap<K, V>(
     }
 
     override fun equals(other: Any?): Boolean {
+        if (other === this) return true
+        if (other !is Map<*, *>) return false
+        if (size != other.size) return false
         return when (other) {
             is PersistentOrderedMap<*, *> -> {
                 hashMap.node.equalsWith(other.hashMap.node) { a, b ->

--- a/core/commonMain/src/implementations/persistentOrderedMap/PersistentOrderedMap.kt
+++ b/core/commonMain/src/implementations/persistentOrderedMap/PersistentOrderedMap.kt
@@ -9,8 +9,9 @@ import kotlinx.collections.immutable.ImmutableCollection
 import kotlinx.collections.immutable.ImmutableSet
 import kotlinx.collections.immutable.PersistentMap
 import kotlinx.collections.immutable.implementations.immutableMap.PersistentHashMap
+import kotlinx.collections.immutable.implementations.immutableMap.PersistentHashMap.Companion.equals
+import kotlinx.collections.immutable.implementations.immutableMap.PersistentHashMap.Companion.hashCode
 import kotlinx.collections.immutable.implementations.immutableMap.PersistentHashMapBuilder
-import kotlinx.collections.immutable.implementations.persistentOrderedSet.Links
 import kotlinx.collections.immutable.internal.EndOfChain
 import kotlinx.collections.immutable.mutate
 
@@ -157,6 +158,12 @@ internal class PersistentOrderedMap<K, V>(
             else -> super.equals(other)
         }
     }
+
+    /**
+     * We provide [equals], so as a matter of style, we should also provide [hashCode].
+     * However, the implementation from [AbstractMap] is enough.
+     */
+    override fun hashCode(): Int = super<AbstractMap>.hashCode()
 
     internal companion object {
         private val EMPTY = PersistentOrderedMap<Nothing, Nothing>(EndOfChain, EndOfChain, PersistentHashMap.emptyOf())

--- a/core/commonMain/src/implementations/persistentOrderedMap/PersistentOrderedMap.kt
+++ b/core/commonMain/src/implementations/persistentOrderedMap/PersistentOrderedMap.kt
@@ -9,8 +9,6 @@ import kotlinx.collections.immutable.ImmutableCollection
 import kotlinx.collections.immutable.ImmutableSet
 import kotlinx.collections.immutable.PersistentMap
 import kotlinx.collections.immutable.implementations.immutableMap.PersistentHashMap
-import kotlinx.collections.immutable.implementations.immutableMap.PersistentHashMap.Companion.equals
-import kotlinx.collections.immutable.implementations.immutableMap.PersistentHashMap.Companion.hashCode
 import kotlinx.collections.immutable.implementations.immutableMap.PersistentHashMapBuilder
 import kotlinx.collections.immutable.internal.EndOfChain
 import kotlinx.collections.immutable.mutate

--- a/core/commonMain/src/implementations/persistentOrderedMap/PersistentOrderedMapBuilder.kt
+++ b/core/commonMain/src/implementations/persistentOrderedMap/PersistentOrderedMapBuilder.kt
@@ -156,7 +156,7 @@ internal class PersistentOrderedMapBuilder<K, V>(private var map: PersistentOrde
                 }
             }
             // should be super.equals(other), but https://youtrack.jetbrains.com/issue/KT-45673
-            else -> other.entries.all { entry -> containsEntry(entry) }
+            else -> other.all { entry -> containsEntry(entry) }
         }
     }
 

--- a/core/commonMain/src/implementations/persistentOrderedMap/PersistentOrderedMapBuilder.kt
+++ b/core/commonMain/src/implementations/persistentOrderedMap/PersistentOrderedMapBuilder.kt
@@ -9,6 +9,7 @@ import kotlinx.collections.immutable.PersistentMap
 import kotlinx.collections.immutable.implementations.immutableMap.PersistentHashMap
 import kotlinx.collections.immutable.implementations.immutableMap.PersistentHashMapBuilder
 import kotlinx.collections.immutable.internal.EndOfChain
+import kotlinx.collections.immutable.internal.MapImplementation
 import kotlinx.collections.immutable.internal.assert
 
 internal class PersistentOrderedMapBuilder<K, V>(private var map: PersistentOrderedMap<K, V>) : AbstractMutableMap<K, V>(), PersistentMap.Builder<K, V> {
@@ -155,9 +156,15 @@ internal class PersistentOrderedMapBuilder<K, V>(private var map: PersistentOrde
                     a.value == b
                 }
             }
-            // should be super.equals(other), but https://youtrack.jetbrains.com/issue/KT-45673
-            else -> other.all { entry -> containsEntry(entry) }
+            // should be `super.equals(other)`, but https://youtrack.jetbrains.com/issue/KT-45673
+            else -> other.all { entry -> MapImplementation.containsEntry(this, entry) }
         }
     }
 
+    /**
+     * We provide [equals], so as a matter of style, we should also provide [hashCode].
+     *
+     * Should be `super.hashCode()`, but https://youtrack.jetbrains.com/issue/KT-45673
+     */
+    override fun hashCode(): Int = MapImplementation.hashCode(this)
 }

--- a/core/commonMain/src/implementations/persistentOrderedMap/PersistentOrderedMapBuilder.kt
+++ b/core/commonMain/src/implementations/persistentOrderedMap/PersistentOrderedMapBuilder.kt
@@ -120,16 +120,6 @@ internal class PersistentOrderedMapBuilder<K, V>(private var map: PersistentOrde
         lastKey = EndOfChain
     }
 
-    private fun <K1, V1> containsEntry(entry: Map.Entry<K1, V1>): Boolean {
-        entry is Map.Entry<*, *> || return false
-        val (k, v) = entry
-        val thisValue = get(k)
-        return when {
-            thisValue === null -> containsKey(k)
-            else -> thisValue == v
-        }
-    }
-
     override fun equals(other: Any?): Boolean {
         if (other === this) return true
         if (other !is Map<*, *>) return false

--- a/core/commonMain/src/implementations/persistentOrderedMap/PersistentOrderedMapBuilderContentViews.kt
+++ b/core/commonMain/src/implementations/persistentOrderedMap/PersistentOrderedMapBuilderContentViews.kt
@@ -6,6 +6,7 @@
 package kotlinx.collections.immutable.implementations.persistentOrderedMap
 
 import kotlinx.collections.immutable.implementations.immutableMap.AbstractMapBuilderEntries
+import kotlinx.collections.immutable.internal.MapImplementation
 
 internal class PersistentOrderedMapBuilderEntries<K, V>(private val builder: PersistentOrderedMapBuilder<K, V>)
     : AbstractMapBuilderEntries<MutableMap.MutableEntry<K, V>, K, V>() {
@@ -29,8 +30,7 @@ internal class PersistentOrderedMapBuilderEntries<K, V>(private val builder: Per
         get() = builder.size
 
     override fun containsEntry(element: Map.Entry<K, V>): Boolean {
-        return builder[element.key]?.let { candidate -> candidate == element.value }
-                ?: (element.value == null && builder.containsKey(element.key))
+        return MapImplementation.containsEntry(builder, element)
     }
 }
 

--- a/core/commonMain/src/implementations/persistentOrderedSet/PersistentOrderedSet.kt
+++ b/core/commonMain/src/implementations/persistentOrderedSet/PersistentOrderedSet.kt
@@ -7,6 +7,9 @@ package kotlinx.collections.immutable.implementations.persistentOrderedSet
 
 import kotlinx.collections.immutable.PersistentSet
 import kotlinx.collections.immutable.implementations.immutableMap.PersistentHashMap
+import kotlinx.collections.immutable.implementations.persistentOrderedMap.LinkedValue
+import kotlinx.collections.immutable.implementations.persistentOrderedMap.PersistentOrderedMap
+import kotlinx.collections.immutable.implementations.persistentOrderedMap.PersistentOrderedMapBuilder
 import kotlinx.collections.immutable.internal.EndOfChain
 import kotlinx.collections.immutable.mutate
 
@@ -99,6 +102,18 @@ internal class PersistentOrderedSet<E>(
 
     override fun builder(): PersistentSet.Builder<E> {
         return PersistentOrderedSetBuilder(this)
+    }
+
+    override fun equals(other: Any?): Boolean {
+        return when (other) {
+            is PersistentOrderedSet<*> -> {
+                hashMap.node.equalsWith(other.hashMap.node) { _, _ -> true }
+            }
+            is PersistentOrderedSetBuilder<*> -> {
+                hashMap.node.equalsWith(other.hashMapBuilder.node) { _, _ -> true }
+            }
+            else -> super.equals(other)
+        }
     }
 
     internal companion object {

--- a/core/commonMain/src/implementations/persistentOrderedSet/PersistentOrderedSet.kt
+++ b/core/commonMain/src/implementations/persistentOrderedSet/PersistentOrderedSet.kt
@@ -7,8 +7,6 @@ package kotlinx.collections.immutable.implementations.persistentOrderedSet
 
 import kotlinx.collections.immutable.PersistentSet
 import kotlinx.collections.immutable.implementations.immutableMap.PersistentHashMap
-import kotlinx.collections.immutable.implementations.immutableMap.PersistentHashMap.Companion.equals
-import kotlinx.collections.immutable.implementations.immutableMap.PersistentHashMap.Companion.hashCode
 import kotlinx.collections.immutable.internal.EndOfChain
 import kotlinx.collections.immutable.mutate
 

--- a/core/commonMain/src/implementations/persistentOrderedSet/PersistentOrderedSet.kt
+++ b/core/commonMain/src/implementations/persistentOrderedSet/PersistentOrderedSet.kt
@@ -105,6 +105,9 @@ internal class PersistentOrderedSet<E>(
     }
 
     override fun equals(other: Any?): Boolean {
+        if (other === this) return true
+        if (other !is Set<*>) return false
+        if (size != other.size) return false
         return when (other) {
             is PersistentOrderedSet<*> -> {
                 hashMap.node.equalsWith(other.hashMap.node) { _, _ -> true }

--- a/core/commonMain/src/implementations/persistentOrderedSet/PersistentOrderedSet.kt
+++ b/core/commonMain/src/implementations/persistentOrderedSet/PersistentOrderedSet.kt
@@ -7,9 +7,8 @@ package kotlinx.collections.immutable.implementations.persistentOrderedSet
 
 import kotlinx.collections.immutable.PersistentSet
 import kotlinx.collections.immutable.implementations.immutableMap.PersistentHashMap
-import kotlinx.collections.immutable.implementations.persistentOrderedMap.LinkedValue
-import kotlinx.collections.immutable.implementations.persistentOrderedMap.PersistentOrderedMap
-import kotlinx.collections.immutable.implementations.persistentOrderedMap.PersistentOrderedMapBuilder
+import kotlinx.collections.immutable.implementations.immutableMap.PersistentHashMap.Companion.equals
+import kotlinx.collections.immutable.implementations.immutableMap.PersistentHashMap.Companion.hashCode
 import kotlinx.collections.immutable.internal.EndOfChain
 import kotlinx.collections.immutable.mutate
 
@@ -118,6 +117,12 @@ internal class PersistentOrderedSet<E>(
             else -> super.equals(other)
         }
     }
+
+    /**
+     * We provide [equals], so as a matter of style, we should also provide [hashCode].
+     * However, the implementation from [AbstractSet] is enough.
+     */
+    override fun hashCode(): Int = super<AbstractSet>.hashCode()
 
     internal companion object {
         private val EMPTY = PersistentOrderedSet<Nothing>(EndOfChain, EndOfChain, PersistentHashMap.emptyOf())

--- a/core/commonMain/src/implementations/persistentOrderedSet/PersistentOrderedSetBuilder.kt
+++ b/core/commonMain/src/implementations/persistentOrderedSet/PersistentOrderedSetBuilder.kt
@@ -86,4 +86,16 @@ internal class PersistentOrderedSetBuilder<E>(private var set: PersistentOrdered
     override fun iterator(): MutableIterator<E> {
         return PersistentOrderedSetMutableIterator(this)
     }
+
+    override fun equals(other: Any?): Boolean {
+        return when (other) {
+            is PersistentOrderedSet<*> -> {
+                hashMapBuilder.node.equalsWith(other.hashMap.node) { _, _ -> true }
+            }
+            is PersistentOrderedSetBuilder<*> -> {
+                hashMapBuilder.node.equalsWith(other.hashMapBuilder.node) { _, _ -> true }
+            }
+            else -> super.equals(other)
+        }
+    }
 }

--- a/core/commonMain/src/implementations/persistentOrderedSet/PersistentOrderedSetBuilder.kt
+++ b/core/commonMain/src/implementations/persistentOrderedSet/PersistentOrderedSetBuilder.kt
@@ -98,4 +98,10 @@ internal class PersistentOrderedSetBuilder<E>(private var set: PersistentOrdered
             else -> super.equals(other)
         }
     }
+
+    /**
+     * We provide [equals], so as a matter of style, we should also provide [hashCode].
+     * However, the implementation from [AbstractMutableSet] is enough.
+     */
+    override fun hashCode(): Int = super<AbstractMutableSet>.hashCode()
 }

--- a/core/commonMain/src/internal/MapImplementation.kt
+++ b/core/commonMain/src/internal/MapImplementation.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2016-2021 JetBrains s.r.o.
+ * Use of this source code is governed by the Apache 2.0 License that can be found in the LICENSE.txt file.
+ */
+
+package kotlinx.collections.immutable.internal
+
+import kotlin.jvm.JvmName
+
+/**
+ * This should not be needed after KT-30016 and KT-45673 are fixed
+ */
+internal object MapImplementation {
+    internal fun <K, V, K1, V1> containsEntry(map: Map<K, V>, element: Map.Entry<K1, V1>): Boolean {
+        @Suppress("USELESS_CAST")
+        if ((element as Any?) !is Map.Entry<*, *>) return false
+        return map[element.key]?.let { candidate -> candidate == element.value }
+            ?: (element.value == null && map.containsKey(element.key))
+    }
+
+    @JvmName("containsMutableEntry")
+    internal fun <K, V, K1, V1> containsEntry(map: MutableMap<K, V>, element: MutableMap.MutableEntry<K1, V1>): Boolean {
+        @Suppress("USELESS_CAST")
+        if ((element as Any?) !is MutableMap.MutableEntry<*, *>) return false
+        return map[element.key]?.let { candidate -> candidate == element.value }
+            ?: (element.value == null && map.containsKey(element.key))
+    }
+
+    internal fun <K, V> hashCode(map: Map<K, V>) = map.entries.hashCode()
+}
+

--- a/core/commonTest/src/contract/map/ImmutableMapTest.kt
+++ b/core/commonTest/src/contract/map/ImmutableMapTest.kt
@@ -58,11 +58,11 @@ class ImmutableHashMapTest : ImmutableMapTest() {
         val builder1 = immutableMapOf<String, Int>().builder()
         val builder2 = immutableMapOf<String, Int>().builder()
         val expected = mutableMapOf<String, Int>()
-        for(i in 300..400) {
+        for (i in 300..400) {
             builder1.put("$i", i)
             expected.put("$i", i)
         }
-        for(i in 0..200) {
+        for (i in 0..200) {
             builder2.put("$i", i)
             expected.put("$i", i)
         }
@@ -77,6 +77,7 @@ class ImmutableHashMapTest : ImmutableMapTest() {
         compareMaps(expected, builder1.build())
     }
 }
+
 class ImmutableOrderedMapTest : ImmutableMapTest() {
     override fun <K, V> immutableMapOf(vararg pairs: Pair<K, V>): PersistentMap<K, V> = persistentMapOf(*pairs)
     override fun <K, V> compareMaps(expected: Map<K, V>, actual: Map<K, V>) = compare(expected, actual) { mapBehavior(ordered = true) }
@@ -294,7 +295,7 @@ abstract class ImmutableMapTest {
 
     @Test
     fun specializedEquality() {
-        val data = (0..200).map { i -> IntWrapper(i, i % 50) to "$i"}.toTypedArray()
+        val data = (0..200).map { i -> IntWrapper(i, i % 50) to "$i" }.toTypedArray()
         val changed = data.copyOf().apply { this[42] = IntWrapper(42, 42) to "Invalid" }
 
         val base = immutableMapOf(*data)
@@ -328,16 +329,34 @@ abstract class ImmutableMapTest {
     fun collisionEquality() {
         val m1 = immutableMapOf<ObjectWrapper<Int>, String>().putAll(
             arrayOf(
-                ObjectWrapper(1, 42) to "Hello",
-                ObjectWrapper(2, 42) to "World"
+                IntWrapper(1, 42) to "Hello",
+                IntWrapper(2, 42) to "World"
             )
         )
         val m2 = immutableMapOf<ObjectWrapper<Int>, String>().putAll(
             arrayOf(
-                ObjectWrapper(2, 42) to "World",
-                ObjectWrapper(1, 42) to "Hello"
+                IntWrapper(2, 42) to "World",
+                IntWrapper(1, 42) to "Hello"
             )
         )
         assertEquals(m2, m1)
+    }
+
+    @Test
+    fun hashing() {
+        val collisionData = arrayOf(
+            IntWrapper(1, 42) to "Hello",
+            IntWrapper(2, 42) to "World"
+        )
+        val collisionMap = immutableMapOf(*collisionData)
+
+        assertEquals(mapOf(*collisionData).hashCode(), collisionMap.hashCode())
+        assertEquals(mapOf(*collisionData).hashCode(), collisionMap.builder().hashCode())
+
+        val data = (0..200).map { i -> IntWrapper(i, i % 50) to "$i" }.toTypedArray()
+
+        val persistentMap = immutableMapOf(*data)
+        assertEquals(mapOf(*data).hashCode(), persistentMap.hashCode())
+        assertEquals(mapOf(*data).hashCode(), persistentMap.builder().hashCode())
     }
 }

--- a/core/commonTest/src/contract/map/ImmutableMapTest.kt
+++ b/core/commonTest/src/contract/map/ImmutableMapTest.kt
@@ -11,6 +11,7 @@ import tests.contract.compare
 import tests.contract.mapBehavior
 import tests.contract.setBehavior
 import tests.stress.IntWrapper
+import tests.stress.ObjectWrapper
 import kotlin.test.*
 
 class ImmutableHashMapTest : ImmutableMapTest() {
@@ -289,5 +290,22 @@ abstract class ImmutableMapTest {
         val mapANA: PersistentMap<Any, Any?> = mapSNI + listOf(1 to "x")
 
         assertEquals<Map<*, *>>(mapOf(1 to "x", "x" to 1, "y" to null), mapANA)
+    }
+
+    @Test
+    fun collisionEquality() {
+        val m1 = immutableMapOf<ObjectWrapper<Int>, String>().putAll(
+            arrayOf(
+                ObjectWrapper(1, 42) to "Hello",
+                ObjectWrapper(2, 42) to "World"
+            )
+        )
+        val m2 = immutableMapOf<ObjectWrapper<Int>, String>().putAll(
+            arrayOf(
+                ObjectWrapper(2, 42) to "World",
+                ObjectWrapper(1, 42) to "Hello"
+            )
+        )
+        assertEquals(m2, m1)
     }
 }

--- a/core/commonTest/src/contract/map/ImmutableMapTest.kt
+++ b/core/commonTest/src/contract/map/ImmutableMapTest.kt
@@ -293,6 +293,38 @@ abstract class ImmutableMapTest {
     }
 
     @Test
+    fun specializedEquality() {
+        val data = (0..200).map { i -> ObjectWrapper(i, i % 50) to "$i"}.toTypedArray()
+        val changed = data.copyOf().apply { this[42] = ObjectWrapper(42, 42) to "Invalid" }
+
+        val base = immutableMapOf(*data)
+        assertTrue(base == mapOf(*data))
+        assertTrue(base == persistentHashMapOf(*data))
+        assertTrue(base == persistentMapOf(*data))
+        assertTrue(base == persistentHashMapOf<ObjectWrapper<Int>, String>().builder().apply { putAll(data) })
+        assertTrue(base == persistentMapOf<ObjectWrapper<Int>, String>().builder().apply { putAll(data) })
+
+        assertFalse(base == mapOf(*changed))
+        assertFalse(base == persistentHashMapOf(*changed))
+        assertFalse(base == persistentMapOf(*changed))
+        assertFalse(base == persistentHashMapOf<ObjectWrapper<Int>, String>().builder().apply { putAll(changed) })
+        assertFalse(base == persistentMapOf<ObjectWrapper<Int>, String>().builder().apply { putAll(changed) })
+
+        val builder = immutableMapOf<ObjectWrapper<Int>, String>().builder().apply { putAll(data) }
+        assertTrue(builder == mapOf(*data))
+        assertTrue(builder == persistentHashMapOf(*data))
+        assertTrue(builder == persistentMapOf(*data))
+        assertTrue(builder == persistentHashMapOf<ObjectWrapper<Int>, String>().builder().apply { putAll(data) })
+        assertTrue(builder == persistentMapOf<ObjectWrapper<Int>, String>().builder().apply { putAll(data) })
+
+        assertFalse(builder == mapOf(*changed))
+        assertFalse(builder == persistentHashMapOf(*changed))
+        assertFalse(builder == persistentMapOf(*changed))
+        assertFalse(builder == persistentHashMapOf<ObjectWrapper<Int>, String>().builder().apply { putAll(changed) })
+        assertFalse(builder == persistentMapOf<ObjectWrapper<Int>, String>().builder().apply { putAll(changed) })
+    }
+
+    @Test
     fun collisionEquality() {
         val m1 = immutableMapOf<ObjectWrapper<Int>, String>().putAll(
             arrayOf(

--- a/core/commonTest/src/contract/map/ImmutableMapTest.kt
+++ b/core/commonTest/src/contract/map/ImmutableMapTest.kt
@@ -294,34 +294,34 @@ abstract class ImmutableMapTest {
 
     @Test
     fun specializedEquality() {
-        val data = (0..200).map { i -> ObjectWrapper(i, i % 50) to "$i"}.toTypedArray()
-        val changed = data.copyOf().apply { this[42] = ObjectWrapper(42, 42) to "Invalid" }
+        val data = (0..200).map { i -> IntWrapper(i, i % 50) to "$i"}.toTypedArray()
+        val changed = data.copyOf().apply { this[42] = IntWrapper(42, 42) to "Invalid" }
 
         val base = immutableMapOf(*data)
         assertTrue(base == mapOf(*data))
         assertTrue(base == persistentHashMapOf(*data))
         assertTrue(base == persistentMapOf(*data))
-        assertTrue(base == persistentHashMapOf<ObjectWrapper<Int>, String>().builder().apply { putAll(data) })
-        assertTrue(base == persistentMapOf<ObjectWrapper<Int>, String>().builder().apply { putAll(data) })
+        assertTrue(base == persistentHashMapOf<IntWrapper, String>().builder().apply { putAll(data) })
+        assertTrue(base == persistentMapOf<IntWrapper, String>().builder().apply { putAll(data) })
 
         assertFalse(base == mapOf(*changed))
         assertFalse(base == persistentHashMapOf(*changed))
         assertFalse(base == persistentMapOf(*changed))
-        assertFalse(base == persistentHashMapOf<ObjectWrapper<Int>, String>().builder().apply { putAll(changed) })
-        assertFalse(base == persistentMapOf<ObjectWrapper<Int>, String>().builder().apply { putAll(changed) })
+        assertFalse(base == persistentHashMapOf<IntWrapper, String>().builder().apply { putAll(changed) })
+        assertFalse(base == persistentMapOf<IntWrapper, String>().builder().apply { putAll(changed) })
 
         val builder = immutableMapOf<ObjectWrapper<Int>, String>().builder().apply { putAll(data) }
         assertTrue(builder == mapOf(*data))
         assertTrue(builder == persistentHashMapOf(*data))
         assertTrue(builder == persistentMapOf(*data))
-        assertTrue(builder == persistentHashMapOf<ObjectWrapper<Int>, String>().builder().apply { putAll(data) })
-        assertTrue(builder == persistentMapOf<ObjectWrapper<Int>, String>().builder().apply { putAll(data) })
+        assertTrue(builder == persistentHashMapOf<IntWrapper, String>().builder().apply { putAll(data) })
+        assertTrue(builder == persistentMapOf<IntWrapper, String>().builder().apply { putAll(data) })
 
         assertFalse(builder == mapOf(*changed))
         assertFalse(builder == persistentHashMapOf(*changed))
         assertFalse(builder == persistentMapOf(*changed))
-        assertFalse(builder == persistentHashMapOf<ObjectWrapper<Int>, String>().builder().apply { putAll(changed) })
-        assertFalse(builder == persistentMapOf<ObjectWrapper<Int>, String>().builder().apply { putAll(changed) })
+        assertFalse(builder == persistentHashMapOf<IntWrapper, String>().builder().apply { putAll(changed) })
+        assertFalse(builder == persistentMapOf<IntWrapper, String>().builder().apply { putAll(changed) })
     }
 
     @Test


### PR DESCRIPTION
Same as with other bulk operations, equals() can be streamlined to exploit HAMT/CHAMP internal structure for all set/map implementations.
Disclaimer: this optimization only works for two sets/maps of equal size using the same implementation and works best when equals will return false, which is already kind of a stretch, but we have cases for this exact setup.

Benchmarks show good results even for equal sets/maps:
https://docs.google.com/spreadsheets/d/1Y5N_-4S7yvEADMVtn82yP1bIP2wQ3mxXV3X1EL16Oes/edit?usp=sharing

Another questionable thing in this PR is support for comparing different implementations of maps (say, comparing an ordered map builder with an immutable hash map), which is mostly added because it's possible and not because it's realistic.