### PR TITLE
Enable '-jvm-default=disable' explicitly to prevent API dump changes

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,5 @@
 import org.jetbrains.kotlin.gradle.dsl.KotlinJsCompile
+import org.jetbrains.kotlin.gradle.dsl.KotlinJvmCompile
 import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
 
@@ -56,6 +57,10 @@ allprojects {
         if (this is KotlinJsCompile) {
             compilerOptions {
                 freeCompilerArgs.add("-Xwasm-enable-array-range-checks")
+            }
+        } else if (this is KotlinJvmCompile) {
+            compilerOptions {
+                freeCompilerArgs.add("-jvm-default=disable")
             }
         }
     }


### PR DESCRIPTION
The default mode is changing from 'disable' to 'enable' in KT-71768. However, core libraries will migrate to the new '-jvm-default=enable' mode explicitly, once they update to Kotlin 2.2, see KT-72051.
