### PR TITLE
Release v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # CHANGELOG
 
+## 0.3.9
+
+- Fixed the equality bug in PersistentMap — Added proper node promotion during mutable operations to ensure a consistent internal tree structure [#217](https://github.com/Kotlin/kotlinx.collections.immutable/pull/217)
+- Fixed the bug in PersistentMap equals implementation — Ensured proper node promotion during mutable key removal even when nodes share the same owner [#218](https://github.com/Kotlin/kotlinx.collections.immutable/pull/218)
+- Fixed the ghost element issue in PersistentHashSet — Corrected condition check order to ensure proper recursive element promotion after collision removal [#219](https://github.com/Kotlin/kotlinx.collections.immutable/pull/219)
+- Updated Kotlin to version 2.1.20 and core dependencies [#213](https://github.com/Kotlin/kotlinx.collections.immutable/pull/213)
+- Enabled '-Xjvm-default=disable' explicitly to prevent API dump changes [#210](https://github.com/Kotlin/kotlinx.collections.immutable/pull/210)
+
 ## 0.3.8
 
 - Add extension functions to convert Array to persistent collections [#159](https://github.com/Kotlin/kotlinx.collections.immutable/issues/159)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-## 0.3.9
+## 0.4
 
 - Fixed the equality bug in PersistentMap — Added proper node promotion during mutable operations to ensure a consistent internal tree structure [#217](https://github.com/Kotlin/kotlinx.collections.immutable/pull/217)
 - Fixed the bug in PersistentMap equals implementation — Ensured proper node promotion during mutable key removal even when nodes share the same owner [#218](https://github.com/Kotlin/kotlinx.collections.immutable/pull/218)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-## 0.4
+## 0.4.0
 
 - Fixed the equality bug in PersistentMap — Added proper node promotion during mutable operations to ensure a consistent internal tree structure [#217](https://github.com/Kotlin/kotlinx.collections.immutable/pull/217)
 - Fixed the bug in PersistentMap equals implementation — Ensured proper node promotion during mutable key removal even when nodes share the same owner [#218](https://github.com/Kotlin/kotlinx.collections.immutable/pull/218)

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ kotlin {
     sourceSets {
         commonMain {
              dependencies {
-                 implementation("org.jetbrains.kotlinx:kotlinx-collections-immutable:0.3.8")
+                 implementation("org.jetbrains.kotlinx:kotlinx-collections-immutable:0.3.9")
              }
         }
     }
@@ -155,7 +155,7 @@ Add dependencies (you can also add other modules that you need):
 <dependency>
     <groupId>org.jetbrains.kotlinx</groupId>
     <artifactId>kotlinx-collections-immutable-jvm</artifactId>
-    <version>0.3.8</version>
+    <version>0.3.9</version>
 </dependency>
 ```
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 [![GitHub license](https://img.shields.io/github/license/kotlin/kotlinx.collections.immutable)](LICENSE.txt) 
 [![Build status](https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:KotlinTools_KotlinxCollectionsImmutable_Build_All)/statusIcon.svg)](https://teamcity.jetbrains.com/viewType.html?buildTypeId=KotlinTools_KotlinxCollectionsImmutable_Build_All)
 [![Maven Central](https://img.shields.io/maven-central/v/org.jetbrains.kotlinx/kotlinx-collections-immutable.svg?label=Maven%20Central)](https://central.sonatype.com/artifact/org.jetbrains.kotlinx/kotlinx-collections-immutable)
+[![Kotlin](https://img.shields.io/badge/kotlin-2.1.20-blue.svg?logo=kotlin)](http://kotlinlang.org)
+
 
 Immutable collection interfaces and implementation prototypes for Kotlin.
 

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ kotlin {
     sourceSets {
         commonMain {
              dependencies {
-                 implementation("org.jetbrains.kotlinx:kotlinx-collections-immutable:0.3.9")
+                 implementation("org.jetbrains.kotlinx:kotlinx-collections-immutable:0.4")
              }
         }
     }
@@ -155,7 +155,7 @@ Add dependencies (you can also add other modules that you need):
 <dependency>
     <groupId>org.jetbrains.kotlinx</groupId>
     <artifactId>kotlinx-collections-immutable-jvm</artifactId>
-    <version>0.3.9</version>
+    <version>0.4</version>
 </dependency>
 ```
 

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ collection.mutate { some_actions_on(it) }
 
 The library is published to Maven Central repository.
 
-The library depends on the Kotlin Standard Library of the version at least `1.9.21`.
+The library depends on the Kotlin Standard Library of the version at least `2.1.20`.
 
 ### Gradle
 

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ kotlin {
     sourceSets {
         commonMain {
              dependencies {
-                 implementation("org.jetbrains.kotlinx:kotlinx-collections-immutable:0.4")
+                 implementation("org.jetbrains.kotlinx:kotlinx-collections-immutable:0.4.0")
              }
         }
     }
@@ -155,7 +155,7 @@ Add dependencies (you can also add other modules that you need):
 <dependency>
     <groupId>org.jetbrains.kotlinx</groupId>
     <artifactId>kotlinx-collections-immutable-jvm</artifactId>
-    <version>0.4</version>
+    <version>0.4.0</version>
 </dependency>
 ```
 


### PR DESCRIPTION
Add a badge with a Kotlin version.
If I understand correctly, the library version in the Readme will be updated automatically after publishing to maven central.

## 0.4.0

- Fixed the equality bug in PersistentMap — Added proper node promotion during mutable operations to ensure a consistent internal tree structure [#217](https://github.com/Kotlin/kotlinx.collections.immutable/pull/217)
- Fixed the bug in PersistentMap equals implementation — Ensured proper node promotion during mutable key removal even when nodes share the same owner [#218](https://github.com/Kotlin/kotlinx.collections.immutable/pull/218)
- Fixed the ghost element issue in PersistentHashSet — Corrected condition check order to ensure proper recursive element promotion after collision removal [#219](https://github.com/Kotlin/kotlinx.collections.immutable/pull/219)
- Updated Kotlin to version 2.1.20 and core dependencies [#213](https://github.com/Kotlin/kotlinx.collections.immutable/pull/213)
- Enabled '-Xjvm-default=disable' explicitly to prevent API dump changes [#210](https://github.com/Kotlin/kotlinx.collections.immutable/pull/210)