### PR TITLE
Invalidate ordered map builder after entry value updates

### DIFF
--- a/core/commonMain/src/implementations/persistentOrderedMap/PersistentOrderedMapBuilderContentIterators.kt
+++ b/core/commonMain/src/implementations/persistentOrderedMap/PersistentOrderedMapBuilderContentIterators.kt
@@ -72,7 +72,7 @@ internal class PersistentOrderedMapBuilderEntriesIterator<K, V>(map: PersistentO
     override fun next(): MutableMap.MutableEntry<K, V> {
         val links = internal.next()
         @Suppress("UNCHECKED_CAST")
-        return MutableMapEntry(internal.builder.hashMapBuilder, internal.lastIteratedKey as K, links)
+        return MutableMapEntry(internal.builder, internal.lastIteratedKey as K, links)
     }
 
     override fun remove() {
@@ -80,7 +80,7 @@ internal class PersistentOrderedMapBuilderEntriesIterator<K, V>(map: PersistentO
     }
 }
 
-private class MutableMapEntry<K, V>(private val mutableMap: MutableMap<K, LinkedValue<V>>,
+private class MutableMapEntry<K, V>(private val builder: PersistentOrderedMapBuilder<K, V>,
                                     key: K,
                                     private var links: LinkedValue<V>) : MapEntry<K, V>(key, links.value), MutableMap.MutableEntry<K, V> {
     override val value: V
@@ -89,7 +89,7 @@ private class MutableMapEntry<K, V>(private val mutableMap: MutableMap<K, Linked
     override fun setValue(newValue: V): V {
         val result = links.value
         links = links.withValue(newValue)
-        mutableMap[key] = links
+        builder[key] = newValue
         return result
     }
 }

--- a/core/commonTest/src/contract/map/PersistentOrderedMapTest.kt
+++ b/core/commonTest/src/contract/map/PersistentOrderedMapTest.kt
@@ -11,6 +11,16 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 
 class PersistentOrderedMapTest {
+    @Test
+    fun `builder entry setValue invalidates cached map`() {
+        val builder = persistentMapOf("a" to 1).builder()
+        assertEquals(persistentMapOf("a" to 1), builder.build())
+
+        val entry = builder.entries.iterator().next()
+        assertEquals(1, entry.setValue(2))
+
+        assertEquals(persistentMapOf("a" to 2), builder.build())
+    }
 
     /**
      * Test from issue: https://github.com/Kotlin/kotlinx.collections.immutable/issues/198


### PR DESCRIPTION
This bug was found and fixed by Codex.

PersistentOrderedMapBuilder caches the last built ordered map. Updating an entry through MutableMap.MutableEntry.setValue updated only the backing hash map builder, leaving the ordered builder cache incorrectly valid. A later build() could therefore return the previously built map.

Route entry value updates through the ordered map builder so its existing cache invalidation path runs. Add a regression test that builds once before mutating an entry value.