### PR TITLE
Enable '-Xjvm-default=disable' explicitly to prevent API dump changes

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,5 @@
 import org.jetbrains.kotlin.gradle.dsl.KotlinJsCompile
+import org.jetbrains.kotlin.gradle.dsl.KotlinJvmCompile
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
 
 buildscript {
@@ -53,6 +54,10 @@ allprojects {
         if (this is KotlinJsCompile) {
             compilerOptions {
                 freeCompilerArgs.add("-Xwasm-enable-array-range-checks")
+            }
+        } else if (this is KotlinJvmCompile) {
+            compilerOptions {
+                freeCompilerArgs.add("-Xjvm-default=disable")
             }
         }
     }


### PR DESCRIPTION
The default mode is changing from 'disable' to 'enable' in KT-71768. However, core libraries will migrate to the new '-jvm-default=enable' mode explicitly, once they update to Kotlin 2.2, see KT-72051.
