### PR TITLE
Support Kotlin Community Build parameters

### DIFF
--- a/benchmarks/build.gradle.kts
+++ b/benchmarks/build.gradle.kts
@@ -3,7 +3,7 @@ import org.gradle.jvm.tasks.Jar
 
 plugins {
     id("kotlin-multiplatform")
-    id("org.jetbrains.kotlinx.benchmark") version "0.4.1"
+    id("org.jetbrains.kotlinx.benchmark") version "0.4.7"
 }
 
 
@@ -39,7 +39,7 @@ kotlin {
         commonMain {
             dependencies {
                 api("org.jetbrains.kotlin:kotlin-stdlib-common")
-                api("org.jetbrains.kotlinx:kotlinx-benchmark-runtime:0.4.1")
+                api("org.jetbrains.kotlinx:kotlinx-benchmark-runtime:0.4.7")
                 api(project(":kotlinx-collections-immutable"))
             }
         }

--- a/benchmarks/build.gradle.kts
+++ b/benchmarks/build.gradle.kts
@@ -24,7 +24,7 @@ kotlin {
         }
     }
 
-    js {
+    js(IR) {
         nodejs {
 
         }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,14 +24,13 @@ infra {
 }
 
 allprojects {
-    logger.info("Using Kotlin $kotlin_version for project $this")
     repositories {
         addDevRepositoryIfEnabled(this, project)
         mavenCentral()
     }
 
-    // TODO: enable after https://youtrack.jetbrains.com/issue/KT-46257 gets fixed
-//    tasks.withType<org.jetbrains.kotlin.gradle.dsl.KotlinCompile<*>> {
-//        kotlinOptions.allWarningsAsErrors = true
-//    }
+    tasks.withType<org.jetbrains.kotlin.gradle.dsl.KotlinCompile<*>> {
+        kotlinOptions.allWarningsAsErrors = true
+        kotlinOptions.freeCompilerArgs += listOf("-version")
+    }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,11 +1,14 @@
 buildscript {
+    repositories {
+        addDevRepositoryIfEnabled(this, project)
+    }
     dependencies {
-        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.6.0")
+        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version")
     }
 }
 
 plugins {
-    id("kotlinx.team.infra") version "0.3.0-dev-64"
+    id("kotlinx.team.infra") version infra_version
 }
 
 infra {
@@ -21,7 +24,9 @@ infra {
 }
 
 allprojects {
+    logger.info("Using Kotlin $kotlin_version for project $this")
     repositories {
+        addDevRepositoryIfEnabled(this, project)
         mavenCentral()
     }
 

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,0 +1,11 @@
+plugins {
+    `kotlin-dsl`
+}
+
+repositories {
+    mavenCentral()
+}
+
+kotlinDslPluginOptions {
+    experimentalWarning.set(false)
+}

--- a/buildSrc/src/main/kotlin/KotlinCommunity.kt
+++ b/buildSrc/src/main/kotlin/KotlinCommunity.kt
@@ -1,0 +1,46 @@
+@file:JvmName("KotlinCommunity")
+
+import org.gradle.api.Project
+import org.gradle.api.artifacts.dsl.*
+import java.net.*
+import java.util.logging.Logger
+
+/*
+ * Functions in this file are responsible for configuring kotlinx-collections-immutable build against a custom dev version
+ * of Kotlin compiler.
+ * Such configuration is used in aggregate builds of Kotlin in order to check whether not-yet-released changes
+ * are compatible with our libraries (aka "integration testing that substitues lack of unit testing").
+ */
+
+/**
+ * Kotlin compiler artifacts are expected to be downloaded from maven central by default.
+ * In case of compiling with kotlin compiler artifacts that are not published into the MC,
+ * a kotlin_repo_url gradle parameter should be specified.
+ * To reproduce a build locally, a kotlin/dev repo should be passed.
+ *
+ * @return an url for a kotlin compiler repository parametrized from command line or gradle.properties,
+ *   empty string otherwise
+ */
+fun getKotlinDevRepositoryUrl(project: Project): String? {
+    val url = project.rootProject.properties["kotlin_repo_url"] as? String
+    if (url != null) {
+        project.logger.info("""Configured Kotlin Compiler repository url: '$url' for project ${project.name}""")
+    }
+    return url
+}
+
+/**
+ * If the kotlin_repo_url gradle parameter is provided, adds it to the [repositoryHandler].
+ */
+fun addDevRepositoryIfEnabled(repositoryHandler: RepositoryHandler, project: Project) {
+    val devRepoUrl = getKotlinDevRepositoryUrl(project) ?: return
+    repositoryHandler.maven {
+        url = URI.create(devRepoUrl)
+    }
+}
+
+val Project.kotlin_version: String
+    get() = rootProject.properties["kotlin_version"] as String
+
+val Project.infra_version: String
+    get() = rootProject.properties["infra_version"] as String

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -44,7 +44,7 @@ kotlin {
         }
     }
 
-    js(BOTH) {
+    js(IR) {
         nodejs {
             testTask {
                 useMocha {

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,6 +2,9 @@ group=org.jetbrains.kotlinx
 version=0.4
 versionSuffix=SNAPSHOT
 
+kotlin_version=1.6.0
+infra_version=0.3.0-dev-64
+
 org.gradle.jvmargs=-Xmx2g -XX:MaxPermSize=2048m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
 
 kotlin.mpp.enableGranularSourceSetsMetadata=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ version=0.4
 versionSuffix=SNAPSHOT
 
 kotlin_version=1.8.10
-infra_version=0.3.0-dev-64
+infra_version=0.3.0-dev-73
 
 org.gradle.jvmargs=-Xmx2g -XX:MaxPermSize=2048m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@ group=org.jetbrains.kotlinx
 version=0.4
 versionSuffix=SNAPSHOT
 
-kotlin_version=1.6.0
+kotlin_version=1.8.10
 infra_version=0.3.0-dev-64
 
 org.gradle.jvmargs=-Xmx2g -XX:MaxPermSize=2048m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/settings.gradle
+++ b/settings.gradle
@@ -2,6 +2,9 @@ pluginManagement {
     repositories {
         maven { url 'https://maven.pkg.jetbrains.space/kotlin/p/kotlinx/maven' }
         gradlePluginPortal()
+        if (settings.hasProperty("kotlin_repo_url") && settings.kotlin_repo_url != null) {
+            maven { url = settings.kotlin_repo_url }
+        }
     }
 }
 


### PR DESCRIPTION
The project takes the same set of Gradle parameters as the [kotlinx-benchmark](https://github.com/Kotlin/kotlinx-benchmark) project. Namely, `kotlin_version` specifies the Kotlin version to use, `kotlin_repo_url` specifies the repository to download artifacts from.