### PR TITLE
Bump Kotlin version to 2.0.20

### DIFF
--- a/benchmarks/build.gradle.kts
+++ b/benchmarks/build.gradle.kts
@@ -13,6 +13,7 @@ evaluationDependsOn(":kotlinx-collections-immutable")
 kotlin {
     infra {
         target("macosX64")
+        target("macosArm64")
         target("linuxX64")
         target("mingwX64")
     }
@@ -102,6 +103,7 @@ benchmark {
         register("js")
         register("wasmJs")
         register("macosX64")
+        register("macosArm64")
         register("linuxX64")
         register("mingwX64")
     }

--- a/benchmarks/build.gradle.kts
+++ b/benchmarks/build.gradle.kts
@@ -1,6 +1,6 @@
 import kotlinx.benchmark.gradle.JvmBenchmarkTarget
 import org.gradle.jvm.tasks.Jar
-import org.jetbrains.kotlin.gradle.targets.js.dsl.ExperimentalWasmDsl
+import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
 
 plugins {
     id("kotlin-multiplatform")

--- a/benchmarks/build.gradle.kts
+++ b/benchmarks/build.gradle.kts
@@ -4,7 +4,7 @@ import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
 
 plugins {
     id("kotlin-multiplatform")
-    id("org.jetbrains.kotlinx.benchmark") version "0.4.10"
+    id("org.jetbrains.kotlinx.benchmark") version "0.4.13"
 }
 
 
@@ -47,7 +47,7 @@ kotlin {
     sourceSets {
         commonMain {
             dependencies {
-                implementation("org.jetbrains.kotlinx:kotlinx-benchmark-runtime:0.4.10")
+                implementation("org.jetbrains.kotlinx:kotlinx-benchmark-runtime:0.4.13")
                 implementation(project(":kotlinx-collections-immutable"))
             }
         }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,7 +2,7 @@ import org.jetbrains.kotlin.gradle.dsl.KotlinJsCompile
 
 buildscript {
     dependencies {
-        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.21")
+        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:2.0.20")
     }
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,7 +2,7 @@ import org.jetbrains.kotlin.gradle.dsl.KotlinJsCompile
 
 buildscript {
     dependencies {
-        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:2.0.20")
+        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:${rootProject.properties["kotlin_version"]}")
     }
 }
 
@@ -37,6 +37,11 @@ apiValidation {
 allprojects {
     repositories {
         mavenCentral()
+
+        val kotlinRepoUrl = providers.gradleProperty("kotlin_repo_url").orNull
+        if (kotlinRepoUrl != null) {
+            maven(kotlinRepoUrl)
+        }
     }
 
     tasks.withType<org.jetbrains.kotlin.gradle.dsl.KotlinCompile<*>> {

--- a/core/api/kotlinx-collections-immutable.klib.api
+++ b/core/api/kotlinx-collections-immutable.klib.api
@@ -120,6 +120,9 @@ final class <#A: kotlin/Any?, #B: out kotlin/Any?> kotlinx.collections.immutable
     final fun hashCode(): kotlin/Int // kotlinx.collections.immutable.adapters/ImmutableMapAdapter.hashCode|hashCode(){}[0]
     final fun isEmpty(): kotlin/Boolean // kotlinx.collections.immutable.adapters/ImmutableMapAdapter.isEmpty|isEmpty(){}[0]
     final fun toString(): kotlin/String // kotlinx.collections.immutable.adapters/ImmutableMapAdapter.toString|toString(){}[0]
+
+    // Targets: [js]
+    final fun asJsReadonlyMapView(): kotlin.js.collections/JsReadonlyMap<#A, #B> // kotlinx.collections.immutable.adapters/ImmutableMapAdapter.asJsReadonlyMapView|asJsReadonlyMapView(){}[0]
 }
 
 final class <#A: kotlin/Any?> kotlinx.collections.immutable.adapters/ImmutableListAdapter : kotlin.collections/List<#A>, kotlinx.collections.immutable/ImmutableList<#A> { // kotlinx.collections.immutable.adapters/ImmutableListAdapter|null[0]
@@ -141,6 +144,9 @@ final class <#A: kotlin/Any?> kotlinx.collections.immutable.adapters/ImmutableLi
     final fun listIterator(kotlin/Int): kotlin.collections/ListIterator<#A> // kotlinx.collections.immutable.adapters/ImmutableListAdapter.listIterator|listIterator(kotlin.Int){}[0]
     final fun subList(kotlin/Int, kotlin/Int): kotlinx.collections.immutable/ImmutableList<#A> // kotlinx.collections.immutable.adapters/ImmutableListAdapter.subList|subList(kotlin.Int;kotlin.Int){}[0]
     final fun toString(): kotlin/String // kotlinx.collections.immutable.adapters/ImmutableListAdapter.toString|toString(){}[0]
+
+    // Targets: [js]
+    final fun asJsReadonlyArrayView(): kotlin.js.collections/JsReadonlyArray<#A> // kotlinx.collections.immutable.adapters/ImmutableListAdapter.asJsReadonlyArrayView|asJsReadonlyArrayView(){}[0]
 }
 
 final class <#A: kotlin/Any?> kotlinx.collections.immutable.adapters/ImmutableSetAdapter : kotlinx.collections.immutable.adapters/ImmutableCollectionAdapter<#A>, kotlinx.collections.immutable/ImmutableSet<#A> { // kotlinx.collections.immutable.adapters/ImmutableSetAdapter|null[0]

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -146,13 +146,3 @@ tasks {
         maxHeapSize = "1024m"
     }
 }
-
-with(org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsRootPlugin.apply(rootProject)) {
-    nodeVersion = "21.0.0-v8-canary202309167e82ab1fa2"
-    nodeDownloadBaseUrl = "https://nodejs.org/download/v8-canary"
-}
-
-// Drop this when node js version become stable
-tasks.withType<org.jetbrains.kotlin.gradle.targets.js.npm.tasks.KotlinNpmInstallTask>().configureEach {
-    args.add("--ignore-engines")
-}

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -1,5 +1,5 @@
 import kotlinx.team.infra.mavenPublicationsPom
-import org.jetbrains.kotlin.gradle.targets.js.dsl.ExperimentalWasmDsl
+import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
 
 plugins {
     id("kotlin-multiplatform")

--- a/core/commonMain/src/implementations/immutableList/PersistentVectorBuilder.kt
+++ b/core/commonMain/src/implementations/immutableList/PersistentVectorBuilder.kt
@@ -10,7 +10,6 @@ import kotlinx.collections.immutable.internal.ListImplementation.checkElementInd
 import kotlinx.collections.immutable.internal.ListImplementation.checkPositionIndex
 import kotlinx.collections.immutable.internal.MutabilityOwnership
 import kotlinx.collections.immutable.internal.assert
-import kotlinx.collections.immutable.internal.modCount
 
 internal class PersistentVectorBuilder<E>(vector: PersistentList<E>,
                                           vectorRoot: Array<Any?>?,

--- a/core/commonMain/src/internal/commonFunctions.kt
+++ b/core/commonMain/src/internal/commonFunctions.kt
@@ -6,6 +6,3 @@
 package kotlinx.collections.immutable.internal
 
 internal expect fun assert(condition: Boolean)
-
-@Suppress("NO_ACTUAL_FOR_EXPECT") // implemented by protected property in JVM
-internal expect var AbstractMutableList<*>.modCount: Int

--- a/core/commonTest/src/stress/ExecutionTimeMeasuringTest.kt
+++ b/core/commonTest/src/stress/ExecutionTimeMeasuringTest.kt
@@ -10,7 +10,6 @@ import kotlin.test.BeforeTest
 import kotlin.time.*
 import kotlin.time.Duration.Companion.seconds
 
-@OptIn(ExperimentalTime::class)
 abstract class ExecutionTimeMeasuringTest {
     private var clockMark: TimeMark? = null
 

--- a/core/commonTest/src/stress/list/PersistentListBuilderTest.kt
+++ b/core/commonTest/src/stress/list/PersistentListBuilderTest.kt
@@ -17,9 +17,7 @@ import tests.testOn
 import kotlin.random.Random
 import kotlin.random.nextInt
 import kotlin.test.*
-import kotlin.time.ExperimentalTime
 
-@OptIn(ExperimentalTime::class)
 class PersistentListBuilderTest : ExecutionTimeMeasuringTest() {
 
     @Test

--- a/core/jsMain/src/internal/commonFunctions.kt
+++ b/core/jsMain/src/internal/commonFunctions.kt
@@ -10,7 +10,3 @@ internal actual fun assert(condition: Boolean) {
         throw AssertionError("Assertion failed")
     }
 }
-
-internal actual var AbstractMutableList<*>.modCount: Int
-    get() = 0
-    set(@Suppress("UNUSED_PARAMETER") value) {}

--- a/core/nativeMain/src/internal/commonFunctions.kt
+++ b/core/nativeMain/src/internal/commonFunctions.kt
@@ -7,8 +7,3 @@ package kotlinx.collections.immutable.internal
 
 @OptIn(kotlin.experimental.ExperimentalNativeApi::class)
 internal actual fun assert(condition: Boolean) = kotlin.assert(condition)
-
-
-internal actual var AbstractMutableList<*>.modCount: Int
-    get() = 0
-    set(@Suppress("UNUSED_PARAMETER") value) {}

--- a/core/wasmMain/src/internal/commonFunctions.kt
+++ b/core/wasmMain/src/internal/commonFunctions.kt
@@ -10,7 +10,3 @@ internal actual fun assert(condition: Boolean) {
         throw AssertionError("Assertion failed")
     }
 }
-
-internal actual var AbstractMutableList<*>.modCount: Int
-    get() = 0
-    set(@Suppress("UNUSED_PARAMETER") value) {}

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,4 +2,6 @@ group=org.jetbrains.kotlinx
 version=0.4
 versionSuffix=SNAPSHOT
 
+kotlin_version=2.0.20
+
 org.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=2048m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -2,6 +2,11 @@ pluginManagement {
     repositories {
         maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlinx/maven")
         gradlePluginPortal()
+
+        val kotlinRepoUrl = providers.gradleProperty("kotlin_repo_url").orNull
+        if (kotlinRepoUrl != null) {
+            maven(kotlinRepoUrl)
+        }
     }
 }
 


### PR DESCRIPTION
Additionally:
* Adopt build scripts for receiving `kotlin_version` and `kotlin_repo_url` as project parameters
* Bump binary-compatibility-validator version to 0.16.3 to fix `master` build
* Small cleanups