### PR TITLE
Remove the usage of an obsolete KGP option

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -64,7 +64,6 @@ kotlin {
             kotlinOptions {
                 sourceMap = true
                 moduleKind = "umd"
-                metaInfo = true
             }
         }
     }


### PR DESCRIPTION
The `metaInfo` option is deprecated, see [KT-65990](https://youtrack.jetbrains.com/issue/KT-65990).