### PR TITLE
Fix for #109

### DIFF
--- a/core/commonMain/src/implementations/immutableMap/TrieNode.kt
+++ b/core/commonMain/src/implementations/immutableMap/TrieNode.kt
@@ -790,10 +790,9 @@ internal class TrieNode<K, V>(
     private fun mutableReplaceNode(targetNode: TrieNode<K, V>, newNode: TrieNode<K, V>?, nodeIndex: Int, positionMask: Int, owner: MutabilityOwnership) = when {
         newNode == null ->
             mutableRemoveNodeAtIndex(nodeIndex, positionMask, owner)
-        ownedBy === owner || targetNode !== newNode ->
+        targetNode !== newNode ->
             mutableUpdateNodeAtIndex(nodeIndex, newNode, owner)
-        else ->
-            this
+        else -> this
     }
 
     fun remove(keyHash: Int, key: K, value: @UnsafeVariance V, shift: Int): TrieNode<K, V>? {


### PR DESCRIPTION
Seems like some logic here is broken: `mutableUpdateNodeAtIndex` expects `newNode` to be newly-created, but `mutableReplaceNode` does not check for it properly (`newNode` may be equal to `targetNode`, which may be any node of any builder previously created)