### PR TITLE
Added missing reference to deployment id parameter

### DIFF
--- a/.teamcity/additionalConfiguration.kt
+++ b/.teamcity/additionalConfiguration.kt
@@ -24,4 +24,7 @@ fun Project.additionalConfiguration() {
     val deploymentProject = knownBuilds.deploymentSubproject
     val startTask = deploymentProject.knownBuilds.deployStart
     startTask.params.param("reverse.dep.*.DeploymentName", "kotlinx.collections.immutable %releaseVersion%")
+    deploymentProject.knownBuilds.deployPublish.params {
+        param("DeploymentId", "${deploymentProject.knownBuilds.deployUpload.depParamRefs["output.DeploymentId"]}")
+    }
 }


### PR DESCRIPTION
Follow up for the https://github.com/Kotlin/kotlinx.collections.immutable/pull/249, we caught the issue while releasing kx-datetime. 