### PR TITLE
Use another KotlinJvmCompile to change JVM compiler options

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 import org.jetbrains.kotlin.gradle.dsl.KotlinJsCompile
-import org.jetbrains.kotlin.gradle.dsl.KotlinJvmCompile
+import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
 
 buildscript {


### PR DESCRIPTION
Apparently the one in the `dsl` package is deprecated with error since 2.2 (KT-68597):
https://github.com/JetBrains/kotlin/blob/35162db3a4162849366a7e1175d74e0fadbb8732/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/dsl/KotlinCompile.kt#L20