### PR TITLE
Fix ordered map builder entry value updates

### DIFF
--- a/core/commonMain/src/implementations/persistentOrderedMap/PersistentOrderedMapBuilder.kt
+++ b/core/commonMain/src/implementations/persistentOrderedMap/PersistentOrderedMapBuilder.kt
@@ -86,6 +86,11 @@ internal class PersistentOrderedMapBuilder<K, V>(map: PersistentOrderedMap<K, V>
         }
     }
 
+    internal fun setEntryValue(key: K, links: LinkedValue<V>) {
+        builtMap = null
+        hashMapBuilder[key] = links
+    }
+
     override fun remove(key: K): V? {
         val links = hashMapBuilder.remove(key) ?: return null
         builtMap = null

--- a/core/commonMain/src/implementations/persistentOrderedMap/PersistentOrderedMapBuilderContentIterators.kt
+++ b/core/commonMain/src/implementations/persistentOrderedMap/PersistentOrderedMapBuilderContentIterators.kt
@@ -72,7 +72,7 @@ internal class PersistentOrderedMapBuilderEntriesIterator<K, V>(map: PersistentO
     override fun next(): MutableMap.MutableEntry<K, V> {
         val links = internal.next()
         @Suppress("UNCHECKED_CAST")
-        return MutableMapEntry(internal.builder.hashMapBuilder, internal.lastIteratedKey as K, links)
+        return MutableMapEntry(internal.builder, internal.lastIteratedKey as K, links)
     }
 
     override fun remove() {
@@ -80,7 +80,7 @@ internal class PersistentOrderedMapBuilderEntriesIterator<K, V>(map: PersistentO
     }
 }
 
-private class MutableMapEntry<K, V>(private val mutableMap: MutableMap<K, LinkedValue<V>>,
+private class MutableMapEntry<K, V>(private val builder: PersistentOrderedMapBuilder<K, V>,
                                     key: K,
                                     private var links: LinkedValue<V>) : MapEntry<K, V>(key, links.value), MutableMap.MutableEntry<K, V> {
     override val value: V
@@ -89,7 +89,7 @@ private class MutableMapEntry<K, V>(private val mutableMap: MutableMap<K, Linked
     override fun setValue(newValue: V): V {
         val result = links.value
         links = links.withValue(newValue)
-        mutableMap[key] = links
+        builder.setEntryValue(key, links)
         return result
     }
 }

--- a/core/commonTest/src/contract/map/PersistentOrderedMapTest.kt
+++ b/core/commonTest/src/contract/map/PersistentOrderedMapTest.kt
@@ -11,6 +11,16 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 
 class PersistentOrderedMapTest {
+    @Test
+    fun `builder entry setValue invalidates cached map`() {
+        val builder = persistentMapOf("a" to 1).builder()
+        assertEquals(persistentMapOf("a" to 1), builder.build())
+
+        val entry = builder.entries.iterator().next()
+        assertEquals(1, entry.setValue(2))
+
+        assertEquals(persistentMapOf("a" to 2), builder.build())
+    }
 
     /**
      * Test from issue: https://github.com/Kotlin/kotlinx.collections.immutable/issues/198


### PR DESCRIPTION
Fixes a stale cached-map result when updating a PersistentMap builder entry through MutableMap.MutableEntry.setValue.

PersistentOrderedMapBuilder caches the last built ordered map. Entry setValue previously updated only the underlying hash-map builder, leaving the ordered builder cache valid. A subsequent build() could therefore return the previous map.

This change routes entry value updates through the ordered-map builder so the ordered builder cache is invalidated before the hash-map builder is updated.

Added a regression test that builds once, updates an entry value through the builder entry iterator, and verifies the next build() reflects the new value.