### PR TITLE
Avoid creating new PersistentList instance when adding empty collection

### DIFF
--- a/core/commonMain/src/implementations/immutableList/AbstractPersistentList.kt
+++ b/core/commonMain/src/implementations/immutableList/AbstractPersistentList.kt
@@ -8,6 +8,7 @@ package kotlinx.collections.immutable.implementations.immutableList
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.PersistentList
 import kotlinx.collections.immutable.mutate
+import kotlinx.collections.immutable.internal.ListImplementation.checkPositionIndex
 
 public abstract class AbstractPersistentList<E> : PersistentList<E>, AbstractList<E>() {
     override fun subList(fromIndex: Int, toIndex: Int): ImmutableList<E> {
@@ -15,10 +16,13 @@ public abstract class AbstractPersistentList<E> : PersistentList<E>, AbstractLis
     }
 
     override fun addAll(elements: Collection<E>): PersistentList<E> {
+        if (elements.isEmpty()) return this
         return mutate { it.addAll(elements) }
     }
 
     override fun addAll(index: Int, c: Collection<E>): PersistentList<E> {
+        checkPositionIndex(index, size)
+        if (c.isEmpty()) return this
         return mutate { it.addAll(index, c) }
     }
 
@@ -31,10 +35,12 @@ public abstract class AbstractPersistentList<E> : PersistentList<E>, AbstractLis
     }
 
     override fun removeAll(elements: Collection<E>): PersistentList<E> {
+        if (elements.isEmpty()) return this
         return removeAll { elements.contains(it) }
     }
 
     override fun retainAll(elements: Collection<E>): PersistentList<E> {
+        if (elements.isEmpty()) return persistentVectorOf()
         return removeAll { !elements.contains(it) }
     }
 

--- a/core/commonMain/src/implementations/immutableList/PersistentVectorBuilder.kt
+++ b/core/commonMain/src/implementations/immutableList/PersistentVectorBuilder.kt
@@ -669,6 +669,7 @@ internal class PersistentVectorBuilder<E>(private var vector: PersistentList<E>,
     }
 
     override fun removeAll(elements: Collection<E>): Boolean {
+        if (elements.isEmpty()) return false
         return removeAllWithPredicate { elements.contains(it) }
     }
 

