### PR TITLE
PeristentHashMapBuilder.putAll() with another persistent hash map can produce incorrect results #114

### DIFF
--- a/.teamcity/Benchmarks.kt
+++ b/.teamcity/Benchmarks.kt
@@ -43,6 +43,10 @@ fun Project.benchmarkAll(buildVersion: BuildType) = BuildType {
     buildNumberPattern = buildVersion.depParamRefs.buildNumber.ref
 
     commonConfigure()
+
+    failureConditions {
+        executionTimeoutMin = 1440
+    }
 }.also { buildType(it) }
 
 fun Project.benchmark(target: String, platform: Platform, buildVersion: BuildType) = buildType("${target}Benchmark", platform) {

--- a/benchmarks/commonMain/src/benchmarks/immutableMap/PutAll.kt
+++ b/benchmarks/commonMain/src/benchmarks/immutableMap/PutAll.kt
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2016-2021 JetBrains s.r.o.
+ * Use of this source code is governed by the Apache 2.0 License that can be found in the LICENSE.txt file.
+ */
+
+package benchmarks.immutableMap
+
+import benchmarks.*
+import kotlinx.collections.immutable.PersistentMap
+import kotlinx.benchmark.*
+import kotlinx.collections.immutable.persistentMapOf
+
+@State(Scope.Benchmark)
+open class PutAll {
+    @Param(BM_1, BM_10, BM_100, BM_1000, BM_10000, BM_100000, BM_1000000)
+    var size: Int = 0
+
+    @Param(HASH_IMPL, ORDERED_IMPL)
+    var implementation = ""
+
+    @Param(ASCENDING_HASH_CODE, RANDOM_HASH_CODE, COLLISION_HASH_CODE)
+    var hashCodeType = ""
+
+    private var lhs = persistentMapOf<IntWrapper, String>()
+    private var lhsSmall = persistentMapOf<IntWrapper, String>()
+    private var rhs = persistentMapOf<IntWrapper, String>()
+    private var rhsSmall = persistentMapOf<IntWrapper, String>()
+
+    @Setup
+    fun prepare() {
+        val keys = generateKeys(hashCodeType, 2 * size)
+        lhs = persistentMapPut(implementation, keys.take(size))
+        lhsSmall = persistentMapPut(implementation, keys.take((size / 1000) + 1))
+        rhs = persistentMapPut(implementation, keys.takeLast(size))
+        rhsSmall = persistentMapPut(implementation, keys.takeLast((size / 1000) + 1))
+    }
+
+    @Benchmark
+    fun putAllEqualSize(): PersistentMap<IntWrapper, String> {
+        return lhs.putAll(rhs)
+    }
+
+    @Benchmark
+    fun putAllSmallIntoLarge(): PersistentMap<IntWrapper, String> {
+        return lhs.putAll(rhsSmall)
+    }
+
+    @Benchmark
+    fun putAllLargeIntoSmall(): PersistentMap<IntWrapper, String> {
+        return lhsSmall.putAll(rhs)
+    }
+}

--- a/core/commonMain/src/implementations/immutableMap/TrieNode.kt
+++ b/core/commonMain/src/implementations/immutableMap/TrieNode.kt
@@ -460,38 +460,72 @@ internal class TrieNode<K, V>(
         }
     }
 
