### PR TITLE
Adopt KUP requirements imposed by KT-75078

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -63,8 +63,6 @@ allprojects {
                     "-Wextra",
                     "-Xuse-fir-experimental-checkers"
                 )
-                logger.info("kotlin_Werror_override was set to 'disable'")
-                logger.info("Using -Wextra and -Xuse-fir-experimental-checkers compiler options")
             }
             freeCompilerArgs.addAll(
                 "-Xexpect-actual-classes",
@@ -85,9 +83,13 @@ allprojects {
         val extraOpts = providers.gradleProperty("kotlin_additional_cli_options").orNull
         extraOpts?.split(' ')?.let { opts ->
             if (opts.isNotEmpty()) {
-                logger.info("Adding additional compiler options: ${opts.joinToString(", ")}")
                 compilerOptions.freeCompilerArgs.addAll(opts)
             }
+        }
+
+        doFirst {
+            logger.info("Added Kotlin compiler flags: ${compilerOptions.freeCompilerArgs.get().joinToString(", ")}")
+            logger.info("allWarningsAsErrors=${compilerOptions.allWarningsAsErrors.get()}")
         }
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -81,7 +81,7 @@ allprojects {
         }
 
         val extraOpts = providers.gradleProperty("kotlin_additional_cli_options").orNull
-        extraOpts?.split(' ')?.let { opts ->
+        extraOpts?.split(' ')?.map(String::trim)?.filter(String::isNotBlank)?.let { opts ->
             if (opts.isNotEmpty()) {
                 compilerOptions.freeCompilerArgs.addAll(opts)
             }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -46,10 +46,29 @@ allprojects {
         }
     }
 
+    val setAllWarningsAsError = providers.gradleProperty("kotlin_Werror_override").map {
+        when (it) {
+            "enable" -> true
+            "disable" -> false
+            else -> error("Unexpected value for 'kotlin_Werror_override' property: $it")
+        }
+    }
+
     tasks.withType(KotlinCompilationTask::class).configureEach {
         compilerOptions {
-            allWarningsAsErrors = true
-            freeCompilerArgs.add("-Xexpect-actual-classes")
+            if (setAllWarningsAsError.orNull != false) {
+                allWarningsAsErrors = true
+            } else {
+                freeCompilerArgs.addAll(
+                    "-Wextra",
+                    "-Xuse-fir-experimental-checkers"
+                )
+            }
+            freeCompilerArgs.addAll(
+                "-Xexpect-actual-classes",
+                "-Xreport-all-warnings",
+                "-Xrender-internal-diagnostic-names"
+            )
         }
         if (this is KotlinJsCompile) {
             compilerOptions {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -81,6 +81,14 @@ allprojects {
                 freeCompilerArgs.add("-Xjvm-default=disable")
             }
         }
+
+        val extraOpts = providers.gradleProperty("kotlin_additional_cli_options").orNull
+        extraOpts?.split(' ')?.let { opts ->
+            if (opts.isNotEmpty()) {
+                logger.info("Adding additional compiler options: ${opts.joinToString(", ")}")
+                compilerOptions.freeCompilerArgs.addAll(opts)
+            }
+        }
     }
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -63,6 +63,8 @@ allprojects {
                     "-Wextra",
                     "-Xuse-fir-experimental-checkers"
                 )
+                logger.info("kotlin_Werror_override was set to 'disable'")
+                logger.info("Using -Wextra and -Xuse-fir-experimental-checkers compiler options")
             }
             freeCompilerArgs.addAll(
                 "-Xexpect-actual-classes",


### PR DESCRIPTION
`-Werror` doesn't work with `2.0.20`, so we either have to check the compiler version before using it, or update the Kotlin version (https://github.com/Kotlin/kotlinx.collections.immutable/pull/213).

Closes #212