### PR TITLE
Enable Kotlin Power Assert plugin

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
 
 buildscript {
     dependencies {
-        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:${rootProject.properties["kotlin_version"]}")
+        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:${rootProject.properties["kotlinVersion"]}")
     }
 }
 

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -6,6 +6,7 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     id("kotlin-multiplatform")
+    id("org.jetbrains.kotlin.plugin.power-assert")
     id("org.jetbrains.dokka")
     `maven-publish`
 }
@@ -144,6 +145,19 @@ kotlin {
         val nativeTest by getting {
         }
     }
+}
+
+@OptIn(ExperimentalKotlinGradlePluginApi::class)
+powerAssert {
+    functions = listOf(
+        "kotlin.check",
+        "kotlin.test.assertTrue",
+        "kotlin.test.assertEquals",
+        "kotlin.test.assertNotEquals",
+        "kotlin.test.assertNull",
+        "kotlin.test.assertNotNull",
+        "kotlin.test.assertFalse",
+    )
 }
 
 dependencies {

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -152,11 +152,11 @@ powerAssert {
     functions = listOf(
         "kotlin.check",
         "kotlin.test.assertTrue",
+        "kotlin.test.assertFalse",
         "kotlin.test.assertEquals",
         "kotlin.test.assertNotEquals",
         "kotlin.test.assertNull",
-        "kotlin.test.assertNotNull",
-        "kotlin.test.assertFalse",
+        "kotlin.test.assertNotNull"
     )
 }
 

--- a/core/commonTest/src/stress/list/PersistentListBuilderTest.kt
+++ b/core/commonTest/src/stress/list/PersistentListBuilderTest.kt
@@ -31,11 +31,11 @@ class PersistentListBuilderTest : ExecutionTimeMeasuringTest() {
         val elements = distinctStringValues(elementsToAdd)
         repeat(times = elementsToAdd) { index ->
             builder.add(elements[index])
-            check(!builder.isEmpty())
+            check(builder.isNotEmpty())
         }
         repeat(times = elementsToAdd - 1) {
             builder.removeAt(builder.size - 1)
-            check(!builder.isEmpty())
+            check(builder.isNotEmpty())
         }
         builder.removeAt(builder.size - 1)
         assertTrue(builder.isEmpty())

--- a/core/commonTest/src/stress/list/PersistentListBuilderTest.kt
+++ b/core/commonTest/src/stress/list/PersistentListBuilderTest.kt
@@ -31,11 +31,11 @@ class PersistentListBuilderTest : ExecutionTimeMeasuringTest() {
         val elements = distinctStringValues(elementsToAdd)
         repeat(times = elementsToAdd) { index ->
             builder.add(elements[index])
-            assertFalse(builder.isEmpty())
+            check(!builder.isEmpty())
         }
         repeat(times = elementsToAdd - 1) {
             builder.removeAt(builder.size - 1)
-            assertFalse(builder.isEmpty())
+            check(!builder.isEmpty())
         }
         builder.removeAt(builder.size - 1)
         assertTrue(builder.isEmpty())
@@ -51,11 +51,11 @@ class PersistentListBuilderTest : ExecutionTimeMeasuringTest() {
 
         repeat(times = elementsToAdd) { index ->
             builder.add(index)
-            assertEquals(index + 1, builder.size)
+            check(index + 1 == builder.size)
         }
         repeat(times = elementsToAdd) { index ->
             builder.removeAt(builder.size - 1)
-            assertEquals(elementsToAdd - index - 1, builder.size)
+            check(elementsToAdd - index - 1 == builder.size)
         }
     }
 
@@ -70,10 +70,10 @@ class PersistentListBuilderTest : ExecutionTimeMeasuringTest() {
 
         repeat(times = elementsToAdd) { index ->
             builder.add(0, index)
-            assertEquals(index, builder.first())
+            check(index == builder.first())
         }
         repeat(times = elementsToAdd) { index ->
-            assertEquals(elementsToAdd - index - 1, builder.first())
+            check(elementsToAdd - index - 1 == builder.first())
             builder.removeAt(0)
         }
         assertNull(builder.firstOrNull())
@@ -89,10 +89,10 @@ class PersistentListBuilderTest : ExecutionTimeMeasuringTest() {
 
         repeat(times = elementsToAdd) { index ->
             builder.add(index)
-            assertEquals(index, builder.last())
+            check(index == builder.last())
         }
         repeat(times = elementsToAdd) { index ->
-            assertEquals(elementsToAdd - index - 1, builder.last())
+            check(elementsToAdd - index - 1 == builder.last())
             builder.removeAt(builder.size - 1)
         }
         assertNull(builder.lastOrNull())
@@ -110,7 +110,7 @@ class PersistentListBuilderTest : ExecutionTimeMeasuringTest() {
         repeat(times = elementsToAdd) { index ->
             list.add(index)
             builder.add(index)
-            assertEquals<List<*>>(list, builder.toList())
+            check(list == builder.toList())
         }
     }
 
@@ -127,12 +127,12 @@ class PersistentListBuilderTest : ExecutionTimeMeasuringTest() {
         repeat(times = elementsToAdd) { index ->
             builder.add(0, index)
 
-            assertEquals(index, builder.first())
-            assertEquals(0, builder.last())
-            assertEquals(index + 1, builder.size)
+            check(index == builder.first())
+            check(0 == builder.last())
+            check(index + 1 == builder.size)
 
             val expectedContent = allElements.subList(elementsToAdd - builder.size, elementsToAdd)
-            assertEquals(expectedContent, builder)
+            check(expectedContent == builder)
         }
     }
 
@@ -146,10 +146,10 @@ class PersistentListBuilderTest : ExecutionTimeMeasuringTest() {
         repeat(times = elementsToAdd) { index ->
             builder.add(index)
 
-            assertEquals(0, builder[0])
-            assertEquals(index, builder[index])
-            assertEquals(index + 1, builder.size)
-            assertEquals(allElements.subList(0, builder.size), builder)
+            check(0 == builder[0])
+            check(index == builder[index])
+            check(index + 1 == builder.size)
+            check(allElements.subList(0, builder.size) == builder)
         }
     }
 
@@ -167,10 +167,10 @@ class PersistentListBuilderTest : ExecutionTimeMeasuringTest() {
             builder.add(index)
         }
         repeat(times = elementsToAdd) { index ->
-            assertEquals(elementsToAdd - 1, builder.last())
-            assertEquals(index, builder.first())
-            assertEquals(elementsToAdd - index, builder.size)
-            assertEquals(allElements.subList(index, elementsToAdd), builder)
+            check(elementsToAdd - 1 == builder.last())
+            check(index == builder.first())
+            check(elementsToAdd - index == builder.size)
+            check(allElements.subList(index, elementsToAdd) == builder)
 
             builder.removeAt(0)
         }
@@ -191,10 +191,10 @@ class PersistentListBuilderTest : ExecutionTimeMeasuringTest() {
             builder.add(0, index)
         }
         repeat(times = elementsToAdd) { index ->
-            assertEquals(index, builder.last())
-            assertEquals(elementsToAdd - 1, builder.first())
-            assertEquals(elementsToAdd - index, builder.size)
-            assertEquals(allElements.subList(0, builder.size), builder)
+            check(index == builder.last())
+            check(elementsToAdd - 1 == builder.first())
+            check(elementsToAdd - index == builder.size)
+            check(allElements.subList(0, builder.size) == builder)
 
             builder.removeAt(builder.size - 1)
         }
@@ -205,9 +205,9 @@ class PersistentListBuilderTest : ExecutionTimeMeasuringTest() {
             builder.add(index)
         }
         repeat(times = linear) { index ->
-            assertEquals(linear - 1 - index, builder.last())
-            assertEquals(0, builder.first())
-            assertEquals(linear - index, builder.size)
+            check(linear - 1 - index == builder.last())
+            check(0 == builder.first())
+            check(linear - index == builder.size)
 
             builder.removeAt(builder.size - 1)
         }
@@ -227,12 +227,12 @@ class PersistentListBuilderTest : ExecutionTimeMeasuringTest() {
             builder.add(index)
 
             for (i in 0..index) {
-                assertEquals(i, builder[i])
+                check(i == builder[i])
             }
         }
         repeat(times = elementsToAdd) { index ->
             for (i in index until elementsToAdd) {
-                assertEquals(i, builder[i - index])
+                check(i == builder[i - index])
             }
 
             builder.removeAt(0)
@@ -253,18 +253,18 @@ class PersistentListBuilderTest : ExecutionTimeMeasuringTest() {
             builder.add(index * 2)
 
             for (i in 0..index) {
-                assertEquals(i + index, builder[i])
+                check(i + index == builder[i])
                 builder[i] = i + index + 1
-                assertEquals(i + index + 1, builder[i])
+                check(i + index + 1 == builder[i])
             }
         }
         repeat(times = elementsToAdd) { index ->
             for (i in 0 until elementsToAdd - index) {
                 val expected = elementsToAdd + i
 
-                assertEquals(expected, builder[i])
+                check(expected == builder[i])
                 builder[i] = expected - 1
-                assertEquals(expected - 1, builder[i])
+                check(expected - 1 == builder[i])
             }
 
             builder.removeAt(0)
@@ -323,14 +323,14 @@ class PersistentListBuilderTest : ExecutionTimeMeasuringTest() {
         if (towardStart) {
             repeat(iterationCount) {
                 if (!expectedIterator.hasPrevious()) return
-                assertEquals(expectedIterator.previous(), actualIterator.previous())
+                check(expectedIterator.previous() == actualIterator.previous())
                 afterIteration()
                 compare(expectedIterator, actualIterator) { listIteratorProperties() }
             }
         } else {
             repeat(iterationCount) {
                 if (!expectedIterator.hasNext()) return
-                assertEquals(expectedIterator.next(), actualIterator.next())
+                check(expectedIterator.next() == actualIterator.next())
                 afterIteration()
                 compare(expectedIterator, actualIterator) { listIteratorProperties() }
             }
@@ -518,7 +518,7 @@ class PersistentListBuilderTest : ExecutionTimeMeasuringTest() {
                     val builder = list.builder().also { it.addAll(index, elementsToAdd) }
 
                     val expected = initialElements.toMutableList().also { it.addAll(index, elementsToAdd) }
-                    assertEquals(expected, builder)
+                    check(expected == builder)
                 }
             }
         }
@@ -565,8 +565,8 @@ class PersistentListBuilderTest : ExecutionTimeMeasuringTest() {
                     it.removeAll { e -> hashSet.contains(e) }
                 }
 
-                assertEquals(expected, builder)
-                assertEquals(expected, builderPredicate)
+                check(expected == builder)
+                check(expected == builderPredicate)
             }
         }
     }
@@ -595,14 +595,14 @@ class PersistentListBuilderTest : ExecutionTimeMeasuringTest() {
                 val shouldSet = operationType > 0.15 && operationType < 0.3
 
                 if (list.isNotEmpty() && shouldRemove) {
-                    assertEquals(
-                            list.removeAt(operationIndex),
+                    check(
+                            list.removeAt(operationIndex) ==
                             builder.removeAt(operationIndex)
                     )
                 } else if (list.isNotEmpty() && shouldSet) {
                     val value = Random.nextInt()
-                    assertEquals(
-                            list.set(operationIndex, value),
+                    check(
+                            list.set(operationIndex, value) ==
                             builder.set(operationIndex, value)
                     )
 
@@ -638,19 +638,19 @@ class PersistentListBuilderTest : ExecutionTimeMeasuringTest() {
     }
 
     private fun testAfterOperation(list1: List<Int>, list2: List<Int>, operationIndex: Int) {
-        assertEquals(list1.firstOrNull(), list2.firstOrNull())
-        assertEquals(list1.lastOrNull(), list2.lastOrNull())
-        assertEquals(list1.size, list2.size)
+        check(list1.firstOrNull() == list2.firstOrNull())
+        check(list1.lastOrNull() == list2.lastOrNull())
+        check(list1.size == list2.size)
         if (operationIndex < list1.size) {
-            assertEquals(list1[operationIndex], list2[operationIndex])
+            check(list1[operationIndex] == list2[operationIndex])
         }
         if (operationIndex > 0) {
-            assertEquals(list1[operationIndex - 1], list2[operationIndex - 1])
+            check(list1[operationIndex - 1] == list2[operationIndex - 1])
         }
         if (operationIndex + 1 < list1.size) {
-            assertEquals(list1[operationIndex + 1], list2[operationIndex + 1])
+            check(list1[operationIndex + 1] == list2[operationIndex + 1])
         }
 
-//        assertEquals(list1, list2)
+//        check(list1 == list2)
     }
 }

--- a/core/commonTest/src/stress/list/PersistentListTest.kt
+++ b/core/commonTest/src/stress/list/PersistentListTest.kt
@@ -27,11 +27,11 @@ class PersistentListTest : ExecutionTimeMeasuringTest() {
         val elements = distinctStringValues(elementsToAdd)
         repeat(times = elementsToAdd) { index ->
             vector = vector.add(elements[index])
-            assertFalse(vector.isEmpty())
+            check(!vector.isEmpty())
         }
         repeat(times = elementsToAdd - 1) {
             vector = vector.removeAt(vector.size - 1)
-            assertFalse(vector.isEmpty())
+            check(!vector.isEmpty())
         }
         vector = vector.removeAt(vector.size - 1)
         assertTrue(vector.isEmpty())
@@ -48,11 +48,11 @@ class PersistentListTest : ExecutionTimeMeasuringTest() {
 
         repeat(times = elementsToAdd) { index ->
             vector = vector.add(index)
-            assertEquals(index + 1, vector.size)
+            check(index + 1 == vector.size)
         }
         repeat(times = elementsToAdd) { index ->
             vector = vector.removeAt(vector.size - 1)
-            assertEquals(elementsToAdd - index - 1, vector.size)
+            check(elementsToAdd - index - 1 == vector.size)
         }
     }
 
@@ -69,10 +69,10 @@ class PersistentListTest : ExecutionTimeMeasuringTest() {
 
         repeat(times = elementsToAdd) { index ->
             vector = vector.add(0, index)
-            assertEquals(index, vector.first())
+            check(index == vector.first())
         }
         repeat(times = elementsToAdd) { index ->
-            assertEquals(elementsToAdd - index - 1, vector.first())
+            check(elementsToAdd - index - 1 == vector.first())
             vector = vector.removeAt(0)
         }
         assertNull(vector.firstOrNull())
@@ -90,10 +90,10 @@ class PersistentListTest : ExecutionTimeMeasuringTest() {
 
         repeat(times = elementsToAdd) { index ->
             vector = vector.add(index)
-            assertEquals(index, vector.last())
+            check(index == vector.last())
         }
         repeat(times = elementsToAdd) { index ->
-            assertEquals(elementsToAdd - index - 1, vector.last())
+            check(elementsToAdd - index - 1 == vector.last())
             vector = vector.removeAt(vector.size - 1)
         }
         assertNull(vector.lastOrNull())
@@ -130,7 +130,7 @@ class PersistentListTest : ExecutionTimeMeasuringTest() {
         repeat(times = elementsToAdd) { index ->
             list.add(index)
             vector = vector.add(index)
-            assertEquals(list, vector.toList())
+            check(list == vector.toList())
         }
     }
 
@@ -149,12 +149,12 @@ class PersistentListTest : ExecutionTimeMeasuringTest() {
         repeat(times = elementsToAdd) { index ->
             vector = vector.add(0, index)
 
-            assertEquals(index, vector.first())
-            assertEquals(0, vector.last())
-            assertEquals(index + 1, vector.size)
+            check(index == vector.first())
+            check(0 == vector.last())
+            check(index + 1 == vector.size)
 
             val expectedContent = allElements.subList(elementsToAdd - vector.size, elementsToAdd)
-            assertEquals(expectedContent, vector.toList())
+            check(expectedContent == vector.toList())
         }
     }
 
@@ -170,11 +170,11 @@ class PersistentListTest : ExecutionTimeMeasuringTest() {
         repeat(times = elementsToAdd) { index ->
             vector = vector.add(index)
 
-            assertEquals(0, vector[0])
-            assertEquals(index, vector[index])
-            assertEquals(index + 1, vector.size)
+            check(0 == vector[0])
+            check(index == vector[index])
+            check(index + 1 == vector.size)
 
-            assertEquals(allElements.subList(0, vector.size), vector)
+            check(allElements.subList(0, vector.size) == vector)
         }
     }
 
@@ -196,10 +196,10 @@ class PersistentListTest : ExecutionTimeMeasuringTest() {
             vector = vector.add(index)
         }
         repeat(times = elementsToAdd) { index ->
-            assertEquals(elementsToAdd - 1, vector.last())
-            assertEquals(index, vector.first())
-            assertEquals(elementsToAdd - index, vector.size)
-            assertEquals(allElements.subList(index, elementsToAdd), vector)
+            check(elementsToAdd - 1 == vector.last())
+            check(index == vector.first())
+            check(elementsToAdd - index == vector.size)
+            check(allElements.subList(index, elementsToAdd) == vector)
 
             vector = vector.removeAt(0)
         }
@@ -222,10 +222,10 @@ class PersistentListTest : ExecutionTimeMeasuringTest() {
             vector = vector.add(0, index)
         }
         repeat(times = elementsToAdd) { index ->
-            assertEquals(index, vector.last())
-            assertEquals(elementsToAdd - 1, vector.first())
-            assertEquals(elementsToAdd - index, vector.size)
-            assertEquals(allElements.subList(0, vector.size), vector)
+            check(index == vector.last())
+            check(elementsToAdd - 1 == vector.first())
+            check(elementsToAdd - index == vector.size)
+            check(allElements.subList(0, vector.size) == vector)
 
             vector = vector.removeAt(vector.size - 1)
         }
@@ -236,9 +236,9 @@ class PersistentListTest : ExecutionTimeMeasuringTest() {
             vector = vector.add(index)
         }
         repeat(times = linear) { index ->
-            assertEquals(linear - 1 - index, vector.last())
-            assertEquals(0, vector.first())
-            assertEquals(linear - index, vector.size)
+            check(linear - 1 - index == vector.last())
+            check(0 == vector.first())
+            check(linear - index == vector.size)
 
             vector = vector.removeAt(vector.size - 1)
         }
@@ -259,12 +259,12 @@ class PersistentListTest : ExecutionTimeMeasuringTest() {
             vector = vector.add(index)
 
             for (i in 0..index) {
-                assertEquals(i, vector[i])
+                check(i == vector[i])
             }
         }
         repeat(times = elementsToAdd) { index ->
             for (i in index until elementsToAdd) {
-                assertEquals(i, vector[i - index])
+                check(i == vector[i - index])
             }
 
             vector = vector.removeAt(0)
@@ -286,18 +286,18 @@ class PersistentListTest : ExecutionTimeMeasuringTest() {
             vector = vector.add(index * 2)
 
             for (i in 0..index) {
-                assertEquals(i + index, vector[i])
+                check(i + index == vector[i])
                 vector = vector.set(i, i + index + 1)
-                assertEquals(i + index + 1, vector[i])
+                check(i + index + 1 == vector[i])
             }
         }
         repeat(times = elementsToAdd) { index ->
             for (i in 0 until elementsToAdd - index) {
                 val expected = elementsToAdd + i
 
-                assertEquals(expected, vector[i])
+                check(expected == vector[i])
                 vector = vector.set(i, expected - 1)
-                assertEquals(expected - 1, vector[i])
+                check(expected - 1 == vector[i])
             }
 
             vector = vector.removeAt(0)
@@ -342,7 +342,7 @@ class PersistentListTest : ExecutionTimeMeasuringTest() {
                     val result = list.addAll(index, elementsToAdd)
 
                     val expected = initialElements.toMutableList().also { it.addAll(index, elementsToAdd) }
-                    assertEquals<List<*>>(expected, result)
+                    check(expected == result)
                 }
             }
         }
@@ -398,8 +398,8 @@ class PersistentListTest : ExecutionTimeMeasuringTest() {
                     it.removeAll { e -> hashSet.contains(e) }
                 }
 
-                assertEquals<List<*>>(expected, result)
-                assertEquals<List<*>>(expected, resultPredicate)
+                check(expected == result)
+                check(expected == resultPredicate)
             }
         }
     }
@@ -462,19 +462,19 @@ class PersistentListTest : ExecutionTimeMeasuringTest() {
     }
 
     private fun testAfterOperation(list: List<Int>, vector: PersistentList<Int>, operationIndex: Int) {
-        assertEquals(list.firstOrNull(), vector.firstOrNull())
-        assertEquals(list.lastOrNull(), vector.lastOrNull())
-        assertEquals(list.size, vector.size)
+        check(list.firstOrNull() == vector.firstOrNull())
+        check(list.lastOrNull() == vector.lastOrNull())
+        check(list.size == vector.size)
         if (operationIndex < list.size) {
-            assertEquals(list[operationIndex], vector[operationIndex])
+            check(list[operationIndex] == vector[operationIndex])
         }
         if (operationIndex > 0) {
-            assertEquals(list[operationIndex - 1], vector[operationIndex - 1])
+            check(list[operationIndex - 1] == vector[operationIndex - 1])
         }
         if (operationIndex + 1 < list.size) {
-            assertEquals(list[operationIndex + 1], vector[operationIndex + 1])
+            check(list[operationIndex + 1] == vector[operationIndex + 1])
         }
 
-//        assertEquals(list, vector)
+//        check(list == vector)
     }
 }

--- a/core/commonTest/src/stress/list/PersistentListTest.kt
+++ b/core/commonTest/src/stress/list/PersistentListTest.kt
@@ -27,11 +27,11 @@ class PersistentListTest : ExecutionTimeMeasuringTest() {
         val elements = distinctStringValues(elementsToAdd)
         repeat(times = elementsToAdd) { index ->
             vector = vector.add(elements[index])
-            check(!vector.isEmpty())
+            check(vector.isNotEmpty())
         }
         repeat(times = elementsToAdd - 1) {
             vector = vector.removeAt(vector.size - 1)
-            check(!vector.isEmpty())
+            check(vector.isNotEmpty())
         }
         vector = vector.removeAt(vector.size - 1)
         assertTrue(vector.isEmpty())

--- a/core/commonTest/src/stress/map/PersistentHashMapBuilderTest.kt
+++ b/core/commonTest/src/stress/map/PersistentHashMapBuilderTest.kt
@@ -29,11 +29,11 @@ class PersistentHashMapBuilderTest : ExecutionTimeMeasuringTest() {
         val values = distinctStringValues(elementsToAdd)
         repeat(times = elementsToAdd) { index ->
             builder[index] = values[index]
-            check(!builder.isEmpty())
+            check(builder.isNotEmpty())
         }
         repeat(times = elementsToAdd - 1) {
             builder.remove(builder.size - 1)
-            check(!builder.isEmpty())
+            check(builder.isNotEmpty())
         }
         builder.remove(builder.size - 1)
         assertTrue(builder.isEmpty())

--- a/core/commonTest/src/stress/map/PersistentHashMapBuilderTest.kt
+++ b/core/commonTest/src/stress/map/PersistentHashMapBuilderTest.kt
@@ -29,11 +29,11 @@ class PersistentHashMapBuilderTest : ExecutionTimeMeasuringTest() {
         val values = distinctStringValues(elementsToAdd)
         repeat(times = elementsToAdd) { index ->
             builder[index] = values[index]
-            assertFalse(builder.isEmpty())
+            check(!builder.isEmpty())
         }
         repeat(times = elementsToAdd - 1) {
             builder.remove(builder.size - 1)
-            assertFalse(builder.isEmpty())
+            check(!builder.isEmpty())
         }
         builder.remove(builder.size - 1)
         assertTrue(builder.isEmpty())
@@ -48,21 +48,21 @@ class PersistentHashMapBuilderTest : ExecutionTimeMeasuringTest() {
         val elementsToAdd = NForAlgorithmComplexity.O_NlogN
 
         repeat(times = elementsToAdd) { index ->
-            assertNull(builder.put(index, index))
-            assertEquals(index + 1, builder.size)
+            check(builder.put(index, index) == null)
+            check(index + 1 == builder.size)
 
-            assertEquals(index, builder.put(index, 7))
-            assertEquals(index + 1, builder.size)
+            check(index == builder.put(index, 7))
+            check(index + 1 == builder.size)
 
-            assertEquals(7, builder.put(index, index))
-            assertEquals(index + 1, builder.size)
+            check(7 == builder.put(index, index))
+            check(index + 1 == builder.size)
         }
         repeat(times = elementsToAdd) { index ->
-            assertEquals(index, builder.remove(index))
-            assertEquals(elementsToAdd - index - 1, builder.size)
+            check(index == builder.remove(index))
+            check(elementsToAdd - index - 1 == builder.size)
 
-            assertNull(builder.remove(index))
-            assertEquals(elementsToAdd - index - 1, builder.size)
+            check(builder.remove(index) == null)
+            check(elementsToAdd - index - 1 == builder.size)
         }
     }
 
@@ -73,14 +73,14 @@ class PersistentHashMapBuilderTest : ExecutionTimeMeasuringTest() {
             val keys = actualBuilder.keys
             val entries = actualBuilder.entries
 
-            assertTrue(listOf(values.size, keys.size, entries.size).all { it == expectedKeys.size })
+            check(listOf(values.size, keys.size, entries.size).all { it == expectedKeys.size })
 
-            assertEquals<Set<*>>(expectedKeys, keys)
-            assertTrue(keys.containsAll(values))
+            check(expectedKeys == keys)
+            check(keys.containsAll(values))
 
             entries.forEach { entry ->
-                assertEquals(entry.key, entry.value)
-                assertTrue(expectedKeys.contains(entry.key))
+                check(entry.key == entry.value)
+                check(expectedKeys.contains(entry.key))
             }
         }
 
@@ -133,14 +133,14 @@ class PersistentHashMapBuilderTest : ExecutionTimeMeasuringTest() {
         fun testKeysIterator(expected: MutableMap<IntWrapper, Int>, actual: PersistentMap.Builder<IntWrapper, Int>) {
             var expectedSize = actual.size
             while (expectedSize > 0) {
-                assertEquals(expectedSize, actual.size)
+                check(expectedSize == actual.size)
 
                 val iterator = actual.keys.iterator()
                 repeat(expectedSize) {
-                    assertTrue(iterator.hasNext())
+                    check(iterator.hasNext())
 
                     val nextKey = iterator.next()
-                    assertEquals(expected[nextKey], actual[nextKey])
+                    check(expected[nextKey] == actual[nextKey])
 
                     val shouldRemove = Random.nextDouble() < 0.2
                     if (shouldRemove) {
@@ -148,10 +148,10 @@ class PersistentHashMapBuilderTest : ExecutionTimeMeasuringTest() {
                         expectedSize--
                     }
                 }
-                assertFalse(iterator.hasNext())
+                check(!iterator.hasNext())
             }
 
-            assertTrue(actual.isEmpty())
+            check(actual.isEmpty())
         }
 
         testAfterRandomPut { expected, map ->
@@ -164,11 +164,11 @@ class PersistentHashMapBuilderTest : ExecutionTimeMeasuringTest() {
         fun testValuesIterator(actual: PersistentMap.Builder<IntWrapper, Int>) {
             var expectedSize = actual.size
             while (expectedSize > 0) {
-                assertEquals(expectedSize, actual.size)
+                check(expectedSize == actual.size)
 
                 val iterator = actual.values.iterator()
                 repeat(expectedSize) {
-                    assertTrue(iterator.hasNext())
+                    check(iterator.hasNext())
 
                     val _ = iterator.next()
 
@@ -178,10 +178,10 @@ class PersistentHashMapBuilderTest : ExecutionTimeMeasuringTest() {
                         expectedSize--
                     }
                 }
-                assertFalse(iterator.hasNext())
+                check(!iterator.hasNext())
             }
 
-            assertTrue(actual.isEmpty())
+            check(actual.isEmpty())
         }
 
         testAfterRandomPut { _, map ->
@@ -194,19 +194,19 @@ class PersistentHashMapBuilderTest : ExecutionTimeMeasuringTest() {
         fun testEntriesIterator(expected: MutableMap<IntWrapper, Int>, actual: PersistentMap.Builder<IntWrapper, Int>) {
             var expectedSize = actual.size
             while (expectedSize > 0) {
-                assertEquals(expectedSize, actual.size)
+                check(expectedSize == actual.size)
 
                 val iterator = actual.entries.iterator()
                 repeat(expectedSize) {
-                    assertTrue(iterator.hasNext())
+                    check(iterator.hasNext())
 
                     val nextEntry = iterator.next()
-                    assertEquals(expected[nextEntry.key], actual[nextEntry.key])
+                    check(expected[nextEntry.key] == actual[nextEntry.key])
 
                     val shouldUpdate = Random.nextDouble() < 0.1
                     if (shouldUpdate) {
                         val newValue = Random.nextInt()
-                        assertEquals(expected.put(nextEntry.key, newValue), nextEntry.setValue(newValue))
+                        check(expected.put(nextEntry.key, newValue) == nextEntry.setValue(newValue))
                     }
                     val shouldRemove = Random.nextDouble() < 0.2
                     if (shouldRemove) {
@@ -214,10 +214,10 @@ class PersistentHashMapBuilderTest : ExecutionTimeMeasuringTest() {
                         expectedSize--
                     }
                 }
-                assertFalse(iterator.hasNext())
+                check(!iterator.hasNext())
             }
 
-            assertTrue(actual.isEmpty())
+            check(actual.isEmpty())
         }
 
         testAfterRandomPut { expected, map ->
@@ -236,10 +236,10 @@ class PersistentHashMapBuilderTest : ExecutionTimeMeasuringTest() {
             builder[index] = values[index]
         }
         repeat(times = elementsToAdd) { index ->
-            assertEquals(elementsToAdd - index, builder.size)
-            assertEquals(values[index], builder[index])
-            assertEquals(values[index], builder.remove(index))
-            assertNull(builder[index])
+            check(elementsToAdd - index == builder.size)
+            check(values[index] == builder[index])
+            check(values[index] == builder.remove(index))
+            check(builder[index] == null)
         }
     }
 
@@ -301,12 +301,12 @@ class PersistentHashMapBuilderTest : ExecutionTimeMeasuringTest() {
             builder[index] = values[index]
         }
         repeat(times = elementsToAdd) { index ->
-            assertEquals(elementsToAdd - index, builder.size)
-            assertEquals(values[index], builder[index])
-            assertFalse(builder.remove(index, values[index + 1]))
-            assertEquals(values[index], builder[index])
-            assertTrue(builder.remove(index, values[index]))
-            assertNull(builder[index])
+            check(elementsToAdd - index == builder.size)
+            check(values[index] == builder[index])
+            check(!builder.remove(index, values[index + 1]))
+            check(values[index] == builder[index])
+            check(builder.remove(index, values[index]))
+            check(builder[index] == null)
         }
     }
 
@@ -321,12 +321,12 @@ class PersistentHashMapBuilderTest : ExecutionTimeMeasuringTest() {
             builder[index] = values[index]
 
             for (i in 0..index) {
-                assertEquals(values[i], builder[i])
+                check(values[i] == builder[i])
             }
         }
         repeat(times = elementsToAdd) { index ->
             for (i in elementsToAdd - 1 downTo index) {
-                assertEquals(values[i], builder[i])
+                check(values[i] == builder[i])
             }
 
             builder.remove(index)
@@ -341,23 +341,23 @@ class PersistentHashMapBuilderTest : ExecutionTimeMeasuringTest() {
 
         val values = distinctStringValues(2 * elementsToAdd)
         repeat(times = elementsToAdd) { index ->
-            assertNull(builder.put(index, values[2 * index]))
+            check(builder.put(index, values[2 * index]) == null)
 
             for (i in 0..index) {
                 val valueIndex = i + index
 
-                assertEquals(values[valueIndex], builder[i])
-                assertEquals(values[valueIndex], builder.put(i, values[valueIndex + 1]))
-                assertEquals(values[valueIndex + 1], builder[i])
+                check(values[valueIndex] == builder[i])
+                check(values[valueIndex] == builder.put(i, values[valueIndex + 1]))
+                check(values[valueIndex + 1] == builder[i])
             }
         }
         repeat(times = elementsToAdd) { index ->
             for (i in index until elementsToAdd) {
                 val valueIndex = elementsToAdd - index + i
 
-                assertEquals(values[valueIndex], builder[i])
-                assertEquals(values[valueIndex], builder.put(i, values[valueIndex - 1]))
-                assertEquals(values[valueIndex - 1], builder[i])
+                check(values[valueIndex] == builder[i])
+                check(values[valueIndex] == builder.put(i, values[valueIndex - 1]))
+                check(values[valueIndex - 1] == builder[i])
             }
 
             builder.remove(index)
@@ -380,47 +380,47 @@ class PersistentHashMapBuilderTest : ExecutionTimeMeasuringTest() {
             }
 
             repeat(times = elementsToAdd) { index ->
-                assertNull(builder.put(key(index), Int.MIN_VALUE))
-                assertEquals(Int.MIN_VALUE, builder[key(index)])
-                assertEquals(index + 1, builder.size)
+                check(builder.put(key(index), Int.MIN_VALUE) == null)
+                check(Int.MIN_VALUE == builder[key(index)])
+                check(index + 1 == builder.size)
 
-                assertEquals(Int.MIN_VALUE, builder.put(key(index), index))
-                assertEquals(index + 1, builder.size)
+                check(Int.MIN_VALUE == builder.put(key(index), index))
+                check(index + 1 == builder.size)
 
                 val collisions = keyGen.wrappersByHashCode(key(index).hashCode)
-                assertTrue(collisions.contains(key(index)))
+                check(collisions.contains(key(index)))
 
                 for (key in collisions) {
-                    assertEquals(key.obj, builder[key])
+                    check(key.obj == builder[key])
                 }
             }
             repeat(times = elementsToAdd) { index ->
                 val collisions = keyGen.wrappersByHashCode(key(index).hashCode)
-                assertTrue(collisions.contains(key(index)))
+                check(collisions.contains(key(index)))
 
                 if (builder[key(index)] == null) {
                     for (key in collisions) {
-                        assertNull(builder[key])
+                        check(builder[key] == null)
                     }
                 } else {
                     for (key in collisions) {
-                        assertEquals(key.obj, builder[key])
+                        check(key.obj == builder[key])
 
                         if (removeEntryPredicate == 1) {
                             val nonExistingValue = Int.MIN_VALUE
-                            assertFalse(builder.remove(key, nonExistingValue))
-                            assertEquals(key.obj, builder[key])
+                            check(!builder.remove(key, nonExistingValue))
+                            check(key.obj == builder[key])
 
-                            assertTrue(builder.remove(key, key.obj))
+                            check(builder.remove(key, key.obj))
                         } else {
                             val nonExistingKey = IntWrapper(Int.MIN_VALUE, key.hashCode)
-                            assertNull(builder.remove(nonExistingKey))
-                            assertEquals(key.obj, builder[key])
+                            check(builder.remove(nonExistingKey) == null)
+                            check(key.obj == builder[key])
 
-                            assertEquals(key.obj, builder.remove(key))
+                            check(key.obj == builder.remove(key))
                         }
 
-                        assertNull(builder[key])
+                        check(builder[key] == null)
                     }
                 }
             }
@@ -458,16 +458,16 @@ class PersistentHashMapBuilderTest : ExecutionTimeMeasuringTest() {
 
                 when {
                     shouldRemoveByKey -> {
-                        assertEquals(map.remove(key), builder.remove(key))
+                        check(map.remove(key) == builder.remove(key))
                     }
                     shouldRemoveByKeyAndValue -> {
                         val shouldBeCurrentValue = Random.nextDouble() < 0.8
                         val value = if (shouldOperateOnExistingKey && shouldBeCurrentValue) map[key]!! else Random.nextInt()
-                        assertEquals(map.remove(key, value), builder.remove(key, value))
+                        check(map.remove(key, value) == builder.remove(key, value))
                     }
                     else -> {
                         val value = Random.nextInt()
-                        assertEquals(map.put(key, value), builder.put(key, value))
+                        check(map.put(key, value) == builder.put(key, value))
                     }
                 }
 
@@ -501,12 +501,12 @@ class PersistentHashMapBuilderTest : ExecutionTimeMeasuringTest() {
             actual: Map<IntWrapper, Int>,
             operationKey: IntWrapper
     ) {
-        assertEquals(expected.size, actual.size)
-        assertEquals(expected[operationKey], actual[operationKey])
-        assertEquals(expected.containsKey(operationKey), actual.containsKey(operationKey))
+        check(expected.size == actual.size)
+        check(expected[operationKey] == actual[operationKey])
+        check(expected.containsKey(operationKey) == actual.containsKey(operationKey))
 
-//        assertEquals(expected.containsValue(operationKey.obj), actual.containsValue(operationKey.obj))
-//        assertEquals(expected.keys, actual.keys)
-//        assertEquals(expected.values.sorted(), actual.values.sorted())
+//        check(expected.containsValue(operationKey.obj) == actual.containsValue(operationKey.obj))
+//        check(expected.keys == actual.keys)
+//        check(expected.values.sorted() == actual.values.sorted())
     }
 }

--- a/core/commonTest/src/stress/map/PersistentHashMapTest.kt
+++ b/core/commonTest/src/stress/map/PersistentHashMapTest.kt
@@ -30,11 +30,11 @@ class PersistentHashMapTest : ExecutionTimeMeasuringTest() {
         val values = distinctStringValues(elementsToAdd)
         repeat(times = elementsToAdd) { index ->
             map = map.put(index, values[index])
-            check(!map.isEmpty())
+            check(map.isNotEmpty())
         }
         repeat(times = elementsToAdd - 1) { index ->
             map = map.remove(index)
-            check(!map.isEmpty())
+            check(map.isNotEmpty())
         }
         map = map.remove(elementsToAdd - 1)
         assertTrue(map.isEmpty())

--- a/core/commonTest/src/stress/map/PersistentHashMapTest.kt
+++ b/core/commonTest/src/stress/map/PersistentHashMapTest.kt
@@ -30,11 +30,11 @@ class PersistentHashMapTest : ExecutionTimeMeasuringTest() {
         val values = distinctStringValues(elementsToAdd)
         repeat(times = elementsToAdd) { index ->
             map = map.put(index, values[index])
-            assertFalse(map.isEmpty())
+            check(!map.isEmpty())
         }
         repeat(times = elementsToAdd - 1) { index ->
             map = map.remove(index)
-            assertFalse(map.isEmpty())
+            check(!map.isEmpty())
         }
         map = map.remove(elementsToAdd - 1)
         assertTrue(map.isEmpty())
@@ -51,20 +51,20 @@ class PersistentHashMapTest : ExecutionTimeMeasuringTest() {
 
         repeat(times = elementsToAdd) { index ->
             map = map.put(index, index)
-            assertEquals(index + 1, map.size)
+            check(index + 1 == map.size)
 
             map = map.put(index, index)
-            assertEquals(index + 1, map.size)
+            check(index + 1 == map.size)
 
             map = map.put(index, 7)
-            assertEquals(index + 1, map.size)
+            check(index + 1 == map.size)
         }
         repeat(times = elementsToAdd) { index ->
             map = map.remove(index)
-            assertEquals(elementsToAdd - index - 1, map.size)
+            check(elementsToAdd - index - 1 == map.size)
 
             map = map.remove(index)
-            assertEquals(elementsToAdd - index - 1, map.size)
+            check(elementsToAdd - index - 1 == map.size)
         }
     }
 
@@ -75,14 +75,14 @@ class PersistentHashMapTest : ExecutionTimeMeasuringTest() {
             val keys = actualMap.keys
             val entries = actualMap.entries
 
-            assertTrue(listOf(values.size, keys.size, entries.size).all { it == expectedKeys.size })
+            check(listOf(values.size, keys.size, entries.size).all { it == expectedKeys.size })
 
-            assertEquals<Set<*>>(expectedKeys, keys)
-            assertTrue(keys.containsAll(values))
+            check(expectedKeys == keys)
+            check(keys.containsAll(values))
 
             entries.forEach { entry ->
-                assertEquals(entry.key, entry.value)
-                assertTrue(expectedKeys.contains(entry.key))
+                check(entry.key == entry.value)
+                check(expectedKeys.contains(entry.key))
             }
         }
 
@@ -121,10 +121,10 @@ class PersistentHashMapTest : ExecutionTimeMeasuringTest() {
             map = map.put(index, values[index])
         }
         repeat(times = elementsToAdd) { index ->
-            assertEquals(elementsToAdd - index, map.size)
-            assertEquals(values[index], map[index])
+            check(elementsToAdd - index == map.size)
+            check(values[index] == map[index])
             map = map.remove(index)
-            assertNull(map[index])
+            check(map[index] == null)
         }
         assertTrue(map.isEmpty())
     }
@@ -142,12 +142,12 @@ class PersistentHashMapTest : ExecutionTimeMeasuringTest() {
             map = map.put(index, values[index])
         }
         repeat(times = elementsToAdd) { index ->
-            assertEquals(elementsToAdd - index, map.size)
-            assertEquals(values[index], map[index])
+            check(elementsToAdd - index == map.size)
+            check(values[index] == map[index])
             map = map.remove(index, values[index + 1])
-            assertEquals(values[index], map[index])
+            check(values[index] == map[index])
             map = map.remove(index, values[index])
-            assertNull(map[index])
+            check(map[index] == null)
         }
         assertTrue(map.isEmpty())
     }
@@ -164,12 +164,12 @@ class PersistentHashMapTest : ExecutionTimeMeasuringTest() {
             map = map.put(index, values[index])
 
             for (i in 0..index) {
-                assertEquals(values[i], map[i])
+                check(values[i] == map[i])
             }
         }
         repeat(times = elementsToAdd) { index ->
             for (i in elementsToAdd - 1 downTo index) {
-                assertEquals(values[i], map[i])
+                check(values[i] == map[i])
             }
 
             map = map.remove(index)
@@ -190,18 +190,18 @@ class PersistentHashMapTest : ExecutionTimeMeasuringTest() {
             for (i in 0..index) {
                 val valueIndex = i + index
 
-                assertEquals(values[valueIndex], map[i])
+                check(values[valueIndex] == map[i])
                 map = map.put(i, values[valueIndex + 1])
-                assertEquals(values[valueIndex + 1], map[i])
+                check(values[valueIndex + 1] == map[i])
             }
         }
         repeat(times = elementsToAdd) { index ->
             for (i in index until elementsToAdd) {
                 val valueIndex = elementsToAdd - index + i
 
-                assertEquals(values[valueIndex], map[i])
+                check(values[valueIndex] == map[i])
                 map = map.put(i, values[valueIndex - 1])
-                assertEquals(values[valueIndex - 1], map[i])
+                check(values[valueIndex - 1] == map[i])
             }
 
             map = map.remove(index)
@@ -230,48 +230,48 @@ class PersistentHashMapTest : ExecutionTimeMeasuringTest() {
 
             repeat(times = elementsToAdd) { index ->
                 map = map.put(key(index), Int.MIN_VALUE)
-                assertEquals(Int.MIN_VALUE, map[key(index)])
-                assertEquals(index + 1, map.size)
+                check(Int.MIN_VALUE == map[key(index)])
+                check(index + 1 == map.size)
 
                 map = map.put(key(index), index)
-                assertEquals(index + 1, map.size)
+                check(index + 1 == map.size)
 
                 val collisions = keyGen.wrappersByHashCode(key(index).hashCode)
-                assertTrue(collisions.contains(key(index)))
+                check(collisions.contains(key(index)))
 
                 for (key in collisions) {
-                    assertEquals(key.obj, map[key])
+                    check(key.obj == map[key])
                 }
             }
             repeat(times = elementsToAdd) { index ->
                 val collisions = keyGen.wrappersByHashCode(key(index).hashCode)
-                assertTrue(collisions.contains(key(index)))
+                check(collisions.contains(key(index)))
 
                 if (map[key(index)] == null) {
                     for (key in collisions) {
-                        assertNull(map[key])
+                        check(map[key] == null)
                     }
                 } else {
                     for (key in collisions) {
-                        assertEquals(key.obj, map[key])
+                        check(key.obj == map[key])
 
                         map = if (removeEntryPredicate == 1) {
                             val nonExistingValue = Int.MIN_VALUE
                             val sameMap = map.remove(key, nonExistingValue)
-                            assertEquals(map.size, sameMap.size)
-                            assertEquals(key.obj, sameMap[key])
+                            check(map.size == sameMap.size)
+                            check(key.obj == sameMap[key])
 
                             map.remove(key, key.obj)
                         } else {
                             val nonExistingKey = IntWrapper(Int.MIN_VALUE, key.hashCode)
                             val sameMap = map.remove(nonExistingKey)
-                            assertEquals(map.size, sameMap.size)
-                            assertEquals(key.obj, sameMap[key])
+                            check(map.size == sameMap.size)
+                            check(key.obj == sameMap[key])
 
                             map.remove(key)
                         }
 
-                        assertNull(map[key])
+                        check(map[key] == null)
                     }
                 }
             }
@@ -356,12 +356,12 @@ class PersistentHashMapTest : ExecutionTimeMeasuringTest() {
             actual: Map<IntWrapper?, Int?>,
             operationKey: IntWrapper?
     ) {
-        assertEquals(expected.size, actual.size)
-        assertEquals(expected[operationKey], actual[operationKey])
-        assertEquals(expected.containsKey(operationKey), actual.containsKey(operationKey))
+        check(expected.size == actual.size)
+        check(expected[operationKey] == actual[operationKey])
+        check(expected.containsKey(operationKey) == actual.containsKey(operationKey))
 
-//        assertEquals(expected.containsValue(operationKey?.obj), actual.containsValue(operationKey?.obj))
-//        assertEquals(expected.keys, actual.keys)
-//        assertEquals(expected.values.sortedBy { it }, actual.values.sortedBy { it })
+//        check(expected.containsValue(operationKey?.obj) == actual.containsValue(operationKey?.obj))
+//        check(expected.keys == actual.keys)
+//        check(expected.values.sortedBy { it } == actual.values.sortedBy { it })
     }
 }

--- a/core/commonTest/src/stress/set/PersistentHashSetBuilderTest.kt
+++ b/core/commonTest/src/stress/set/PersistentHashSetBuilderTest.kt
@@ -28,11 +28,11 @@ class PersistentHashSetBuilderTest : ExecutionTimeMeasuringTest() {
 
         repeat(times = elementsToAdd) { index ->
             builder.add(index)
-            check(!builder.isEmpty())
+            check(builder.isNotEmpty())
         }
         repeat(times = elementsToAdd - 1) { index ->
             builder.remove(index)
-            check(!builder.isEmpty())
+            check(builder.isNotEmpty())
         }
         builder.remove(elementsToAdd - 1)
         assertTrue(builder.isEmpty())

--- a/core/commonTest/src/stress/set/PersistentHashSetBuilderTest.kt
+++ b/core/commonTest/src/stress/set/PersistentHashSetBuilderTest.kt
@@ -28,11 +28,11 @@ class PersistentHashSetBuilderTest : ExecutionTimeMeasuringTest() {
 
         repeat(times = elementsToAdd) { index ->
             builder.add(index)
-            assertFalse(builder.isEmpty())
+            check(!builder.isEmpty())
         }
         repeat(times = elementsToAdd - 1) { index ->
             builder.remove(index)
-            assertFalse(builder.isEmpty())
+            check(!builder.isEmpty())
         }
         builder.remove(elementsToAdd - 1)
         assertTrue(builder.isEmpty())
@@ -48,17 +48,17 @@ class PersistentHashSetBuilderTest : ExecutionTimeMeasuringTest() {
 
         repeat(times = elementsToAdd) { index ->
             builder.add(index)
-            assertEquals(index + 1, builder.size)
+            check(index + 1 == builder.size)
 
             builder.add(index)
-            assertEquals(index + 1, builder.size)
+            check(index + 1 == builder.size)
         }
         repeat(times = elementsToAdd) { index ->
             builder.remove(index)
-            assertEquals(elementsToAdd - index - 1, builder.size)
+            check(elementsToAdd - index - 1 == builder.size)
 
             builder.remove(index)
-            assertEquals(elementsToAdd - index - 1, builder.size)
+            check(elementsToAdd - index - 1 == builder.size)
         }
     }
 
@@ -76,14 +76,14 @@ class PersistentHashSetBuilderTest : ExecutionTimeMeasuringTest() {
             mutableSet.add(element)
             builder.add(element)
 
-            assertEquals(builder, mutableSet)
+            check(builder == mutableSet)
         }
 
         mutableSet.toMutableList().forEach { element ->
             mutableSet.remove(element)
             builder.remove(element)
 
-            assertEquals(builder, mutableSet)
+            check(builder == mutableSet)
         }
 
         assertTrue(builder.isEmpty())
@@ -121,10 +121,10 @@ class PersistentHashSetBuilderTest : ExecutionTimeMeasuringTest() {
                     iterator = builder.iterator()
                 }
             }
-            assertTrue(didRemove)
+            check(didRemove)
 
-            assertEquals(mutableSet.size, builder.size)
-            assertEquals(mutableSet, builder)
+            check(mutableSet.size == builder.size)
+            check(mutableSet == builder)
         }
 
         assertTrue(builder.isEmpty())
@@ -140,11 +140,11 @@ class PersistentHashSetBuilderTest : ExecutionTimeMeasuringTest() {
             builder.add(index)
         }
         repeat(times = elementsToAdd) { index ->
-            assertEquals(elementsToAdd - index, builder.size)
+            check(elementsToAdd - index == builder.size)
 
-            assertTrue(builder.contains(index))
+            check(builder.contains(index))
             builder.remove(index)
-            assertFalse(builder.contains(index))
+            check(!builder.contains(index))
         }
     }
 
@@ -159,12 +159,12 @@ class PersistentHashSetBuilderTest : ExecutionTimeMeasuringTest() {
             builder.add(elements[index])
 
             for (i in 0..index) {
-                assertTrue(builder.contains(elements[i]))
+                check(builder.contains(elements[i]))
             }
         }
         repeat(times = elementsToAdd) { index ->
             for (i in elementsToAdd - 1 downTo index) {
-                assertTrue(builder.contains(elements[i]))
+                check(builder.contains(elements[i]))
             }
 
             builder.remove(elements[index])
@@ -183,24 +183,24 @@ class PersistentHashSetBuilderTest : ExecutionTimeMeasuringTest() {
             for (i in index downTo 0) {
                 val element = i + index
 
-                assertTrue(builder.contains(element))
+                check(builder.contains(element))
                 builder.remove(element)
-                assertFalse(builder.contains(element))
-                assertFalse(builder.contains(element + 1))
+                check(!builder.contains(element))
+                check(!builder.contains(element + 1))
                 builder.add(element + 1)
-                assertTrue(builder.contains(element + 1))
+                check(builder.contains(element + 1))
             }
         }
         repeat(times = elementsToAdd) { index ->
             for (i in index until elementsToAdd ) {
                 val element = elementsToAdd - index + i
 
-                assertTrue(builder.contains(element))
+                check(builder.contains(element))
                 builder.remove(element)
-                assertFalse(builder.contains(element))
-                assertFalse(builder.contains(element - 1))
+                check(!builder.contains(element))
+                check(!builder.contains(element - 1))
                 builder.add(element - 1)
-                assertTrue(builder.contains(element - 1))
+                check(builder.contains(element - 1))
             }
 
             builder.remove(elementsToAdd - 1)
@@ -222,36 +222,36 @@ class PersistentHashSetBuilderTest : ExecutionTimeMeasuringTest() {
 
         repeat(times = elementsToAdd) { index ->
             builder.add(wrapper(index))
-            assertTrue(builder.contains(wrapper(index)))
-            assertEquals(index + 1, builder.size)
+            check(builder.contains(wrapper(index)))
+            check(index + 1 == builder.size)
 
             builder.add(wrapper(index))
-            assertEquals(index + 1, builder.size)
+            check(index + 1 == builder.size)
 
             val collisions = eGen.wrappersByHashCode(wrapper(index).hashCode)
-            assertTrue(collisions.contains(wrapper(index)))
+            check(collisions.contains(wrapper(index)))
 
             for (wrapper in collisions) {
-                assertTrue(builder.contains(wrapper))
+                check(builder.contains(wrapper))
             }
         }
         repeat(times = elementsToAdd) { index ->
             val collisions = eGen.wrappersByHashCode(wrapper(index).hashCode)
-            assertTrue(collisions.contains(wrapper(index)))
+            check(collisions.contains(wrapper(index)))
 
             if (!builder.contains(wrapper(index))) {
                 for (wrapper in collisions) {
-                    assertFalse(builder.contains(wrapper))
+                    check(!builder.contains(wrapper))
                 }
             } else {
                 for (wrapper in collisions) {
-                    assertTrue(builder.contains(wrapper))
+                    check(builder.contains(wrapper))
 
                     val nonExistingElement = IntWrapper(wrapper.obj.inv(), wrapper.hashCode)
-                    assertFalse(builder.remove(nonExistingElement))
-                    assertTrue(builder.contains(wrapper))
-                    assertTrue(builder.remove(wrapper))
-                    assertFalse(builder.contains(wrapper))
+                    check(!builder.remove(nonExistingElement))
+                    check(builder.contains(wrapper))
+                    check(builder.remove(wrapper))
+                    check(!builder.contains(wrapper))
                 }
             }
         }
@@ -285,10 +285,10 @@ class PersistentHashSetBuilderTest : ExecutionTimeMeasuringTest() {
 
                 when {
                     shouldRemove -> {
-                        assertEquals(set.remove(element), builder.remove(element))
+                        check(set.remove(element) == builder.remove(element))
                     }
                     else -> {
-                        assertEquals(set.add(element), builder.add(element))
+                        check(set.add(element) == builder.add(element))
                     }
                 }
 
@@ -318,8 +318,8 @@ class PersistentHashSetBuilderTest : ExecutionTimeMeasuringTest() {
     }
 
     private fun testAfterOperation(expected: Set<IntWrapper>, actual: Set<IntWrapper>, element: IntWrapper) {
-        assertEquals(expected.size, actual.size)
-        assertEquals(expected.contains(element), actual.contains(element))
-//        assertEquals(expected, actual)
+        check(expected.size == actual.size)
+        check(expected.contains(element) == actual.contains(element))
+//        check(expected == actual)
     }
 }

--- a/core/commonTest/src/stress/set/PersistentHashSetTest.kt
+++ b/core/commonTest/src/stress/set/PersistentHashSetTest.kt
@@ -30,11 +30,11 @@ class PersistentHashSetTest : ExecutionTimeMeasuringTest() {
 
         repeat(times = elementsToAdd) { index ->
             set = set.add(index)
-            check(!set.isEmpty())
+            check(set.isNotEmpty())
         }
         repeat(times = elementsToAdd - 1) { index ->
             set = set.remove(index)
-            check(!set.isEmpty())
+            check(set.isNotEmpty())
         }
         set = set.remove(elementsToAdd - 1)
         assertTrue(set.isEmpty())

--- a/core/commonTest/src/stress/set/PersistentHashSetTest.kt
+++ b/core/commonTest/src/stress/set/PersistentHashSetTest.kt
@@ -30,11 +30,11 @@ class PersistentHashSetTest : ExecutionTimeMeasuringTest() {
 
         repeat(times = elementsToAdd) { index ->
             set = set.add(index)
-            assertFalse(set.isEmpty())
+            check(!set.isEmpty())
         }
         repeat(times = elementsToAdd - 1) { index ->
             set = set.remove(index)
-            assertFalse(set.isEmpty())
+            check(!set.isEmpty())
         }
         set = set.remove(elementsToAdd - 1)
         assertTrue(set.isEmpty())
@@ -51,17 +51,17 @@ class PersistentHashSetTest : ExecutionTimeMeasuringTest() {
 
         repeat(times = elementsToAdd) { index ->
             set = set.add(index)
-            assertEquals(index + 1, set.size)
+            check(index + 1 == set.size)
 
             set = set.add(index)
-            assertEquals(index + 1, set.size)
+            check(index + 1 == set.size)
         }
         repeat(times = elementsToAdd) { index ->
             set = set.remove(index)
-            assertEquals(elementsToAdd - index - 1, set.size)
+            check(elementsToAdd - index - 1 == set.size)
 
             set = set.remove(index)
-            assertEquals(elementsToAdd - index - 1, set.size)
+            check(elementsToAdd - index - 1 == set.size)
         }
     }
 
@@ -78,14 +78,14 @@ class PersistentHashSetTest : ExecutionTimeMeasuringTest() {
             mutableSet.add(element)
             set = set.add(element)
 
-            assertEquals<Set<*>>(set, mutableSet)
+            check(set == mutableSet)
         }
 
         mutableSet.toMutableList().forEach { element ->
             mutableSet.remove(element)
             set = set.remove(element)
 
-            assertEquals<Set<*>>(set, mutableSet)
+            check(set == mutableSet)
         }
 
         assertTrue(set.isEmpty())
@@ -102,11 +102,11 @@ class PersistentHashSetTest : ExecutionTimeMeasuringTest() {
             set = set.add(index)
         }
         repeat(times = elementsToAdd) { index ->
-            assertEquals(elementsToAdd - index, set.size)
+            check(elementsToAdd - index == set.size)
 
-            assertTrue(set.contains(index))
+            check(set.contains(index))
             set = set.remove(index)
-            assertFalse(set.contains(index))
+            check(!set.contains(index))
         }
         assertTrue(set.isEmpty())
     }
@@ -123,12 +123,12 @@ class PersistentHashSetTest : ExecutionTimeMeasuringTest() {
             set = set.add(elements[index])
 
             for (i in 0..index) {
-                assertTrue(set.contains(elements[i]))
+                check(set.contains(elements[i]))
             }
         }
         repeat(times = elementsToAdd) { index ->
             for (i in elementsToAdd - 1 downTo index) {
-                assertTrue(set.contains(elements[i]))
+                check(set.contains(elements[i]))
             }
 
             set = set.remove(elements[index])
@@ -148,24 +148,24 @@ class PersistentHashSetTest : ExecutionTimeMeasuringTest() {
             for (i in index downTo 0) {
                 val element = i + index
 
-                assertTrue(set.contains(element))
+                check(set.contains(element))
                 set = set.remove(element)
-                assertFalse(set.contains(element))
-                assertFalse(set.contains(element + 1))
+                check(!set.contains(element))
+                check(!set.contains(element + 1))
                 set = set.add(element + 1)
-                assertTrue(set.contains(element + 1))
+                check(set.contains(element + 1))
             }
         }
         repeat(times = elementsToAdd) { index ->
             for (i in index until elementsToAdd ) {
                 val element = elementsToAdd - index + i
 
-                assertTrue(set.contains(element))
+                check(set.contains(element))
                 set = set.remove(element)
-                assertFalse(set.contains(element))
-                assertFalse(set.contains(element - 1))
+                check(!set.contains(element))
+                check(!set.contains(element - 1))
                 set = set.add(element - 1)
-                assertTrue(set.contains(element - 1))
+                check(set.contains(element - 1))
             }
 
             set = set.remove(elementsToAdd - 1)
@@ -189,38 +189,38 @@ class PersistentHashSetTest : ExecutionTimeMeasuringTest() {
 
         repeat(times = elementsToAdd) { index ->
             set = set.add(wrapper(index))
-            assertTrue(set.contains(wrapper(index)))
-            assertEquals(index + 1, set.size)
+            check(set.contains(wrapper(index)))
+            check(index + 1 == set.size)
 
             set = set.add(wrapper(index))
-            assertEquals(index + 1, set.size)
+            check(index + 1 == set.size)
 
             val collisions = eGen.wrappersByHashCode(wrapper(index).hashCode)
-            assertTrue(collisions.contains(wrapper(index)))
+            check(collisions.contains(wrapper(index)))
 
             for (wrapper in collisions) {
-                assertTrue(set.contains(wrapper))
+                check(set.contains(wrapper))
             }
         }
         repeat(times = elementsToAdd) { index ->
             val collisions = eGen.wrappersByHashCode(wrapper(index).hashCode)
-            assertTrue(collisions.contains(wrapper(index)))
+            check(collisions.contains(wrapper(index)))
 
             if (!set.contains(wrapper(index))) {
                 for (wrapper in collisions) {
-                    assertFalse(set.contains(wrapper))
+                    check(!set.contains(wrapper))
                 }
             } else {
                 for (wrapper in collisions) {
-                    assertTrue(set.contains(wrapper))
+                    check(set.contains(wrapper))
 
                     val nonExistingElement = IntWrapper(wrapper.obj.inv(), wrapper.hashCode)
                     val sameSet = set.remove(nonExistingElement)
-                    assertEquals(set.size, sameSet.size)
-                    assertTrue(sameSet.contains(wrapper))
+                    check(set.size == sameSet.size)
+                    check(sameSet.contains(wrapper))
 
                     set = set.remove(wrapper)
-                    assertFalse(set.contains(wrapper))
+                    check(!set.contains(wrapper))
                 }
             }
         }
@@ -289,8 +289,8 @@ class PersistentHashSetTest : ExecutionTimeMeasuringTest() {
     }
 
     private fun testAfterOperation(expected: Set<IntWrapper?>, actual: Set<IntWrapper?>, element: IntWrapper?) {
-        assertEquals(expected.size, actual.size)
-        assertEquals(expected.contains(element), actual.contains(element))
-//        assertEquals(expected, actual)
+        check(expected.size == actual.size)
+        check(expected.contains(element) == actual.contains(element))
+//        check(expected == actual)
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@ group=org.jetbrains.kotlinx
 version=0.4.0
 versionSuffix=SNAPSHOT
 
-kotlin_version=2.3.0
+kotlinVersion=2.3.0
 dokkaVersion=2.2.0-Beta
 kotlinxBenchmarkVersion=0.4.15
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -8,9 +8,11 @@ pluginManagement {
             maven(kotlinRepoUrl)
         }
     }
+    val kotlinVersion: String by settings
     val dokkaVersion: String by settings
     val kotlinxBenchmarkVersion: String by settings
     plugins {
+        id("org.jetbrains.kotlin.plugin.power-assert") version kotlinVersion
         id("org.jetbrains.dokka") version dokkaVersion
         id("org.jetbrains.kotlinx.benchmark") version kotlinxBenchmarkVersion
     }


### PR DESCRIPTION
This PR enables the Kotlin Power Assert compiler plugin, which transforms assertion calls to include detailed diagnostic messages showing intermediate expression values on failure.  
  
Power Assert injects a diagnostic message string as the last parameter of each configured assertion function. For `assertEquals(expected, actual)` this string is always constructed eagerly, even when the assertion passes. This has no impact on contract and unit tests, but stress tests execute assertions inside tight loops with up to 1000000 iterations, making the constant string allocation a significant performance bottleneck.  
  
To fix this, assertions inside loops in stress tests are replaced with `check` equivalents (`check(a == b)` instead of `assertEquals(a, b)`). Unlike `assertEquals`, `check` accepts a lambda for its message, so the diagnostic string is only materialized on failure. Assertions outside loops and in non-stress tests are left unchanged for readability. `kotlin.check` is already in the Power Assert functions list, so diagnostic output on failure is preserved.