--- a/core/commonMain/src/implementations/immutableList/SmallPersistentVector.kt
+++ b/core/commonMain/src/implementations/immutableList/SmallPersistentVector.kt
@@ -36,6 +36,7 @@ internal class SmallPersistentVector<E>(private val buffer: Array<Any?>) : Immut
     }
 
     override fun addAll(elements: Collection<E>): PersistentList<E> {
+        if (elements.isEmpty()) return this
         if (size + elements.size <= MAX_BUFFER_SIZE) {
             val newBuffer = buffer.copyOf(size + elements.size)
             // TODO: investigate performance of elements.toArray + copyInto
@@ -80,6 +81,7 @@ internal class SmallPersistentVector<E>(private val buffer: Array<Any?>) : Immut
 
     override fun addAll(index: Int, c: Collection<E>): PersistentList<E> {
         checkPositionIndex(index, size)
+        if (c.isEmpty()) return this
         if (size + c.size <= MAX_BUFFER_SIZE) {
             val newBuffer = bufferOfSize(size + c.size)
             buffer.copyInto(newBuffer, endIndex = index)

--- a/core/commonMain/src/implementations/immutableMap/PersistentHashMap.kt
+++ b/core/commonMain/src/implementations/immutableMap/PersistentHashMap.kt
@@ -68,6 +68,7 @@ internal class PersistentHashMap<K, V>(internal val node: TrieNode<K, V>,
     }
 
     override fun putAll(m: Map<out K, @UnsafeVariance V>): PersistentMap<K, V> {
+        if (m.isEmpty()) return this
         return this.mutate { it.putAll(m) }
     }
 

--- a/core/commonMain/src/implementations/immutableMap/PersistentHashMapBuilder.kt
+++ b/core/commonMain/src/implementations/immutableMap/PersistentHashMapBuilder.kt
@@ -66,6 +66,7 @@ internal class PersistentHashMapBuilder<K, V>(private var map: PersistentHashMap
     }
 
     override fun putAll(from: Map<out K, V>) {
+        if (from.isEmpty()) return
         val map = from as? PersistentHashMap ?: (from as? PersistentHashMapBuilder)?.build()
         if (map != null) @Suppress("UNCHECKED_CAST") {
             val intersectionCounter = DeltaCounter()

--- a/core/commonMain/src/implementations/immutableSet/PersistentHashSet.kt
+++ b/core/commonMain/src/implementations/immutableSet/PersistentHashSet.kt
@@ -21,6 +21,7 @@ internal class PersistentHashSet<E>(internal val node: TrieNode<E>,
     }
 
     override fun addAll(elements: Collection<E>): PersistentSet<E> {
+        if (elements.isEmpty()) return this
         return this.mutate { it.addAll(elements) }
     }
 
@@ -31,6 +32,7 @@ internal class PersistentHashSet<E>(internal val node: TrieNode<E>,
     }
 
     override fun removeAll(elements: Collection<E>): PersistentSet<E> {
+        if (elements.isEmpty()) return this
         return mutate { it.removeAll(elements) }
     }
 
@@ -39,6 +41,7 @@ internal class PersistentHashSet<E>(internal val node: TrieNode<E>,
     }
 
     override fun retainAll(elements: Collection<E>): PersistentSet<E> {
+        if (elements.isEmpty()) return PersistentHashSet.emptyOf<E>()
         return mutate { it.retainAll(elements) }
     }
 

--- a/core/commonMain/src/implementations/immutableSet/PersistentHashSetBuilder.kt
+++ b/core/commonMain/src/implementations/immutableSet/PersistentHashSetBuilder.kt
@@ -45,6 +45,7 @@ internal class PersistentHashSetBuilder<E>(private var set: PersistentHashSet<E>
     }
 
     override fun addAll(elements: Collection<E>): Boolean {
+        if (elements.isEmpty()) return false
         val set = elements as? PersistentHashSet ?: (elements as? PersistentHashSetBuilder)?.build()
         if (set !== null) {
             val deltaCounter = DeltaCounter()
@@ -81,6 +82,7 @@ internal class PersistentHashSetBuilder<E>(private var set: PersistentHashSet<E>
     }
 
     override fun removeAll(elements: Collection<E>): Boolean {
+        if (elements.isEmpty()) return false
         val set = elements as? PersistentHashSet ?: (elements as? PersistentHashSetBuilder)?.build()
         if (set !== null) {
             val counter = DeltaCounter()

--- a/core/commonMain/src/implementations/persistentOrderedMap/PersistentOrderedMap.kt
+++ b/core/commonMain/src/implementations/persistentOrderedMap/PersistentOrderedMap.kt
@@ -117,6 +117,7 @@ internal class PersistentOrderedMap<K, V>(
     }
 
     override fun putAll(m: Map<out K, @UnsafeVariance V>): PersistentMap<K, V> {
+        if (m.isEmpty()) return this
         return this.mutate { it.putAll(m) }
     }
 

--- a/core/commonMain/src/implementations/persistentOrderedSet/PersistentOrderedSet.kt
+++ b/core/commonMain/src/implementations/persistentOrderedSet/PersistentOrderedSet.kt
@@ -53,6 +53,7 @@ internal class PersistentOrderedSet<E>(
     }
 
     override fun addAll(elements: Collection<E>): PersistentSet<E> {
+        if (elements.isEmpty()) return this
         return this.mutate { it.addAll(elements) }
     }
 
@@ -78,6 +79,7 @@ internal class PersistentOrderedSet<E>(
     }
 
     override fun removeAll(elements: Collection<E>): PersistentSet<E> {
+        if (elements.isEmpty()) return this
         return mutate { it.removeAll(elements) }
     }
 
@@ -86,6 +88,7 @@ internal class PersistentOrderedSet<E>(
     }
 
     override fun retainAll(elements: Collection<E>): PersistentSet<E> {
+        if (elements.isEmpty()) return PersistentOrderedSet.emptyOf<E>()
         return mutate { it.retainAll(elements) }
     }
 

--- a/core/commonTest/src/contract/list/ImmutableListTest.kt
+++ b/core/commonTest/src/contract/list/ImmutableListTest.kt
@@ -68,6 +68,13 @@ class ImmutableListTest {
         compareLists(list, immList)
     }
 
+    @Test fun emptyListToPersistentList() {
+        val empty = emptyList<Int>()
+        val emptyPersistent = empty.toPersistentList()
+
+        assertSame(emptyPersistent, empty.toPersistentList())
+    }
+
     @Test fun addElements() {
         var list = persistentListOf<String>()
         list = list.add("x")
@@ -194,6 +201,9 @@ class ImmutableListTest {
             testNoOperation({ remove('d') }, { remove('d') })
             testNoOperation({ removeAll(listOf('d', 'e')) }, { removeAll(listOf('d', 'e')) })
             testNoOperation({ removeAll { it.isUpperCase() } }, { removeAll { it.isUpperCase() } })
+            testNoOperation({ removeAll(emptyList()) }, { removeAll(emptyList())})
+            testNoOperation({ addAll(emptyList()) }, { addAll(emptyList())})
+            testNoOperation({ addAll(2, emptyList()) }, { addAll(2, emptyList())})
         }
     }
 

--- a/core/commonTest/src/contract/map/ImmutableMapTest.kt
+++ b/core/commonTest/src/contract/map/ImmutableMapTest.kt
@@ -191,6 +191,12 @@ abstract class ImmutableMapTest {
         assertEquals<Map<*, *>>(map, immMap) // problem
     }
 
+    @Test fun emptyMapToPersistentMap() {
+        val empty = emptyMap<String, Int>()
+        val emptyPersistentMap = empty.toPersistentMap()
+
+        assertSame(emptyPersistentMap, empty.toPersistentMap())
+    }
 
     @Test fun putElements() {
         var map = immutableMapOf<String, Int?>().toPersistentMap()

--- a/core/commonTest/src/contract/set/ImmutableSetTest.kt
+++ b/core/commonTest/src/contract/set/ImmutableSetTest.kt
@@ -339,11 +339,20 @@ abstract class ImmutableSetTestBase {
         val set = immutableSetOf("abcxyz12".toList())
         with(set) {
             testNoOperation({ add('a') }, { add('a') })
+            testNoOperation({ addAll(emptySet()) }, { addAll(emptySet()) })
             testNoOperation({ addAll(listOf('a', 'b')) }, { addAll(listOf('a', 'b')) })
             testNoOperation({ remove('d') }, { remove('d') })
             testNoOperation({ removeAll(listOf('d', 'e')) }, { removeAll(listOf('d', 'e')) })
             testNoOperation({ removeAll { it.isUpperCase() } }, { removeAll { it.isUpperCase() } })
+            testNoOperation({ removeAll(emptySet()) }, { removeAll(emptySet()) })
         }
+    }
+
+    @Test fun emptySetToPersistentSet() {
+        val empty = emptySet<Int>()
+        val emptyPersistentSet = empty.toPersistentSet()
+
+        assertSame(emptyPersistentSet, empty.toPersistentSet())
     }
 
     fun <T> PersistentSet<T>.testNoOperation(persistent: PersistentSet<T>.() -> PersistentSet<T>, mutating: MutableSet<T>.() -> Unit) {


### PR DESCRIPTION
### Problem

I encountered unexpected growth in memory usage while working on an library that uses `PersistentList`. I eventually realized that it is because I had many distinct instances of an empty `PersistentList`.

I traced down the problem, starting with `toPersistentList()`, which I was using to convert all inputs before creating assembling it into my data model. The `toPersistentList()` function takes the empty persistent list and adds all elements of `this` to the empty list. When you add elements to a `SmallPersistentVector`, it checks whether the combined size is less than or equal to `MAX_BUFFER_SIZE` and if it is, it unconditionally creates a new `SmallPersistentVector` instance.

https://github.com/Kotlin/kotlinx.collections.immutable/blob/7fb0d74ea87d1f52e8d30d39d4df066a57f51e50/core/commonMain/src/implementations/immutableList/SmallPersistentVector.kt#L38-L49

This means that no-ops on small lists (such as adding two empty lists) always results in a new instance being created.

I verified that the problem only exists for `SmallPersistentVector`. `PersistentVector` uses `PersistentVectorBuilder`, which already has checks for adding an empty collection.

### What I am changing

I have added a check to `fun addAll(elements: Collection<E>): PersistentList<E>` and `fun addAll(index: Int, c: Collection<E>): PersistentList<E>` to return early if the collection of elements to be added is empty.

I have updated the tests to include missing no-op cases related to adding and removing empty collections in both `ImmutableListTest` and `ImmutableSetTest`, and I have added tests for `toPersistentMap()`, `toPersistentSet()`, and `toPersistentList()` to ensure that when the receiver is an empty map/collection, they always return the same instance of persistent map/set/list.