### PR TITLE
Use -Xjvm-default instead of -jvm-default

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -60,7 +60,7 @@ allprojects {
             }
         } else if (this is KotlinJvmCompile) {
             compilerOptions {
-                freeCompilerArgs.add("-jvm-default=disable")
+                freeCompilerArgs.add("-Xjvm-default=disable")
             }
         }
     }


### PR DESCRIPTION
Apparently this branch is used in user projects to build both 2.1.20 and 2.2.0, and 2.1.20 did not support the new `-jvm-default` (KT-73007).