### PR TITLE
Do not use mocha for wasm targets

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -73,22 +73,12 @@ kotlin {
     @OptIn(ExperimentalWasmDsl::class)
     wasmJs {
         nodejs {
-            testTask {
-                useMocha {
-                    timeout = "30000"
-                }
-            }
         }
     }
 
     @OptIn(ExperimentalWasmDsl::class)
     wasmWasi {
         nodejs {
-            testTask {
-                useMocha {
-                    timeout = "30000"
-                }
-            }
         }
     }
 


### PR DESCRIPTION
It is senseless because for wasm target there is special test framework, and nodejs+wasm can be used only with that special test framework KotlinWasmNode.

https://github.com/JetBrains/kotlin/blob/b1e3239f8749845a7be58728a760c7a90c190833/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/ir/KotlinNodeJsIr.kt#L109