### PR TITLE
Add Kotlin K2 migrations

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -121,8 +121,10 @@ kotlin {
         }
 
         val wasmMain by creating {
+            dependsOn(commonMain)
         }
         val wasmTest by creating {
+            dependsOn(commonTest)
         }
 
         val wasmJsMain by getting {

--- a/core/commonTest/src/contract/list/ImmutableListTest.kt
+++ b/core/commonTest/src/contract/list/ImmutableListTest.kt
@@ -25,7 +25,7 @@ class ImmutableListTest {
 
         assertFailsWith<NoSuchElementException> { empty1.iterator().next() }
 
-        compareLists(emptyList(), empty1)
+        compareLists(emptyList<Int>(), empty1)
 
     }
 

--- a/core/commonTest/src/contract/set/ImmutableSetTest.kt
+++ b/core/commonTest/src/contract/set/ImmutableSetTest.kt
@@ -239,7 +239,7 @@ abstract class ImmutableSetTestBase {
         assertEquals<Set<Any>>(setOf(), empty1)
         assertTrue(empty1 === empty2)
 
-        compareSets(emptySet(), empty1)
+        compareSets(emptySet<Int>(), empty1)
     }
 
     @Test fun ofElements() {


### PR DESCRIPTION
Building the project with the K2 version of the compiler revealed several migrations. 
It is necessary to move these changes to `master` branch to simplify the support of `kotlin-community/dev` branch. As well as simplifying the future migration of the project to a new version of the compiler.