### PR TITLE
Update infra plugin

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,7 +9,7 @@ buildscript {
 }
 
 plugins {
-    id("kotlinx.team.infra") version "0.4.0-dev-80"
+    id("kotlinx.team.infra") version "0.4.0-dev-85"
     id("org.jetbrains.kotlinx.binary-compatibility-validator") version "0.16.3"
 }
 

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -144,4 +144,15 @@ tasks {
     named("jvmTest", Test::class) {
         maxHeapSize = "1024m"
     }
+
+    // See https://youtrack.jetbrains.com/issue/KT-61313
+    withType<Sign>().configureEach {
+        val pubName = name.removePrefix("sign").removeSuffix("Publication")
+        findByName("linkDebugTest$pubName")?.let {
+            mustRunAfter(it)
+        }
+        findByName("compileTestKotlin$pubName")?.let {
+            mustRunAfter(it)
+        }
+    }
 }


### PR DESCRIPTION
Update kotlinx.team.infra to a version that no longer provides native targets and source-set setup functionality that is incompatible with KGP 2.2+.

Also, workaround [KT-61313](https://youtrack.jetbrains.com/issue/KT-61313), which is reproducible since infra plugin 0.4.0-dev-81