### PR TITLE
Fix memory leak in builders

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Builders hold on to the original collection, causing memory leaks in our use case.

In order to make persistent collections composable (to put one as an element of another) and preserve the efficiency of temporary mutability we have to compose builders, instead of persistent collections. Since we hold on to this builders for a long time, the reference to the old collection in all builders causes memory leaks.

The proposed fix is to release the reference, once the collection is changed and there is no chance to return it from build fn.