-    private fun mutablePutAllFromOtherNodeCell(other: TrieNode<K, V>,
-                                               positionMask: Int,
-                                               shift: Int,
-                                               intersectionCounter: DeltaCounter,
-                                               mutator: PersistentHashMapBuilder<K, V>): TrieNode<K, V> {
-        return when {
-            other.hasNodeAt(positionMask) -> {
-                mutablePutAll(
-                        other.nodeAtIndex(other.nodeIndex(positionMask)),
-                        shift + LOG_MAX_BRANCHING_FACTOR,
-                        intersectionCounter,
-                        mutator
-                )
-            }
-            other.hasEntryAt(positionMask) -> {
-                val keyIndex = other.entryKeyIndex(positionMask)
-                val key = other.keyAtIndex(keyIndex)
-                val value = other.valueAtKeyIndex(keyIndex)
-                val oldSize = mutator.size
-                val newNode = mutablePut(
-                        key.hashCode(),
-                        key,
-                        value,
-                        shift + LOG_MAX_BRANCHING_FACTOR,
-                        mutator
-                )
-                if (mutator.size == oldSize) {
-                    intersectionCounter.count++
+    /**
+     * Updates the cell of this node at [positionMask] with entries from the cell of [otherNode] at [positionMask].
+     */
+    private fun mutablePutAllFromOtherNodeCell(
+        otherNode: TrieNode<K, V>,
+        positionMask: Int,
+        shift: Int,
+        intersectionCounter: DeltaCounter,
+        mutator: PersistentHashMapBuilder<K, V>
+    ): TrieNode<K, V> = when {
+        this.hasNodeAt(positionMask) -> {
+            val targetNode = this.nodeAtIndex(nodeIndex(positionMask))
+            when {
+                otherNode.hasNodeAt(positionMask) -> {
+                    val otherTargetNode = otherNode.nodeAtIndex(otherNode.nodeIndex(positionMask))
+                    targetNode.mutablePutAll(otherTargetNode, shift + LOG_MAX_BRANCHING_FACTOR, intersectionCounter, mutator)
                 }
-                newNode
+                otherNode.hasEntryAt(positionMask) -> {
+                    val keyIndex = otherNode.entryKeyIndex(positionMask)
+                    val key = otherNode.keyAtIndex(keyIndex)
+                    val value = otherNode.valueAtKeyIndex(keyIndex)
+                    val oldSize = mutator.size
+                    targetNode.mutablePut(key.hashCode(), key, value, shift + LOG_MAX_BRANCHING_FACTOR, mutator).also {
+                        if (mutator.size == oldSize) intersectionCounter.count++
+                    }
+                }
+                else -> targetNode
             }
-            else -> this
+        }
+
+        otherNode.hasNodeAt(positionMask) -> {
+            val otherTargetNode = otherNode.nodeAtIndex(otherNode.nodeIndex(positionMask))
+            when {
+                this.hasEntryAt(positionMask) -> {
+                    // if otherTargetNode already has a value associated with the key, do not put this entry
+                    val keyIndex = this.entryKeyIndex(positionMask)
+                    val key = this.keyAtIndex(keyIndex)
+                    if (otherTargetNode.containsKey(key.hashCode(), key, shift + LOG_MAX_BRANCHING_FACTOR)) {
+                        intersectionCounter.count++
+                        otherTargetNode
+                    } else {
+                        val value = this.valueAtKeyIndex(keyIndex)
+                        otherTargetNode.mutablePut(key.hashCode(), key, value, shift + LOG_MAX_BRANCHING_FACTOR, mutator)
+                    }
+                }
+                else -> otherTargetNode
+            }
+        }
+
+        else -> { // two entries, and they are not equal by key. See (**) in mutablePutAll
+            val thisKeyIndex = this.entryKeyIndex(positionMask)
+            val thisKey = this.keyAtIndex(thisKeyIndex)
+            val thisValue = this.valueAtKeyIndex(thisKeyIndex)
+            val otherKeyIndex = otherNode.entryKeyIndex(positionMask)
+            val otherKey = otherNode.keyAtIndex(otherKeyIndex)
+            val otherValue = otherNode.valueAtKeyIndex(otherKeyIndex)
+            makeNode(
+                thisKey.hashCode(),
+                thisKey,
+                thisValue,
+                otherKey.hashCode(),
+                otherKey,
+                otherValue,
+                shift + LOG_MAX_BRANCHING_FACTOR,
+                mutator.ownership
+            )
         }
     }
 
@@ -575,7 +609,7 @@ internal class TrieNode<K, V>(
         // but not in the new data nodes
         var newDataMap = dataMap xor otherNode.dataMap and newNodeMap.inv()
         // (**) now, this is tricky: we have a number of entry-entry pairs and we don't know yet whether
-        // they result in an entry (if they are equal) or a new node (if they are not)
+        // they result in an entry (if keys are equal) or a new node (if they are not)
         // but we want to keep it to single allocation, so we check and mark equal ones here
         (dataMap and otherNode.dataMap).forEachOneBit { positionMask, _ ->
             val leftKey = this.keyAtIndex(this.entryKeyIndex(positionMask))
@@ -586,7 +620,7 @@ internal class TrieNode<K, V>(
             else newNodeMap = newNodeMap or positionMask
             // we can use this later to skip calling equals() again
         }
-        assert(newNodeMap and newDataMap == 0)
+        check(newNodeMap and newDataMap == 0)
         val mutableNode = when {
             this.ownedBy == mutator.ownership && this.dataMap == newDataMap && this.nodeMap == newNodeMap -> this
             else -> {
@@ -596,36 +630,7 @@ internal class TrieNode<K, V>(
         }
         newNodeMap.forEachOneBit { positionMask, index ->
             val newNodeIndex = mutableNode.buffer.size - 1 - index
-            mutableNode.buffer[newNodeIndex] = when {
-                hasNodeAt(positionMask) -> {
-                    val before = nodeAtIndex(nodeIndex(positionMask))
-                    before.mutablePutAllFromOtherNodeCell(otherNode, positionMask, shift, intersectionCounter, mutator)
-                }
-
-                otherNode.hasNodeAt(positionMask) -> {
-                    val before = otherNode.nodeAtIndex(otherNode.nodeIndex(positionMask))
-                    before.mutablePutAllFromOtherNodeCell(this, positionMask, shift, intersectionCounter, mutator)
-                }
-
-                else -> { // two entries, and they are not equal by key (see ** above)
-                    val thisKeyIndex = this.entryKeyIndex(positionMask)
-                    val thisKey = this.keyAtIndex(thisKeyIndex)
-                    val thisValue = this.valueAtKeyIndex(thisKeyIndex)
-                    val otherKeyIndex = otherNode.entryKeyIndex(positionMask)
-                    val otherKey = otherNode.keyAtIndex(otherKeyIndex)
-                    val otherValue = otherNode.valueAtKeyIndex(otherKeyIndex)
-                    makeNode(
-                            thisKey.hashCode(),
-                            thisKey,
-                            thisValue,
-                            otherKey.hashCode(),
-                            otherKey,
-                            otherValue,
-                            shift + LOG_MAX_BRANCHING_FACTOR,
-                            mutator.ownership
-                    )
-                }
-            }
+            mutableNode.buffer[newNodeIndex] = mutablePutAllFromOtherNodeCell(otherNode, positionMask, shift, intersectionCounter, mutator)
         }
         newDataMap.forEachOneBit { positionMask, index ->
             val newKeyIndex = index * ENTRY_SIZE

--- a/core/commonTest/src/contract/map/ImmutableMapTest.kt
+++ b/core/commonTest/src/contract/map/ImmutableMapTest.kt
@@ -87,6 +87,16 @@ class ImmutableHashMapTest : ImmutableMapTest() {
 
         assertTrue(map1.containsKey(32))
     }
+
+    @Test
+    fun regressionGithubIssue114() {
+        // https://github.com/Kotlin/kotlinx.collections.immutable/issues/114
+        val p = persistentMapOf(99 to 1)
+        val e = Array(101) { it }.map { it to it }
+        val c = persistentMapOf(*e.toTypedArray())
+        val n = p.builder().apply { putAll(c) }.build()
+        assertEquals(99, n[99])
+    }
 }
 
 class ImmutableOrderedMapTest : ImmutableMapTest() {


### PR DESCRIPTION
When putting all entries of a cell (1) into another cell (2), if (1) is an entry and (2) is a node, for optimization reasons the entry is put into the node. This leads to saving the old value of the entry if the node already contains the key.