### PR TITLE
Replace `MaxPermSize` with `MaxMetaspaceSize` for JDK 17

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,4 +2,4 @@ group=org.jetbrains.kotlinx
 version=0.4
 versionSuffix=SNAPSHOT
 
-org.gradle.jvmargs=-Xmx2g -XX:MaxPermSize=2048m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=2048m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8


### PR DESCRIPTION
I can't run this project on JDK 17 cause `MaxPermSize` has been removed from that, we can replace it to support running on newer JDKs.

https://docs.oracle.com/en/java/javase/17/docs/specs/man/java.html#removed-java-options