### PR TITLE
Fix for #109

### DIFF
--- a/core/commonMain/src/implementations/immutableMap/TrieNode.kt
+++ b/core/commonMain/src/implementations/immutableMap/TrieNode.kt
@@ -784,10 +784,9 @@ internal class TrieNode<K, V>(
     private fun mutableReplaceNode(targetNode: TrieNode<K, V>, newNode: TrieNode<K, V>?, nodeIndex: Int, positionMask: Int, owner: MutabilityOwnership) = when {
         newNode == null ->
             mutableRemoveNodeAtIndex(nodeIndex, positionMask, owner)
-        ownedBy === owner || targetNode !== newNode ->
+        targetNode !== newNode ->
             mutableUpdateNodeAtIndex(nodeIndex, newNode, owner)
-        else ->
-            this
+        else -> this
     }
 
     fun remove(keyHash: Int, key: K, value: @UnsafeVariance V, shift: Int): TrieNode<K, V>? {

--- a/core/commonMain/src/implementations/immutableMap/TrieNode.kt
+++ b/core/commonMain/src/implementations/immutableMap/TrieNode.kt
@@ -202,6 +202,7 @@ internal class TrieNode<K, V>(
 
     /** The given [newNode] must not be a part of any persistent map instance. */
     private fun mutableUpdateNodeAtIndex(nodeIndex: Int, newNode: TrieNode<K, V>, owner: MutabilityOwnership): TrieNode<K, V> {
+        assert(newNode.ownedBy === owner)
 //        assert(buffer[nodeIndex] !== newNode)
 
         // nodes (including collision nodes) that have only one entry are upped if they have no siblings

--- a/core/commonTest/src/contract/map/ImmutableMapTest.kt
+++ b/core/commonTest/src/contract/map/ImmutableMapTest.kt
@@ -77,6 +77,7 @@ class ImmutableHashMapTest : ImmutableMapTest() {
     }
 
     @Test fun regressionGithubIssue109() {
+        // https://github.com/Kotlin/kotlinx.collections.immutable/issues/109
         val map0 = immutableMapOf<Int, Int>().put(0, 0).put(1, 1).put(32, 32)
         val map1 = map0.mutate { it.remove(0) }
         val map2 = map1.mutate {
@@ -84,7 +85,7 @@ class ImmutableHashMapTest : ImmutableMapTest() {
             it.remove(0)
         }
 
-        assertTrue(map1.containsKey(32)) // fails
+        assertTrue(map1.containsKey(32))
     }
 }
 

--- a/core/commonTest/src/contract/map/ImmutableMapTest.kt
+++ b/core/commonTest/src/contract/map/ImmutableMapTest.kt
@@ -75,6 +75,17 @@ class ImmutableHashMapTest : ImmutableMapTest() {
         // make sure builder builds correct map
         compareMaps(expected, builder1.build())
     }
+
+    @Test fun regressionGithubIssue109() {
+        val map0 = immutableMapOf<Int, Int>().put(0, 0).put(1, 1).put(32, 32)
+        val map1 = map0.mutate { it.remove(0) }
+        val map2 = map1.mutate {
+            it.remove(1)
+            it.remove(0)
+        }
+
+        assertTrue(map1.containsKey(32)) // fails
+    }
 }
 
 class ImmutableOrderedMapTest : ImmutableMapTest() {


### PR DESCRIPTION
Github does not allow me to reopen #110, so a new PR

Comments from #110:

Seems like some logic here is broken: `mutableUpdateNodeAtIndex` expects `newNode` to be newly-created, but `mutableReplaceNode` does not check for it properly (`newNode` may be equal to `targetNode`, which may be any node of any builder previously created)

Maybe the idea was to check `newNode.ownedBy` instead of `ownedBy`?
Anyway, removing the check fixes the test.

I'd love to provide a regression test, but have no idea how to reproduce this outside the node implementation.
Even random test triggers this exclusively on JVM, because JVM implementation of these tests (and no other platform) actually calls builder's `remove(key, value)` method due to overloading witchcrafting, no other tests seem to call it under such stressful conditions.