### PR TITLE
Migrate to a new DSL from a deprecated one

### DIFF
--- a/benchmarks/build.gradle.kts
+++ b/benchmarks/build.gradle.kts
@@ -1,6 +1,8 @@
 import kotlinx.benchmark.gradle.JvmBenchmarkTarget
 import org.gradle.jvm.tasks.Jar
+import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
 import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     id("kotlin-multiplatform")
@@ -10,6 +12,7 @@ plugins {
 
 evaluationDependsOn(":kotlinx-collections-immutable")
 
+@OptIn(ExperimentalKotlinGradlePluginApi::class)
 kotlin {
     infra {
         target("macosX64")
@@ -19,10 +22,8 @@ kotlin {
     }
 
     jvm {
-        compilations.all {
-            kotlinOptions {
-                jvmTarget = "1.8"
-            }
+        compilerOptions {
+            jvmTarget.set(JvmTarget.JVM_1_8)
         }
     }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,5 @@
 import org.jetbrains.kotlin.gradle.dsl.KotlinJsCompile
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
 
 buildscript {
     dependencies {
@@ -44,11 +45,15 @@ allprojects {
         }
     }
 
-    tasks.withType<org.jetbrains.kotlin.gradle.dsl.KotlinCompile<*>> {
-        kotlinOptions.allWarningsAsErrors = true
-        kotlinOptions.freeCompilerArgs += "-Xexpect-actual-classes"
+    tasks.withType(KotlinCompilationTask::class).configureEach {
+        compilerOptions {
+            allWarningsAsErrors = true
+            freeCompilerArgs.add("-Xexpect-actual-classes")
+        }
         if (this is KotlinJsCompile) {
-            kotlinOptions.freeCompilerArgs += "-Xwasm-enable-array-range-checks"
+            compilerOptions {
+                freeCompilerArgs.add("-Xwasm-enable-array-range-checks")
+            }
         }
     }
 }

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -1,5 +1,8 @@
 import kotlinx.team.infra.mavenPublicationsPom
+import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
 import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
+import org.jetbrains.kotlin.gradle.dsl.JsModuleKind
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     id("kotlin-multiplatform")
@@ -14,6 +17,7 @@ mavenPublicationsPom {
     description = "Kotlin Immutable Collections multiplatform library"
 }
 
+@OptIn(ExperimentalKotlinGradlePluginApi::class)
 kotlin {
     applyDefaultHierarchyTemplate()
     explicitApi()
@@ -46,10 +50,8 @@ kotlin {
     watchosDeviceArm64()
 
     jvm {
-        compilations.all {
-            kotlinOptions {
-                jvmTarget = "1.8"
-            }
+        compilerOptions {
+            jvmTarget.set(JvmTarget.JVM_1_8)
         }
     }
 
@@ -61,12 +63,9 @@ kotlin {
                 }
             }
         }
-        compilations.all {
-            kotlinOptions {
-                sourceMap = true
-                moduleKind = "umd"
-                metaInfo = true
-            }
+        compilerOptions {
+            sourceMap = true
+            moduleKind.set(JsModuleKind.MODULE_UMD)
         }
     }
 


### PR DESCRIPTION
With never KGP version it's an error to use `metaInfo` property. It was effectively no-op after moving away from legacy JS compiler, so it's safe to remove it.

I also updated build script to a new compiler options DSL to avoid deprecation-related errors in the future.