### PR TITLE
Use BCV version compatible w/ Kotlin 2.1

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,8 +1,9 @@
 import org.jetbrains.kotlin.gradle.dsl.KotlinJsCompile
 
+
 buildscript {
     dependencies {
-        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.21")
+        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:${rootProject.properties["kotlin_version"]}")
     }
 }
 
@@ -30,8 +31,14 @@ apiValidation {
 }
 
 allprojects {
+    val kotlin_repo_url = rootProject.properties["kotlin_repo_url"]
+
     repositories {
         mavenCentral()
+        maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/dev")
+        if (kotlin_repo_url != null) {
+            maven(kotlin_repo_url)
+        }
     }
 
     tasks.withType<org.jetbrains.kotlin.gradle.dsl.KotlinCompile<*>> {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,7 +9,7 @@ buildscript {
 
 plugins {
     id("kotlinx.team.infra") version "0.4.0-dev-80"
-    id("org.jetbrains.kotlinx.binary-compatibility-validator") version "0.13.2"
+    id("org.jetbrains.kotlinx.binary-compatibility-validator") version "0.15.0-20240704150100-2.1-SNAPSHOT"
 }
 
 infra {

--- a/core/commonMain/src/implementations/immutableList/PersistentVectorBuilder.kt
+++ b/core/commonMain/src/implementations/immutableList/PersistentVectorBuilder.kt
@@ -10,7 +10,6 @@ import kotlinx.collections.immutable.internal.ListImplementation.checkElementInd
 import kotlinx.collections.immutable.internal.ListImplementation.checkPositionIndex
 import kotlinx.collections.immutable.internal.MutabilityOwnership
 import kotlinx.collections.immutable.internal.assert
-import kotlinx.collections.immutable.internal.modCount
 
 internal class PersistentVectorBuilder<E>(private var vector: PersistentList<E>,
                                           private var vectorRoot: Array<Any?>?,

--- a/core/commonMain/src/internal/commonFunctions.kt
+++ b/core/commonMain/src/internal/commonFunctions.kt
@@ -6,6 +6,3 @@
 package kotlinx.collections.immutable.internal
 
 internal expect fun assert(condition: Boolean)
-
-@Suppress("NO_ACTUAL_FOR_EXPECT") // implemented by protected property in JVM
-internal expect var AbstractMutableList<*>.modCount: Int

--- a/core/jsMain/src/internal/commonFunctions.kt
+++ b/core/jsMain/src/internal/commonFunctions.kt
@@ -10,7 +10,3 @@ internal actual fun assert(condition: Boolean) {
         throw AssertionError("Assertion failed")
     }
 }
-
-internal actual var AbstractMutableList<*>.modCount: Int
-    get() = 0
-    set(@Suppress("UNUSED_PARAMETER") value) {}

--- a/core/nativeMain/src/internal/commonFunctions.kt
+++ b/core/nativeMain/src/internal/commonFunctions.kt
@@ -7,8 +7,3 @@ package kotlinx.collections.immutable.internal
 
 @OptIn(kotlin.experimental.ExperimentalNativeApi::class)
 internal actual fun assert(condition: Boolean) = kotlin.assert(condition)
-
-
-internal actual var AbstractMutableList<*>.modCount: Int
-    get() = 0
-    set(@Suppress("UNUSED_PARAMETER") value) {}

--- a/core/wasmMain/src/internal/commonFunctions.kt
+++ b/core/wasmMain/src/internal/commonFunctions.kt
@@ -10,7 +10,3 @@ internal actual fun assert(condition: Boolean) {
         throw AssertionError("Assertion failed")
     }
 }
-
-internal actual var AbstractMutableList<*>.modCount: Int
-    get() = 0
-    set(@Suppress("UNUSED_PARAMETER") value) {}

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,3 +3,4 @@ version=0.4
 versionSuffix=SNAPSHOT
 
 org.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=2048m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
+kotlin_version=2.0.0-dev-16989

--- a/settings.gradle
+++ b/settings.gradle
@@ -5,6 +5,8 @@ pluginManagement {
         gradlePluginPortal()
 
         maven { url 'https://maven.pkg.jetbrains.space/kotlin/p/kotlin/dev'}
+        maven { url 'https://maven.pkg.jetbrains.space/kotlin/p/kotlinx/dev'}
+
         if (kotlin_repo_url.present) {
             maven { url kotlin_repo_url.get() }
         }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,7 +1,13 @@
 pluginManagement {
+    def kotlin_repo_url = providers.gradleProperty("kotlin_repo_url")
     repositories {
         maven { url 'https://maven.pkg.jetbrains.space/kotlin/p/kotlinx/maven' }
         gradlePluginPortal()
+
+        maven { url 'https://maven.pkg.jetbrains.space/kotlin/p/kotlin/dev'}
+        if (kotlin_repo_url.present) {
+            maven { url kotlin_repo_url.get() }
+        }
     }
 }
 


### PR DESCRIPTION
The latest BCV versions are incompatible with LV 2.1 due to the old `kotlinx-metadata-jvm` version being used.
Unfortunately, BCV could not be easily updated (https://github.com/Kotlin/binary-compatibility-validator/issues/241#issuecomment-2202719001).
This PR changes the BCV for `kotlin-commuinity/dev` builds to a snapshot build with ab updated metadata version (built from [kotlin-community/stable-metadata](https://github.com/Kotlin/binary-compatibility-validator/tree/kotlin-community/stable-metadata) branch).