### PR TITLE
Ghost element when applying multiples minus operations on a PersistentHashSet

### DIFF
--- a/core/commonMain/src/implementations/immutableSet/TrieNode.kt
+++ b/core/commonMain/src/implementations/immutableSet/TrieNode.kt
@@ -621,16 +621,16 @@ internal class TrieNode<E>(
         val realSize = realBitMap.countOneBits()
         return when {
             realBitMap == 0 -> EMPTY
+            // single values are kept only on root level
+            realSize == 1 && shift != 0 -> when (val single = mutableNode.buffer[mutableNode.indexOfCellAt(realBitMap)]) {
+                is TrieNode<*> -> TrieNode<E>(realBitMap, arrayOf(single), mutator.ownership)
+                else -> single
+            }
             realBitMap == bitmap -> {
                 when {
                     mutableNode.elementsIdentityEquals(this) -> this
                     else -> mutableNode
                 }
-            }
-            // single values are kept only on root level
-            realSize == 1 && shift != 0 -> when (val single = mutableNode.buffer[mutableNode.indexOfCellAt(realBitMap)]) {
-                is TrieNode<*> -> TrieNode<E>(realBitMap, arrayOf(single), mutator.ownership)
-                else -> single
             }
             else -> {
                 // clean up all the EMPTYs in the resulting buffer

--- a/core/commonTest/src/contract/set/PersistentHashSetTest.kt
+++ b/core/commonTest/src/contract/set/PersistentHashSetTest.kt
@@ -71,14 +71,43 @@ class PersistentHashSetTest {
     }
 
     private fun validate(firstBatch: List<Int>, secondBatch: List<Int>, extraElement: Int) {
+        val set = firstBatch.plus(secondBatch).plus(extraElement).toPersistentHashSet()
+        val result = set.minus(firstBatch.toPersistentHashSet()).minus(secondBatch)
+
+        assertEquals(1, result.size)
+        assertEquals(extraElement, result.first())
+    }
+
+    @Test
+    fun equalsTest() {
+        val firstBatch = listOf(
+            0b0_00000_00000_00000,
+            0b0_00001_00000_00000,
+            0b0_00000_00000_00001,
+            0b0_00001_00000_00001,
+        )
+        val secondBatch = listOf(
+            0b0_00010_00000_00000,
+            0b0_00010_00000_00001
+        )
+        val extraElement =
+            0b0_00000_00000_00010
+
         val set: PersistentHashSet<Int> =
-            firstBatch.plus(secondBatch).plus(extraElement).toPersistentHashSet()
+            (firstBatch + secondBatch + extraElement).toPersistentHashSet()
                     as PersistentHashSet<Int>
 
-        val firstBatchSet = firstBatch.toPersistentHashSet()
+        val firstBatchSet: PersistentHashSet<Int> =
+            firstBatch.toPersistentHashSet()
+                    as PersistentHashSet<Int>
 
-        val actual = set.minus(firstBatchSet).minus(secondBatch)
-        val expected = persistentHashSetOf(extraElement)
+        val actual: PersistentHashSet<Int> =
+            set.minus(firstBatchSet)
+                    as PersistentHashSet<Int>
+
+        val expected: PersistentHashSet<Int> =
+            (secondBatch + extraElement).toPersistentHashSet()
+                    as PersistentHashSet<Int>
 
         assertEquals(expected, actual)
     }

--- a/core/commonTest/src/contract/set/PersistentHashSetTest.kt
+++ b/core/commonTest/src/contract/set/PersistentHashSetTest.kt
@@ -90,11 +90,9 @@ class PersistentHashSetTest {
             0b0_00010_00000_00000,
             0b0_00010_00000_00001
         )
-        val extraElement =
-            0b0_00000_00000_00010
 
         val set: PersistentHashSet<Int> =
-            (firstBatch + secondBatch + extraElement).toPersistentHashSet()
+            (firstBatch + secondBatch).toPersistentHashSet()
                     as PersistentHashSet<Int>
 
         val firstBatchSet: PersistentHashSet<Int> =
@@ -106,7 +104,7 @@ class PersistentHashSetTest {
                     as PersistentHashSet<Int>
 
         val expected: PersistentHashSet<Int> =
-            (secondBatch + extraElement).toPersistentHashSet()
+            secondBatch.toPersistentHashSet()
                     as PersistentHashSet<Int>
 
         assertEquals(expected, actual)

--- a/core/commonTest/src/contract/set/PersistentHashSetTest.kt
+++ b/core/commonTest/src/contract/set/PersistentHashSetTest.kt
@@ -6,6 +6,8 @@
 package tests.contract.set
 
 import kotlinx.collections.immutable.persistentHashSetOf
+import kotlinx.collections.immutable.minus
+import kotlinx.collections.immutable.toPersistentHashSet
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
@@ -26,5 +28,20 @@ class PersistentHashSetTest {
 
         assertEquals(set2, builder.build().toSet())
         assertEquals(set2, builder.build())
+    }
+
+    /**
+     * Test from issue: https://github.com/Kotlin/kotlinx.collections.immutable/issues/144
+     */
+    @Test
+    fun reproducer() {
+        val firstBatch = listOf(4554, 9380, 4260, 6602)
+        val secondBatch = listOf(1188, 14794)
+        val extraElement = 7450
+
+        val set = firstBatch.plus(secondBatch).plus(extraElement).toPersistentHashSet()
+        val result = set.minus(firstBatch.toPersistentHashSet()).minus(secondBatch)
+        assertEquals(1, result.size)
+        assertEquals(extraElement, result.first())
     }
 }

--- a/core/commonTest/src/contract/set/PersistentHashSetTest.kt
+++ b/core/commonTest/src/contract/set/PersistentHashSetTest.kt
@@ -80,29 +80,27 @@ class PersistentHashSetTest {
 
     @Test
     fun equalsTest() {
-        val firstBatch = listOf(
+        val batch = listOf(
             0b0_00000_00000_00000,
             0b0_00001_00000_00000
         )
-        val secondBatch = listOf(
-            0b0_00010_00000_00000,
-            0b0_00010_00000_00001
-        )
+        val singleElement =
+            0b0_00010_00000_00000
 
         val set: PersistentHashSet<Int> =
-            (firstBatch + secondBatch).toPersistentHashSet()
+            (batch + singleElement).toPersistentHashSet()
                     as PersistentHashSet<Int>
 
-        val firstBatchSet: PersistentHashSet<Int> =
-            firstBatch.toPersistentHashSet()
+        val batchSet: PersistentHashSet<Int> =
+            batch.toPersistentHashSet()
                     as PersistentHashSet<Int>
 
         val actual: PersistentHashSet<Int> =
-            set.minus(firstBatchSet)
+            set.minus(batchSet)
                     as PersistentHashSet<Int>
 
         val expected: PersistentHashSet<Int> =
-            secondBatch.toPersistentHashSet()
+            persistentHashSetOf(singleElement)
                     as PersistentHashSet<Int>
 
         assertEquals(expected, actual)

--- a/core/commonTest/src/contract/set/PersistentHashSetTest.kt
+++ b/core/commonTest/src/contract/set/PersistentHashSetTest.kt
@@ -96,7 +96,7 @@ class PersistentHashSetTest {
                     as PersistentHashSet<Int>
 
         val actual: PersistentHashSet<Int> =
-            set.minus(batchSet)
+            (set - batchSet)
                     as PersistentHashSet<Int>
 
         val expected: PersistentHashSet<Int> =

--- a/core/commonTest/src/contract/set/PersistentHashSetTest.kt
+++ b/core/commonTest/src/contract/set/PersistentHashSetTest.kt
@@ -35,51 +35,19 @@ class PersistentHashSetTest {
      * Test from issue: https://github.com/Kotlin/kotlinx.collections.immutable/issues/144
      */
     @Test
-    fun reproducer1() {
-        validate(
-            firstBatch = listOf(
-                0b0_00100_01110_01010,
-                0b0_00110_01110_01010,
-                0b0_01001_00101_00100,
-                0b0_00100_00101_00100
-            ),
-            secondBatch = listOf(
-                0b0_01110_01110_01010,
-                0b0_00001_00101_00100
-            ),
-            extraElement =
-                0b0_00111_01000_11010
-        )
-    }
+    fun `removing multiple batches should leave only remaining elements`() {
+        val firstBatch = listOf(4554, 9380, 4260, 6602)
+        val secondBatch = listOf(1188, 14794)
+        val extraElement = 7450
 
-    @Test
-    fun reproducer2() {
-        validate(
-            firstBatch = listOf(
-                0b0_00000_00000_00000,
-                0b0_00001_00000_00000,
-                0b0_00000_00000_00001,
-                0b0_00001_00000_00001,
-            ),
-            secondBatch = listOf(
-                0b0_00010_00000_00000,
-                0b0_00010_00000_00001
-            ),
-            extraElement =
-                0b0_00000_00000_00010
-        )
-    }
-
-    private fun validate(firstBatch: List<Int>, secondBatch: List<Int>, extraElement: Int) {
         val set = firstBatch.plus(secondBatch).plus(extraElement).toPersistentHashSet()
         val result = set.minus(firstBatch.toPersistentHashSet()).minus(secondBatch)
-
         assertEquals(1, result.size)
         assertEquals(extraElement, result.first())
     }
 
     @Test
-    fun equalsTest() {
+    fun `after removing elements from one collision the remaining one element must be promoted to the root`() {
         val set1: PersistentHashSet<Int> = persistentHashSetOf(0, 32768, 65536) as PersistentHashSet<Int>
         val set2: PersistentHashSet<Int> = persistentHashSetOf(0, 32768) as PersistentHashSet<Int>
 

--- a/core/commonTest/src/contract/set/PersistentHashSetTest.kt
+++ b/core/commonTest/src/contract/set/PersistentHashSetTest.kt
@@ -74,9 +74,13 @@ class PersistentHashSetTest {
         val hashSet = HashSet(firstBatch) + secondBatch + extraElement
         assertEquals(hashSet, set)
 
-        val result = set.minus(firstBatch.toPersistentHashSet()).minus(secondBatch)
+        val firstBatchSet = firstBatch.toPersistentHashSet()
+        val firstBatchHashSet: Set<Int> = HashSet(firstBatch)
+        assertEquals(firstBatchHashSet, firstBatchSet)
+
+        val result = set.minus(firstBatchSet).minus(secondBatch)
 
         assertEquals(1, result.size)
-//        assertEquals(extraElement, result.first())
+        assertEquals(extraElement, result.first())
     }
 }

--- a/core/commonTest/src/contract/set/PersistentHashSetTest.kt
+++ b/core/commonTest/src/contract/set/PersistentHashSetTest.kt
@@ -34,22 +34,45 @@ class PersistentHashSetTest {
      * Test from issue: https://github.com/Kotlin/kotlinx.collections.immutable/issues/144
      */
     @Test
-    fun reproducer() {
-        val firstBatch = listOf(
-            0b0_00100_01110_01010,
-            0b0_00110_01110_01010,
-            0b0_01001_00101_00100,
-            0b0_00100_00101_00100
+    fun reproducer1() {
+        validate(
+            firstBatch = listOf(
+                0b0_00100_01110_01010,
+                0b0_00110_01110_01010,
+                0b0_01001_00101_00100,
+                0b0_00100_00101_00100
+            ),
+            secondBatch = listOf(
+                0b0_01110_01110_01010,
+                0b0_00001_00101_00100
+            ),
+            extraElement =
+                0b0_00111_01000_11010
         )
-        val secondBatch = listOf(
-            0b0_00001_00101_00100,
-            0b0_01110_01110_01010
-        )
-        val extraElement =
-            0b0_00111_01000_11010
+    }
 
+    @Test
+    fun reproducer2() {
+        validate(
+            firstBatch = listOf(
+                0b0_00000_00000_00000,
+                0b0_00001_00000_00000,
+                0b0_00000_00000_00001,
+                0b0_00001_00000_00001,
+            ),
+            secondBatch = listOf(
+                0b0_00010_00000_00000,
+                0b0_00010_00000_00001
+            ),
+            extraElement =
+                0b0_00000_00000_00010
+        )
+    }
+
+    private fun validate(firstBatch: List<Int>, secondBatch: List<Int>, extraElement: Int) {
         val set = firstBatch.plus(secondBatch).plus(extraElement).toPersistentHashSet()
         val result = set.minus(firstBatch.toPersistentHashSet()).minus(secondBatch)
+
         assertEquals(1, result.size)
         assertEquals(extraElement, result.first())
     }

--- a/core/commonTest/src/contract/set/PersistentHashSetTest.kt
+++ b/core/commonTest/src/contract/set/PersistentHashSetTest.kt
@@ -82,9 +82,7 @@ class PersistentHashSetTest {
     fun equalsTest() {
         val firstBatch = listOf(
             0b0_00000_00000_00000,
-            0b0_00001_00000_00000,
-            0b0_00000_00000_00001,
-            0b0_00001_00000_00001,
+            0b0_00001_00000_00000
         )
         val secondBatch = listOf(
             0b0_00010_00000_00000,

--- a/core/commonTest/src/contract/set/PersistentHashSetTest.kt
+++ b/core/commonTest/src/contract/set/PersistentHashSetTest.kt
@@ -35,9 +35,18 @@ class PersistentHashSetTest {
      */
     @Test
     fun reproducer() {
-        val firstBatch = listOf(4554, 9380, 4260, 6602)
-        val secondBatch = listOf(1188, 14794)
-        val extraElement = 7450
+        val firstBatch = listOf(
+            0b0_00100_01110_01010,
+            0b0_00110_01110_01010,
+            0b0_01001_00101_00100,
+            0b0_00100_00101_00100
+        )
+        val secondBatch = listOf(
+            0b0_00001_00101_00100,
+            0b0_01110_01110_01010
+        )
+        val extraElement =
+            0b0_00111_01000_11010
 
         val set = firstBatch.plus(secondBatch).plus(extraElement).toPersistentHashSet()
         val result = set.minus(firstBatch.toPersistentHashSet()).minus(secondBatch)

--- a/core/commonTest/src/contract/set/PersistentHashSetTest.kt
+++ b/core/commonTest/src/contract/set/PersistentHashSetTest.kt
@@ -80,28 +80,11 @@ class PersistentHashSetTest {
 
     @Test
     fun equalsTest() {
-        val batch = listOf(
-            0b0_00000_00000_00000,
-            0b0_00001_00000_00000
-        )
-        val singleElement =
-            0b0_00010_00000_00000
+        val set1: PersistentHashSet<Int> = persistentHashSetOf(0, 32768, 65536) as PersistentHashSet<Int>
+        val set2: PersistentHashSet<Int> = persistentHashSetOf(0, 32768) as PersistentHashSet<Int>
 
-        val set: PersistentHashSet<Int> =
-            (batch + singleElement).toPersistentHashSet()
-                    as PersistentHashSet<Int>
-
-        val batchSet: PersistentHashSet<Int> =
-            batch.toPersistentHashSet()
-                    as PersistentHashSet<Int>
-
-        val actual: PersistentHashSet<Int> =
-            (set - batchSet)
-                    as PersistentHashSet<Int>
-
-        val expected: PersistentHashSet<Int> =
-            persistentHashSetOf(singleElement)
-                    as PersistentHashSet<Int>
+        val expected = persistentHashSetOf(65536)
+        val actual = set1 - set2
 
         assertEquals(expected, actual)
     }

--- a/core/commonTest/src/contract/set/PersistentHashSetTest.kt
+++ b/core/commonTest/src/contract/set/PersistentHashSetTest.kt
@@ -5,6 +5,7 @@
 
 package tests.contract.set
 
+import kotlinx.collections.immutable.implementations.immutableSet.PersistentHashSet
 import kotlinx.collections.immutable.persistentHashSetOf
 import kotlinx.collections.immutable.minus
 import kotlinx.collections.immutable.toPersistentHashSet
@@ -70,17 +71,15 @@ class PersistentHashSetTest {
     }
 
     private fun validate(firstBatch: List<Int>, secondBatch: List<Int>, extraElement: Int) {
-        val set = firstBatch.plus(secondBatch).plus(extraElement).toPersistentHashSet()
-        val hashSet = HashSet(firstBatch) + secondBatch + extraElement
-        assertEquals(hashSet, set)
+        val set: PersistentHashSet<Int> =
+            firstBatch.plus(secondBatch).plus(extraElement).toPersistentHashSet()
+                    as PersistentHashSet<Int>
 
         val firstBatchSet = firstBatch.toPersistentHashSet()
-        val firstBatchHashSet: Set<Int> = HashSet(firstBatch)
-        assertEquals(firstBatchHashSet, firstBatchSet)
 
-        val result = set.minus(firstBatchSet).minus(secondBatch)
+        val actual = set.minus(firstBatchSet).minus(secondBatch)
+        val expected = persistentHashSetOf(extraElement)
 
-        assertEquals(1, result.size)
-        assertEquals(extraElement, result.first())
+        assertEquals(expected, actual)
     }
 }

--- a/core/commonTest/src/contract/set/PersistentHashSetTest.kt
+++ b/core/commonTest/src/contract/set/PersistentHashSetTest.kt
@@ -71,9 +71,12 @@ class PersistentHashSetTest {
 
     private fun validate(firstBatch: List<Int>, secondBatch: List<Int>, extraElement: Int) {
         val set = firstBatch.plus(secondBatch).plus(extraElement).toPersistentHashSet()
+        val hashSet = HashSet(firstBatch) + secondBatch + extraElement
+        assertEquals(hashSet, set)
+
         val result = set.minus(firstBatch.toPersistentHashSet()).minus(secondBatch)
 
         assertEquals(1, result.size)
-        assertEquals(extraElement, result.first())
+//        assertEquals(extraElement, result.first())
     }
 }


### PR DESCRIPTION
If after removing elements from one collision there is one element left, it should be promoted up recursively, but because the `realBitMap == bitmap` check is above the `realSize == 1 && shift != 0` check (and the first check always passes if the removal does not happen at this step of the recursion), the promotion only happens 1 level up. I swapped these checks, now everything works correctly. Also, I've added a simpler test that reproduces this issue.