### PR TITLE
Document return values in the KDoc summary instead of `@return`

### DIFF
--- a/core/commonMain/src/ImmutableCollection.kt
+++ b/core/commonMain/src/ImmutableCollection.kt
@@ -173,7 +173,7 @@ public interface PersistentCollection<out E> : ImmutableCollection<E> {
      * Returns all elements in this collection that are also
      * contained in the specified [elements] collection.
      *
-     * @return a new persistent set with elements in this set that are also
+     * @return a new persistent collection with elements in this collection that are also
      *         contained in the specified [elements] collection;
      *         or this instance if no modifications were made in the result of this operation.
      */
@@ -191,7 +191,7 @@ public interface PersistentCollection<out E> : ImmutableCollection<E> {
      * [Migration guide](https://github.com/Kotlin/kotlinx.collections.immutable/blob/master/docs/0.5.0-MIGRATION.md)
      * for more details and guidance with the migration.
      *
-     * @return a new persistent set with elements in this set that are also
+     * @return a new persistent collection with elements in this collection that are also
      *         contained in the specified [elements] collection;
      *         or this instance if no modifications were made in the result of this operation.
      */
@@ -202,14 +202,14 @@ public interface PersistentCollection<out E> : ImmutableCollection<E> {
     public fun retainAll(elements: Collection<@UnsafeVariance E>): PersistentCollection<E>
 
     /**
-     * Returns an empty persistent collection.
+     * Returns the result of removing all elements from this collection.
      *
      * @return an empty persistent collection.
      */
     public fun cleared(): PersistentCollection<E> = @Suppress("DEPRECATION") clear()
 
     /**
-     * Returns an empty persistent collection.
+     * Returns the result of removing all elements from this collection.
      *
      * Use the function [cleared] to make it clear that a new collection is returned.
      *
@@ -244,21 +244,25 @@ public interface PersistentCollection<out E> : ImmutableCollection<E> {
      */
     public interface Builder<E> : MutableCollection<E> {
         /**
-         * Returns a persistent collection with the same contents as this builder.
+         * Builds a persistent collection with the same contents as this builder.
          *
          * This method can be called multiple times.
          *
          * If operations applied on this builder have caused no modifications:
          * - on the first call it returns the same persistent collection instance this builder was obtained from.
          * - on subsequent calls it returns the same previously returned persistent collection instance.
+         *
+         * @return a persistent collection with the same contents as this builder.
          */
         public fun build(): PersistentCollection<E>
     }
 
     /**
-     * Returns a new builder with the same contents as this collection.
+     * Creates a new builder with the same contents as this collection.
      *
      * The builder can be used to efficiently perform multiple modification operations.
+     *
+     * @return a new builder with the same contents as this collection.
      */
     public fun builder(): Builder<@UnsafeVariance E>
 }

--- a/core/commonMain/src/ImmutableCollection.kt
+++ b/core/commonMain/src/ImmutableCollection.kt
@@ -96,17 +96,17 @@ public interface PersistentCollection<out E> : ImmutableCollection<E> {
     public fun remove(element: @UnsafeVariance E): PersistentCollection<E>
 
     /**
-     * Returns a new persistent collection with elements in this collection that are also
-     * contained in the specified [elements] collection removed,
-     * or this instance if no modifications were made in the result of this operation.
+     * Returns a new persistent collection containing all elements of this collection
+     * except the elements contained in the specified [elements] collection,
+     * or this instance if there are no elements to remove.
      */
     public fun removingAll(elements: Collection<@UnsafeVariance E>): PersistentCollection<E> =
         @Suppress("DEPRECATION") removeAll(elements)
 
     /**
-     * Returns a new persistent collection with elements in this collection that are also
-     * contained in the specified [elements] collection removed,
-     * or this instance if no modifications were made in the result of this operation.
+     * Returns a new persistent collection containing all elements of this collection
+     * except the elements contained in the specified [elements] collection,
+     * or this instance if there are no elements to remove.
      *
      * Use the function [removingAll] to make it clear that a new collection is returned.
      *

--- a/core/commonMain/src/ImmutableCollection.kt
+++ b/core/commonMain/src/ImmutableCollection.kt
@@ -26,16 +26,14 @@ public interface ImmutableCollection<out E> : Collection<E>
  */
 public interface PersistentCollection<out E> : ImmutableCollection<E> {
     /**
-     * Returns the result of adding the specified [element] to this collection.
-     *
-     * @return a new persistent collection with the specified [element] added;
-     *         or this instance if this collection does not support duplicates,
-     *         and it already contains the element.
+     * Returns a new persistent collection with the specified [element] added,
+     * or this instance if this collection does not support duplicates and it already contains the element.
      */
     public fun adding(element: @UnsafeVariance E): PersistentCollection<E> = @Suppress("DEPRECATION") add(element)
 
     /**
-     * Returns the result of adding the specified [element] to this collection.
+     * Returns a new persistent collection with the specified [element] added,
+     * or this instance if this collection does not support duplicates and it already contains the element.
      *
      * Use the function [adding] to make it clear that a new collection is returned.
      *
@@ -43,10 +41,6 @@ public interface PersistentCollection<out E> : ImmutableCollection<E> {
      * were deprecated and will be removed in future releases. Refer to the
      * [Migration guide](https://github.com/Kotlin/kotlinx.collections.immutable/blob/master/docs/0.5.0-MIGRATION.md)
      * for more details and guidance with the migration.
-     *
-     * @return a new persistent collection with the specified [element] added;
-     *         or this instance if this collection does not support duplicates,
-     *         and it already contains the element.
      */
     @Deprecated(
         "Use adding() instead. For more details, read the documentation for this function.",
@@ -55,16 +49,15 @@ public interface PersistentCollection<out E> : ImmutableCollection<E> {
     public fun add(element: @UnsafeVariance E): PersistentCollection<E>
 
     /**
-     * Returns the result of adding all elements of the specified [elements] collection to this collection.
-     *
-     * @return a new persistent collection with elements of the specified [elements] collection added;
-     *         or this instance if no modifications were made in the result of this operation.
+     * Returns a new persistent collection with elements of the specified [elements] collection added,
+     * or this instance if no modifications were made in the result of this operation.
      */
     public fun addingAll(elements: Collection<@UnsafeVariance E>): PersistentCollection<E> =
         @Suppress("DEPRECATION") addAll(elements)
 
     /**
-     * Returns the result of adding all elements of the specified [elements] collection to this collection.
+     * Returns a new persistent collection with elements of the specified [elements] collection added,
+     * or this instance if no modifications were made in the result of this operation.
      *
      * Use the function [addingAll] to make it clear that a new collection is returned.
      *
@@ -72,9 +65,6 @@ public interface PersistentCollection<out E> : ImmutableCollection<E> {
      * were deprecated and will be removed in future releases. Refer to the
      * [Migration guide](https://github.com/Kotlin/kotlinx.collections.immutable/blob/master/docs/0.5.0-MIGRATION.md)
      * for more details and guidance with the migration.
-     *
-     * @return a new persistent collection with elements of the specified [elements] collection added;
-     *         or this instance if no modifications were made in the result of this operation.
      */
     @Deprecated(
         "Use addingAll() instead. For more details, read the documentation for this function.",
@@ -83,15 +73,14 @@ public interface PersistentCollection<out E> : ImmutableCollection<E> {
     public fun addAll(elements: Collection<@UnsafeVariance E>): PersistentCollection<E>
 
     /**
-     * Returns the result of removing a single appearance of the specified [element] from this collection.
-     *
-     * @return a new persistent collection with a single appearance of the specified [element] removed;
-     *         or this instance if there is no such element in this collection.
+     * Returns a new persistent collection with a single appearance of the specified [element] removed,
+     * or this instance if there is no such element in this collection.
      */
     public fun removing(element: @UnsafeVariance E): PersistentCollection<E> = @Suppress("DEPRECATION") remove(element)
 
     /**
-     * Returns the result of removing a single appearance of the specified [element] from this collection.
+     * Returns a new persistent collection with a single appearance of the specified [element] removed,
+     * or this instance if there is no such element in this collection.
      *
      * Use the function [removing] to make it clear that a new collection is returned.
      *
@@ -99,9 +88,6 @@ public interface PersistentCollection<out E> : ImmutableCollection<E> {
      * were deprecated and will be removed in future releases. Refer to the
      * [Migration guide](https://github.com/Kotlin/kotlinx.collections.immutable/blob/master/docs/0.5.0-MIGRATION.md)
      * for more details and guidance with the migration.
-     *
-     * @return a new persistent collection with a single appearance of the specified [element] removed;
-     *         or this instance if there is no such element in this collection.
      */
     @Deprecated(
         "Use removing() instead. For more details, read the documentation for this function.",
@@ -110,19 +96,17 @@ public interface PersistentCollection<out E> : ImmutableCollection<E> {
     public fun remove(element: @UnsafeVariance E): PersistentCollection<E>
 
     /**
-     * Returns the result of removing all elements in this collection that are also
-     * contained in the specified [elements] collection.
-     *
-     * @return a new persistent collection with elements in this collection that are also
-     *         contained in the specified [elements] collection removed;
-     *         or this instance if no modifications were made in the result of this operation.
+     * Returns a new persistent collection with elements in this collection that are also
+     * contained in the specified [elements] collection removed,
+     * or this instance if no modifications were made in the result of this operation.
      */
     public fun removingAll(elements: Collection<@UnsafeVariance E>): PersistentCollection<E> =
         @Suppress("DEPRECATION") removeAll(elements)
 
     /**
-     * Returns the result of removing all elements in this collection that are also
-     * contained in the specified [elements] collection.
+     * Returns a new persistent collection with elements in this collection that are also
+     * contained in the specified [elements] collection removed,
+     * or this instance if no modifications were made in the result of this operation.
      *
      * Use the function [removingAll] to make it clear that a new collection is returned.
      *
@@ -130,10 +114,6 @@ public interface PersistentCollection<out E> : ImmutableCollection<E> {
      * were deprecated and will be removed in future releases. Refer to the
      * [Migration guide](https://github.com/Kotlin/kotlinx.collections.immutable/blob/master/docs/0.5.0-MIGRATION.md)
      * for more details and guidance with the migration.
-     *
-     * @return a new persistent collection with elements in this collection that are also
-     *         contained in the specified [elements] collection removed;
-     *         or this instance if no modifications were made in the result of this operation.
      */
     @Deprecated(
         "Use removingAll() instead. For more details, read the documentation for this function.",
@@ -142,16 +122,15 @@ public interface PersistentCollection<out E> : ImmutableCollection<E> {
     public fun removeAll(elements: Collection<@UnsafeVariance E>): PersistentCollection<E>
 
     /**
-     * Returns the result of removing all elements in this collection that match the specified [predicate].
-     *
-     * @return a new persistent collection with elements matching the specified [predicate] removed;
-     *         or this instance if no elements match the predicate.
+     * Returns a new persistent collection with elements matching the specified [predicate] removed,
+     * or this instance if no elements match the predicate.
      */
     public fun removingAll(predicate: (E) -> Boolean): PersistentCollection<E> =
         @Suppress("DEPRECATION") removeAll(predicate)
 
     /**
-     * Returns the result of removing all elements in this collection that match the specified [predicate].
+     * Returns a new persistent collection with elements matching the specified [predicate] removed,
+     * or this instance if no elements match the predicate.
      *
      * Use the function [removingAll] to make it clear that a new collection is returned.
      *
@@ -159,9 +138,6 @@ public interface PersistentCollection<out E> : ImmutableCollection<E> {
      * were deprecated and will be removed in future releases. Refer to the
      * [Migration guide](https://github.com/Kotlin/kotlinx.collections.immutable/blob/master/docs/0.5.0-MIGRATION.md)
      * for more details and guidance with the migration.
-     *
-     * @return a new persistent collection with elements matching the specified [predicate] removed;
-     *         or this instance if no elements match the predicate.
      */
     @Deprecated(
         "Use removingAll() instead. For more details, read the documentation for this function.",
@@ -170,19 +146,17 @@ public interface PersistentCollection<out E> : ImmutableCollection<E> {
     public fun removeAll(predicate: (E) -> Boolean): PersistentCollection<E>
 
     /**
-     * Returns all elements in this collection that are also
-     * contained in the specified [elements] collection.
-     *
-     * @return a new persistent collection with elements in this collection that are also
-     *         contained in the specified [elements] collection;
-     *         or this instance if no modifications were made in the result of this operation.
+     * Returns a new persistent collection with elements in this collection that are also
+     * contained in the specified [elements] collection,
+     * or this instance if no modifications were made in the result of this operation.
      */
     public fun retainingAll(elements: Collection<@UnsafeVariance E>): PersistentCollection<E> =
         @Suppress("DEPRECATION") retainAll(elements)
 
     /**
-     * Returns all elements in this collection that are also
-     * contained in the specified [elements] collection.
+     * Returns a new persistent collection with elements in this collection that are also
+     * contained in the specified [elements] collection,
+     * or this instance if no modifications were made in the result of this operation.
      *
      * Use the function [retainingAll] to make it clear that a new collection is returned.
      *
@@ -190,10 +164,6 @@ public interface PersistentCollection<out E> : ImmutableCollection<E> {
      * were deprecated and will be removed in future releases. Refer to the
      * [Migration guide](https://github.com/Kotlin/kotlinx.collections.immutable/blob/master/docs/0.5.0-MIGRATION.md)
      * for more details and guidance with the migration.
-     *
-     * @return a new persistent collection with elements in this collection that are also
-     *         contained in the specified [elements] collection;
-     *         or this instance if no modifications were made in the result of this operation.
      */
     @Deprecated(
         "Use retainingAll() instead. For more details, read the documentation for this function.",
@@ -202,14 +172,12 @@ public interface PersistentCollection<out E> : ImmutableCollection<E> {
     public fun retainAll(elements: Collection<@UnsafeVariance E>): PersistentCollection<E>
 
     /**
-     * Returns the result of removing all elements from this collection.
-     *
-     * @return an empty persistent collection.
+     * Returns an empty persistent collection.
      */
     public fun cleared(): PersistentCollection<E> = @Suppress("DEPRECATION") clear()
 
     /**
-     * Returns the result of removing all elements from this collection.
+     * Returns an empty persistent collection.
      *
      * Use the function [cleared] to make it clear that a new collection is returned.
      *
@@ -217,8 +185,6 @@ public interface PersistentCollection<out E> : ImmutableCollection<E> {
      * were deprecated and will be removed in future releases. Refer to the
      * [Migration guide](https://github.com/Kotlin/kotlinx.collections.immutable/blob/master/docs/0.5.0-MIGRATION.md)
      * for more details and guidance with the migration.
-     *
-     * @return an empty persistent collection.
      */
     @Deprecated(
         "Use cleared() instead. For more details, read the documentation for this function.",
@@ -244,25 +210,21 @@ public interface PersistentCollection<out E> : ImmutableCollection<E> {
      */
     public interface Builder<E> : MutableCollection<E> {
         /**
-         * Builds a persistent collection with the same contents as this builder.
+         * Returns a persistent collection with the same contents as this builder.
          *
          * This method can be called multiple times.
          *
          * If operations applied on this builder have caused no modifications:
          * - on the first call it returns the same persistent collection instance this builder was obtained from.
          * - on subsequent calls it returns the same previously returned persistent collection instance.
-         *
-         * @return a persistent collection with the same contents as this builder.
          */
         public fun build(): PersistentCollection<E>
     }
 
     /**
-     * Creates a new builder with the same contents as this collection.
+     * Returns a new builder with the same contents as this collection.
      *
      * The builder can be used to efficiently perform multiple modification operations.
-     *
-     * @return a new builder with the same contents as this collection.
      */
     public fun builder(): Builder<@UnsafeVariance E>
 }

--- a/core/commonMain/src/ImmutableList.kt
+++ b/core/commonMain/src/ImmutableList.kt
@@ -20,9 +20,11 @@ import kotlinx.collections.immutable.internal.ListImplementation
 public interface ImmutableList<out E> : List<E>, ImmutableCollection<E> {
 
     /**
-     * Returns a view of the portion of this list between the specified [fromIndex] (inclusive) and [toIndex] (exclusive).
+     * Creates a view of the portion of this list between the specified [fromIndex] (inclusive) and [toIndex] (exclusive).
      *
      * The returned list is backed by this list.
+     *
+     * @return a view of the portion of this list between the specified [fromIndex] (inclusive) and [toIndex] (exclusive).
      *
      * @throws IndexOutOfBoundsException if [fromIndex] is less than zero or [toIndex] is greater than the size of this list.
      * @throws IllegalArgumentException if [fromIndex] is greater than [toIndex].
@@ -65,12 +67,14 @@ public interface ImmutableList<out E> : List<E>, ImmutableCollection<E> {
  */
 public interface PersistentList<out E> : ImmutableList<E>, PersistentCollection<E> {
     /**
-     * Returns a new persistent list with the specified [element] appended.
+     * Returns the result of appending the specified [element] to this list.
+     *
+     * @return a new persistent list with the specified [element] appended.
      */
     override fun adding(element: @UnsafeVariance E): PersistentList<E> = @Suppress("DEPRECATION") add(element)
 
     /**
-     * Returns a new persistent list with the specified [element] appended.
+     * Returns the result of appending the specified [element] to this list.
      *
      * Use the function [adding] to make it clear that a new list is returned.
      *
@@ -78,6 +82,8 @@ public interface PersistentList<out E> : ImmutableList<E>, PersistentCollection<
      * were deprecated and will be removed in future releases. Refer to the
      * [Migration guide](https://github.com/Kotlin/kotlinx.collections.immutable/blob/master/docs/0.5.0-MIGRATION.md)
      * for more details and guidance with the migration.
+     *
+     * @return a new persistent list with the specified [element] appended.
      */
     @Deprecated(
         "Use adding() instead. For more details, read the documentation for this function.",
@@ -237,12 +243,14 @@ public interface PersistentList<out E> : ImmutableList<E>, PersistentCollection<
     override fun retainAll(elements: Collection<@UnsafeVariance E>): PersistentList<E>
 
     /**
-     * Returns an empty persistent list.
+     * Returns the result of removing all elements from this list.
+     *
+     * @return an empty persistent list.
      */
     override fun cleared(): PersistentList<E> = @Suppress("DEPRECATION") clear()
 
     /**
-     * Returns an empty persistent list.
+     * Returns the result of removing all elements from this list.
      *
      * Use the function [cleared] to make it clear that a new list is returned.
      *
@@ -250,6 +258,8 @@ public interface PersistentList<out E> : ImmutableList<E>, PersistentCollection<
      * were deprecated and will be removed in future releases. Refer to the
      * [Migration guide](https://github.com/Kotlin/kotlinx.collections.immutable/blob/master/docs/0.5.0-MIGRATION.md)
      * for more details and guidance with the migration.
+     *
+     * @return an empty persistent list.
      */
     @Deprecated(
         "Use cleared() instead. For more details, read the documentation for this function.",
@@ -290,7 +300,7 @@ public interface PersistentList<out E> : ImmutableList<E>, PersistentCollection<
     public fun addAll(index: Int, c: Collection<@UnsafeVariance E>): PersistentList<E>
 
     /**
-     * Returns the result with the element at the specified [index] replaced with the specified [element].
+     * Returns the result of replacing the element at the specified [index] with the specified [element].
      *
      * @return a new persistent list with the element at the specified [index] replaced with the specified [element].
      *
@@ -300,7 +310,7 @@ public interface PersistentList<out E> : ImmutableList<E>, PersistentCollection<
         @Suppress("DEPRECATION") set(index, element)
 
     /**
-     * Returns the result with the element at the specified [index] replaced with the specified [element].
+     * Returns the result of replacing the element at the specified [index] with the specified [element].
      *
      * Use the function [replacingAt] to make it clear that a new list is returned.
      *
@@ -320,7 +330,7 @@ public interface PersistentList<out E> : ImmutableList<E>, PersistentCollection<
     public fun set(index: Int, element: @UnsafeVariance E): PersistentList<E>
 
     /**
-     * Returns a new persistent list with the specified [element] inserted at the specified [index].
+     * Returns the result of inserting the specified [element] at the specified [index].
      *
      * @return a new persistent list with the specified [element] inserted at the specified [index].
      *
@@ -330,7 +340,7 @@ public interface PersistentList<out E> : ImmutableList<E>, PersistentCollection<
         @Suppress("DEPRECATION") add(index, element)
 
     /**
-     * Returns a new persistent list with the specified [element] inserted at the specified [index].
+     * Returns the result of inserting the specified [element] at the specified [index].
      *
      * Use the function [addingAt] to make it clear that a new list is returned.
      *
@@ -350,7 +360,7 @@ public interface PersistentList<out E> : ImmutableList<E>, PersistentCollection<
     public fun add(index: Int, element: @UnsafeVariance E): PersistentList<E>
 
     /**
-     * Returns a new persistent list with the element at the specified [index] removed.
+     * Returns the result of removing the element at the specified [index] from this list.
      *
      * @return a new persistent list with the element at the specified [index] removed.
      *
@@ -359,7 +369,7 @@ public interface PersistentList<out E> : ImmutableList<E>, PersistentCollection<
     public fun removingAt(index: Int): PersistentList<E> = @Suppress("DEPRECATION") removeAt(index)
 
     /**
-     * Returns a new persistent list with the element at the specified [index] removed.
+     * Returns the result of removing the element at the specified [index] from this list.
      *
      * Use the function [removingAt] to make it clear that a new list is returned.
      *

--- a/core/commonMain/src/ImmutableList.kt
+++ b/core/commonMain/src/ImmutableList.kt
@@ -137,17 +137,17 @@ public interface PersistentList<out E> : ImmutableList<E>, PersistentCollection<
     override fun remove(element: @UnsafeVariance E): PersistentList<E>
 
     /**
-     * Returns a new persistent list with elements in this list that are also
-     * contained in the specified [elements] collection removed,
-     * or this instance if no modifications were made in the result of this operation.
+     * Returns a new persistent list containing all elements of this list
+     * except the elements contained in the specified [elements] collection,
+     * or this instance if there are no elements to remove.
      */
     override fun removingAll(elements: Collection<@UnsafeVariance E>): PersistentList<E> =
         @Suppress("DEPRECATION") removeAll(elements)
 
     /**
-     * Returns a new persistent list with elements in this list that are also
-     * contained in the specified [elements] collection removed,
-     * or this instance if no modifications were made in the result of this operation.
+     * Returns a new persistent list containing all elements of this list
+     * except the elements contained in the specified [elements] collection,
+     * or this instance if there are no elements to remove.
      *
      * Use the function [removingAll] to make it clear that a new list is returned.
      *

--- a/core/commonMain/src/ImmutableList.kt
+++ b/core/commonMain/src/ImmutableList.kt
@@ -20,11 +20,9 @@ import kotlinx.collections.immutable.internal.ListImplementation
 public interface ImmutableList<out E> : List<E>, ImmutableCollection<E> {
 
     /**
-     * Creates a view of the portion of this list between the specified [fromIndex] (inclusive) and [toIndex] (exclusive).
+     * Returns a view of the portion of this list between the specified [fromIndex] (inclusive) and [toIndex] (exclusive).
      *
      * The returned list is backed by this list.
-     *
-     * @return a view of the portion of this list between the specified [fromIndex] (inclusive) and [toIndex] (exclusive).
      *
      * @throws IndexOutOfBoundsException if [fromIndex] is less than zero or [toIndex] is greater than the size of this list.
      * @throws IllegalArgumentException if [fromIndex] is greater than [toIndex].
@@ -67,14 +65,12 @@ public interface ImmutableList<out E> : List<E>, ImmutableCollection<E> {
  */
 public interface PersistentList<out E> : ImmutableList<E>, PersistentCollection<E> {
     /**
-     * Returns the result of appending the specified [element] to this list.
-     *
-     * @return a new persistent list with the specified [element] appended.
+     * Returns a new persistent list with the specified [element] appended.
      */
     override fun adding(element: @UnsafeVariance E): PersistentList<E> = @Suppress("DEPRECATION") add(element)
 
     /**
-     * Returns the result of appending the specified [element] to this list.
+     * Returns a new persistent list with the specified [element] appended.
      *
      * Use the function [adding] to make it clear that a new list is returned.
      *
@@ -82,8 +78,6 @@ public interface PersistentList<out E> : ImmutableList<E>, PersistentCollection<
      * were deprecated and will be removed in future releases. Refer to the
      * [Migration guide](https://github.com/Kotlin/kotlinx.collections.immutable/blob/master/docs/0.5.0-MIGRATION.md)
      * for more details and guidance with the migration.
-     *
-     * @return a new persistent list with the specified [element] appended.
      */
     @Deprecated(
         "Use adding() instead. For more details, read the documentation for this function.",
@@ -92,18 +86,17 @@ public interface PersistentList<out E> : ImmutableList<E>, PersistentCollection<
     override fun add(element: @UnsafeVariance E): PersistentList<E>
 
     /**
-     * Returns the result of appending all elements of the specified [elements] collection to this list.
+     * Returns a new persistent list with elements of the specified [elements] collection appended,
+     * or this instance if the specified collection is empty.
      *
      * The elements are appended in the order they appear in the specified collection.
-     *
-     * @return a new persistent list with elements of the specified [elements] collection appended;
-     *         or this instance if the specified collection is empty.
      */
     override fun addingAll(elements: Collection<@UnsafeVariance E>): PersistentList<E> =
         @Suppress("DEPRECATION") addAll(elements)
 
     /**
-     * Returns the result of appending all elements of the specified [elements] collection to this list.
+     * Returns a new persistent list with elements of the specified [elements] collection appended,
+     * or this instance if the specified collection is empty.
      *
      * The elements are appended in the order they appear in the specified collection.
      *
@@ -113,9 +106,6 @@ public interface PersistentList<out E> : ImmutableList<E>, PersistentCollection<
      * were deprecated and will be removed in future releases. Refer to the
      * [Migration guide](https://github.com/Kotlin/kotlinx.collections.immutable/blob/master/docs/0.5.0-MIGRATION.md)
      * for more details and guidance with the migration.
-     *
-     * @return a new persistent list with elements of the specified [elements] collection appended;
-     *         or this instance if the specified collection is empty.
      */
     @Deprecated(
         "Use addingAll() instead. For more details, read the documentation for this function.",
@@ -124,15 +114,14 @@ public interface PersistentList<out E> : ImmutableList<E>, PersistentCollection<
     override fun addAll(elements: Collection<@UnsafeVariance E>): PersistentList<E>
 
     /**
-     * Returns the result of removing the first appearance of the specified [element] from this list.
-     *
-     * @return a new persistent list with the first appearance of the specified [element] removed;
-     *         or this instance if there is no such element in this list.
+     * Returns a new persistent list with the first appearance of the specified [element] removed,
+     * or this instance if there is no such element in this list.
      */
     override fun removing(element: @UnsafeVariance E): PersistentList<E> = @Suppress("DEPRECATION") remove(element)
 
     /**
-     * Returns the result of removing the first appearance of the specified [element] from this list.
+     * Returns a new persistent list with the first appearance of the specified [element] removed,
+     * or this instance if there is no such element in this list.
      *
      * Use the function [removing] to make it clear that a new list is returned.
      *
@@ -140,9 +129,6 @@ public interface PersistentList<out E> : ImmutableList<E>, PersistentCollection<
      * were deprecated and will be removed in future releases. Refer to the
      * [Migration guide](https://github.com/Kotlin/kotlinx.collections.immutable/blob/master/docs/0.5.0-MIGRATION.md)
      * for more details and guidance with the migration.
-     *
-     * @return a new persistent list with the first appearance of the specified [element] removed;
-     *         or this instance if there is no such element in this list.
      */
     @Deprecated(
         "Use removing() instead. For more details, read the documentation for this function.",
@@ -151,19 +137,17 @@ public interface PersistentList<out E> : ImmutableList<E>, PersistentCollection<
     override fun remove(element: @UnsafeVariance E): PersistentList<E>
 
     /**
-     * Returns the result of removing all elements in this list that are also
-     * contained in the specified [elements] collection.
-     *
-     * @return a new persistent list with elements in this list that are also
-     *         contained in the specified [elements] collection removed;
-     *         or this instance if no modifications were made in the result of this operation.
+     * Returns a new persistent list with elements in this list that are also
+     * contained in the specified [elements] collection removed,
+     * or this instance if no modifications were made in the result of this operation.
      */
     override fun removingAll(elements: Collection<@UnsafeVariance E>): PersistentList<E> =
         @Suppress("DEPRECATION") removeAll(elements)
 
     /**
-     * Returns the result of removing all elements in this list that are also
-     * contained in the specified [elements] collection.
+     * Returns a new persistent list with elements in this list that are also
+     * contained in the specified [elements] collection removed,
+     * or this instance if no modifications were made in the result of this operation.
      *
      * Use the function [removingAll] to make it clear that a new list is returned.
      *
@@ -171,10 +155,6 @@ public interface PersistentList<out E> : ImmutableList<E>, PersistentCollection<
      * were deprecated and will be removed in future releases. Refer to the
      * [Migration guide](https://github.com/Kotlin/kotlinx.collections.immutable/blob/master/docs/0.5.0-MIGRATION.md)
      * for more details and guidance with the migration.
-     *
-     * @return a new persistent list with elements in this list that are also
-     *         contained in the specified [elements] collection removed;
-     *         or this instance if no modifications were made in the result of this operation.
      */
     @Deprecated(
         "Use removingAll() instead. For more details, read the documentation for this function.",
@@ -183,16 +163,15 @@ public interface PersistentList<out E> : ImmutableList<E>, PersistentCollection<
     override fun removeAll(elements: Collection<@UnsafeVariance E>): PersistentList<E>
 
     /**
-     * Returns the result of removing all elements in this list that match the specified [predicate].
-     *
-     * @return a new persistent list with elements matching the specified [predicate] removed;
-     *         or this instance if no elements match the predicate.
+     * Returns a new persistent list with elements matching the specified [predicate] removed,
+     * or this instance if no elements match the predicate.
      */
     override fun removingAll(predicate: (E) -> Boolean): PersistentList<E> =
         @Suppress("DEPRECATION") removeAll(predicate)
 
     /**
-     * Returns the result of removing all elements in this list that match the specified [predicate].
+     * Returns a new persistent list with elements matching the specified [predicate] removed,
+     * or this instance if no elements match the predicate.
      *
      * Use the function [removingAll] to make it clear that a new list is returned.
      *
@@ -200,9 +179,6 @@ public interface PersistentList<out E> : ImmutableList<E>, PersistentCollection<
      * were deprecated and will be removed in future releases. Refer to the
      * [Migration guide](https://github.com/Kotlin/kotlinx.collections.immutable/blob/master/docs/0.5.0-MIGRATION.md)
      * for more details and guidance with the migration.
-     *
-     * @return a new persistent list with elements matching the specified [predicate] removed;
-     *         or this instance if no elements match the predicate.
      */
     @Deprecated(
         "Use removingAll() instead. For more details, read the documentation for this function.",
@@ -211,19 +187,17 @@ public interface PersistentList<out E> : ImmutableList<E>, PersistentCollection<
     override fun removeAll(predicate: (E) -> Boolean): PersistentList<E>
 
     /**
-     * Returns all elements in this list that are also
-     * contained in the specified [elements] collection.
-     *
-     * @return a new persistent list with elements in this list that are also
-     *         contained in the specified [elements] collection;
-     *         or this instance if no modifications were made in the result of this operation.
+     * Returns a new persistent list with elements in this list that are also
+     * contained in the specified [elements] collection,
+     * or this instance if no modifications were made in the result of this operation.
      */
     override fun retainingAll(elements: Collection<@UnsafeVariance E>): PersistentList<E> =
         @Suppress("DEPRECATION") retainAll(elements)
 
     /**
-     * Returns all elements in this list that are also
-     * contained in the specified [elements] collection.
+     * Returns a new persistent list with elements in this list that are also
+     * contained in the specified [elements] collection,
+     * or this instance if no modifications were made in the result of this operation.
      *
      * Use the function [retainingAll] to make it clear that a new list is returned.
      *
@@ -231,10 +205,6 @@ public interface PersistentList<out E> : ImmutableList<E>, PersistentCollection<
      * were deprecated and will be removed in future releases. Refer to the
      * [Migration guide](https://github.com/Kotlin/kotlinx.collections.immutable/blob/master/docs/0.5.0-MIGRATION.md)
      * for more details and guidance with the migration.
-     *
-     * @return a new persistent list with elements in this list that are also
-     *         contained in the specified [elements] collection;
-     *         or this instance if no modifications were made in the result of this operation.
      */
     @Deprecated(
         "Use retainingAll() instead. For more details, read the documentation for this function.",
@@ -243,14 +213,12 @@ public interface PersistentList<out E> : ImmutableList<E>, PersistentCollection<
     override fun retainAll(elements: Collection<@UnsafeVariance E>): PersistentList<E>
 
     /**
-     * Returns the result of removing all elements from this list.
-     *
-     * @return an empty persistent list.
+     * Returns an empty persistent list.
      */
     override fun cleared(): PersistentList<E> = @Suppress("DEPRECATION") clear()
 
     /**
-     * Returns the result of removing all elements from this list.
+     * Returns an empty persistent list.
      *
      * Use the function [cleared] to make it clear that a new list is returned.
      *
@@ -258,8 +226,6 @@ public interface PersistentList<out E> : ImmutableList<E>, PersistentCollection<
      * were deprecated and will be removed in future releases. Refer to the
      * [Migration guide](https://github.com/Kotlin/kotlinx.collections.immutable/blob/master/docs/0.5.0-MIGRATION.md)
      * for more details and guidance with the migration.
-     *
-     * @return an empty persistent list.
      */
     @Deprecated(
         "Use cleared() instead. For more details, read the documentation for this function.",
@@ -268,10 +234,8 @@ public interface PersistentList<out E> : ImmutableList<E>, PersistentCollection<
     override fun clear(): PersistentList<E>
 
     /**
-     * Returns the result of inserting the specified [c] collection at the specified [index].
-     *
-     * @return a new persistent list with the specified [c] collection inserted at the specified [index];
-     *         or this instance if the specified collection is empty.
+     * Returns a new persistent list with the specified [c] collection inserted at the specified [index],
+     * or this instance if the specified collection is empty.
      *
      * @throws IndexOutOfBoundsException if [index] is out of bounds of this list.
      */
@@ -279,7 +243,8 @@ public interface PersistentList<out E> : ImmutableList<E>, PersistentCollection<
         @Suppress("DEPRECATION") addAll(index, c)
 
     /**
-     * Returns the result of inserting the specified [c] collection at the specified [index].
+     * Returns a new persistent list with the specified [c] collection inserted at the specified [index],
+     * or this instance if the specified collection is empty.
      *
      * Use the function [addingAllAt] to make it clear that a new list is returned.
      *
@@ -287,9 +252,6 @@ public interface PersistentList<out E> : ImmutableList<E>, PersistentCollection<
      * were deprecated and will be removed in future releases. Refer to the
      * [Migration guide](https://github.com/Kotlin/kotlinx.collections.immutable/blob/master/docs/0.5.0-MIGRATION.md)
      * for more details and guidance with the migration.
-     *
-     * @return a new persistent list with the specified [c] collection inserted at the specified [index];
-     *         or this instance if the specified collection is empty.
      *
      * @throws IndexOutOfBoundsException if [index] is out of bounds of this list.
      */
@@ -300,9 +262,7 @@ public interface PersistentList<out E> : ImmutableList<E>, PersistentCollection<
     public fun addAll(index: Int, c: Collection<@UnsafeVariance E>): PersistentList<E>
 
     /**
-     * Returns the result of replacing the element at the specified [index] with the specified [element].
-     *
-     * @return a new persistent list with the element at the specified [index] replaced with the specified [element].
+     * Returns a new persistent list with the element at the specified [index] replaced with the specified [element].
      *
      * @throws IndexOutOfBoundsException if [index] is out of bounds of this list.
      */
@@ -310,7 +270,7 @@ public interface PersistentList<out E> : ImmutableList<E>, PersistentCollection<
         @Suppress("DEPRECATION") set(index, element)
 
     /**
-     * Returns the result of replacing the element at the specified [index] with the specified [element].
+     * Returns a new persistent list with the element at the specified [index] replaced with the specified [element].
      *
      * Use the function [replacingAt] to make it clear that a new list is returned.
      *
@@ -318,8 +278,6 @@ public interface PersistentList<out E> : ImmutableList<E>, PersistentCollection<
      * were deprecated and will be removed in future releases. Refer to the
      * [Migration guide](https://github.com/Kotlin/kotlinx.collections.immutable/blob/master/docs/0.5.0-MIGRATION.md)
      * for more details and guidance with the migration.
-     *
-     * @return a new persistent list with the element at the specified [index] replaced with the specified [element].
      *
      * @throws IndexOutOfBoundsException if [index] is out of bounds of this list.
      */
@@ -330,9 +288,7 @@ public interface PersistentList<out E> : ImmutableList<E>, PersistentCollection<
     public fun set(index: Int, element: @UnsafeVariance E): PersistentList<E>
 
     /**
-     * Returns the result of inserting the specified [element] at the specified [index].
-     *
-     * @return a new persistent list with the specified [element] inserted at the specified [index].
+     * Returns a new persistent list with the specified [element] inserted at the specified [index].
      *
      * @throws IndexOutOfBoundsException if [index] is out of bounds of this list.
      */
@@ -340,7 +296,7 @@ public interface PersistentList<out E> : ImmutableList<E>, PersistentCollection<
         @Suppress("DEPRECATION") add(index, element)
 
     /**
-     * Returns the result of inserting the specified [element] at the specified [index].
+     * Returns a new persistent list with the specified [element] inserted at the specified [index].
      *
      * Use the function [addingAt] to make it clear that a new list is returned.
      *
@@ -348,8 +304,6 @@ public interface PersistentList<out E> : ImmutableList<E>, PersistentCollection<
      * were deprecated and will be removed in future releases. Refer to the
      * [Migration guide](https://github.com/Kotlin/kotlinx.collections.immutable/blob/master/docs/0.5.0-MIGRATION.md)
      * for more details and guidance with the migration.
-     *
-     * @return a new persistent list with the specified [element] inserted at the specified [index].
      *
      * @throws IndexOutOfBoundsException if [index] is out of bounds of this list.
      */
@@ -360,16 +314,14 @@ public interface PersistentList<out E> : ImmutableList<E>, PersistentCollection<
     public fun add(index: Int, element: @UnsafeVariance E): PersistentList<E>
 
     /**
-     * Returns the result of removing the element at the specified [index] from this list.
-     *
-     * @return a new persistent list with the element at the specified [index] removed.
+     * Returns a new persistent list with the element at the specified [index] removed.
      *
      * @throws IndexOutOfBoundsException if [index] is out of bounds of this list.
      */
     public fun removingAt(index: Int): PersistentList<E> = @Suppress("DEPRECATION") removeAt(index)
 
     /**
-     * Returns the result of removing the element at the specified [index] from this list.
+     * Returns a new persistent list with the element at the specified [index] removed.
      *
      * Use the function [removingAt] to make it clear that a new list is returned.
      *
@@ -377,8 +329,6 @@ public interface PersistentList<out E> : ImmutableList<E>, PersistentCollection<
      * were deprecated and will be removed in future releases. Refer to the
      * [Migration guide](https://github.com/Kotlin/kotlinx.collections.immutable/blob/master/docs/0.5.0-MIGRATION.md)
      * for more details and guidance with the migration.
-     *
-     * @return a new persistent list with the element at the specified [index] removed.
      *
      * @throws IndexOutOfBoundsException if [index] is out of bounds of this list.
      */

--- a/core/commonMain/src/ImmutableMap.kt
+++ b/core/commonMain/src/ImmutableMap.kt
@@ -159,12 +159,14 @@ public interface PersistentMap<K, out V> : ImmutableMap<K, V> {
     public fun putAll(m: Map<out K, @UnsafeVariance V>): PersistentMap<K, V>
 
     /**
-     * Returns an empty persistent map.
+     * Returns the result of removing all entries from this map.
+     *
+     * @return an empty persistent map.
      */
     public fun cleared(): PersistentMap<K, V> = @Suppress("DEPRECATION") clear()
 
     /**
-     * Returns an empty persistent map.
+     * Returns the result of removing all entries from this map.
      *
      * Use the function [cleared] to make it clear that a new map is returned.
      *
@@ -172,6 +174,8 @@ public interface PersistentMap<K, out V> : ImmutableMap<K, V> {
      * were deprecated and will be removed in future releases. Refer to the
      * [Migration guide](https://github.com/Kotlin/kotlinx.collections.immutable/blob/master/docs/0.5.0-MIGRATION.md)
      * for more details and guidance with the migration.
+     *
+     * @return an empty persistent map.
      */
     @Deprecated(
         "Use cleared() instead. For more details, read the documentation for this function.",
@@ -197,21 +201,25 @@ public interface PersistentMap<K, out V> : ImmutableMap<K, V> {
      */
     public interface Builder<K, V> : MutableMap<K, V> {
         /**
-         * Returns a persistent map with the same contents as this builder.
+         * Builds a persistent map with the same contents as this builder.
          *
          * This method can be called multiple times.
          *
          * If operations applied on this builder have caused no modifications:
          * - on the first call it returns the same persistent map instance this builder was obtained from.
          * - on subsequent calls it returns the same previously returned persistent map instance.
+         *
+         * @return a persistent map with the same contents as this builder.
          */
         public fun build(): PersistentMap<K, V>
     }
 
     /**
-     * Returns a new builder with the same contents as this map.
+     * Creates a new builder with the same contents as this map.
      *
      * The builder can be used to efficiently perform multiple modification operations.
+     *
+     * @return a new builder with the same contents as this map.
      */
     public fun builder(): Builder<K, @UnsafeVariance V>
 }

--- a/core/commonMain/src/ImmutableMap.kt
+++ b/core/commonMain/src/ImmutableMap.kt
@@ -40,17 +40,16 @@ public interface ImmutableMap<K, out V> : Map<K, V> {
  */
 public interface PersistentMap<K, out V> : ImmutableMap<K, V> {
     /**
-     * Returns the result of associating the specified [value] with the specified [key] in this map.
+     * Returns a new persistent map with the specified [value] associated with the specified [key],
+     * or this instance if no modifications were made in the result of this operation.
      *
      * If this map already contains a mapping for the key, the old value is replaced by the specified value.
-     *
-     * @return a new persistent map with the specified [value] associated with the specified [key];
-     *         or this instance if no modifications were made in the result of this operation.
      */
     public fun putting(key: K, value: @UnsafeVariance V): PersistentMap<K, V> = @Suppress("DEPRECATION") put(key, value)
 
     /**
-     * Returns the result of associating the specified [value] with the specified [key] in this map.
+     * Returns a new persistent map with the specified [value] associated with the specified [key],
+     * or this instance if no modifications were made in the result of this operation.
      *
      * If this map already contains a mapping for the key, the old value is replaced by the specified value.
      *
@@ -60,9 +59,6 @@ public interface PersistentMap<K, out V> : ImmutableMap<K, V> {
      * were deprecated and will be removed in future releases. Refer to the
      * [Migration guide](https://github.com/Kotlin/kotlinx.collections.immutable/blob/master/docs/0.5.0-MIGRATION.md)
      * for more details and guidance with the migration.
-     *
-     * @return a new persistent map with the specified [value] associated with the specified [key];
-     *         or this instance if no modifications were made in the result of this operation.
      */
     @Deprecated(
         "Use putting() instead. For more details, read the documentation for this function.",
@@ -71,15 +67,14 @@ public interface PersistentMap<K, out V> : ImmutableMap<K, V> {
     public fun put(key: K, value: @UnsafeVariance V): PersistentMap<K, V>
 
     /**
-     * Returns the result of removing the specified [key] and its corresponding value from this map.
-     *
-     * @return a new persistent map with the specified [key] and its corresponding value removed;
-     *         or this instance if it contains no mapping for the key.
+     * Returns a new persistent map with the specified [key] and its corresponding value removed,
+     * or this instance if it contains no mapping for the key.
      */
     public fun removing(key: K): PersistentMap<K, V> = @Suppress("DEPRECATION") remove(key)
 
     /**
-     * Returns the result of removing the specified [key] and its corresponding value from this map.
+     * Returns a new persistent map with the specified [key] and its corresponding value removed,
+     * or this instance if it contains no mapping for the key.
      *
      * Use the function [removing] to make it clear that a new map is returned.
      *
@@ -87,9 +82,6 @@ public interface PersistentMap<K, out V> : ImmutableMap<K, V> {
      * were deprecated and will be removed in future releases. Refer to the
      * [Migration guide](https://github.com/Kotlin/kotlinx.collections.immutable/blob/master/docs/0.5.0-MIGRATION.md)
      * for more details and guidance with the migration.
-     *
-     * @return a new persistent map with the specified [key] and its corresponding value removed;
-     *         or this instance if it contains no mapping for the key.
      */
     @Deprecated(
         "Use removing() instead. For more details, read the documentation for this function.",
@@ -98,16 +90,15 @@ public interface PersistentMap<K, out V> : ImmutableMap<K, V> {
     public fun remove(key: K): PersistentMap<K, V>
 
     /**
-     * Returns the result of removing the entry that maps the specified [key] to the specified [value].
-     *
-     * @return a new persistent map with the entry for the specified [key] and [value] removed;
-     *         or this instance if it contains no entry with the specified key and value.
+     * Returns a new persistent map with the entry for the specified [key] and [value] removed,
+     * or this instance if it contains no entry with the specified key and value.
      */
     public fun removing(key: K, value: @UnsafeVariance V): PersistentMap<K, V> =
         @Suppress("DEPRECATION") remove(key, value)
 
     /**
-     * Returns the result of removing the entry that maps the specified [key] to the specified [value].
+     * Returns a new persistent map with the entry for the specified [key] and [value] removed,
+     * or this instance if it contains no entry with the specified key and value.
      *
      * Use the function [removing] to make it clear that a new map is returned.
      *
@@ -115,9 +106,6 @@ public interface PersistentMap<K, out V> : ImmutableMap<K, V> {
      * were deprecated and will be removed in future releases. Refer to the
      * [Migration guide](https://github.com/Kotlin/kotlinx.collections.immutable/blob/master/docs/0.5.0-MIGRATION.md)
      * for more details and guidance with the migration.
-     *
-     * @return a new persistent map with the entry for the specified [key] and [value] removed;
-     *         or this instance if it contains no entry with the specified key and value.
      */
     @Deprecated(
         "Use removing() instead. For more details, read the documentation for this function.",
@@ -126,18 +114,17 @@ public interface PersistentMap<K, out V> : ImmutableMap<K, V> {
     public fun remove(key: K, value: @UnsafeVariance V): PersistentMap<K, V>
 
     /**
-     * Returns the result of merging the specified [m] map with this map.
+     * Returns a new persistent map with keys and values from the specified [m] map associated,
+     * or this instance if no modifications were made in the result of this operation.
      *
      * The effect of this call is equivalent to that of calling `put(k, v)` once for each
      * mapping from key `k` to value `v` in the specified map.
-     *
-     * @return a new persistent map with keys and values from the specified map [m] associated;
-     *         or this instance if no modifications were made in the result of this operation.
      */
     public fun puttingAll(m: Map<out K, @UnsafeVariance V>): PersistentMap<K, V> = @Suppress("DEPRECATION") putAll(m)
 
     /**
-     * Returns the result of merging the specified [m] map with this map.
+     * Returns a new persistent map with keys and values from the specified [m] map associated,
+     * or this instance if no modifications were made in the result of this operation.
      *
      * The effect of this call is equivalent to that of calling `put(k, v)` once for each
      * mapping from key `k` to value `v` in the specified map.
@@ -148,9 +135,6 @@ public interface PersistentMap<K, out V> : ImmutableMap<K, V> {
      * were deprecated and will be removed in future releases. Refer to the
      * [Migration guide](https://github.com/Kotlin/kotlinx.collections.immutable/blob/master/docs/0.5.0-MIGRATION.md)
      * for more details and guidance with the migration.
-     *
-     * @return a new persistent map with keys and values from the specified map [m] associated;
-     *         or this instance if no modifications were made in the result of this operation.
      */
     @Deprecated(
         "Use puttingAll() instead. For more details, read the documentation for this function.",
@@ -159,14 +143,12 @@ public interface PersistentMap<K, out V> : ImmutableMap<K, V> {
     public fun putAll(m: Map<out K, @UnsafeVariance V>): PersistentMap<K, V>
 
     /**
-     * Returns the result of removing all entries from this map.
-     *
-     * @return an empty persistent map.
+     * Returns an empty persistent map.
      */
     public fun cleared(): PersistentMap<K, V> = @Suppress("DEPRECATION") clear()
 
     /**
-     * Returns the result of removing all entries from this map.
+     * Returns an empty persistent map.
      *
      * Use the function [cleared] to make it clear that a new map is returned.
      *
@@ -174,8 +156,6 @@ public interface PersistentMap<K, out V> : ImmutableMap<K, V> {
      * were deprecated and will be removed in future releases. Refer to the
      * [Migration guide](https://github.com/Kotlin/kotlinx.collections.immutable/blob/master/docs/0.5.0-MIGRATION.md)
      * for more details and guidance with the migration.
-     *
-     * @return an empty persistent map.
      */
     @Deprecated(
         "Use cleared() instead. For more details, read the documentation for this function.",
@@ -201,25 +181,21 @@ public interface PersistentMap<K, out V> : ImmutableMap<K, V> {
      */
     public interface Builder<K, V> : MutableMap<K, V> {
         /**
-         * Builds a persistent map with the same contents as this builder.
+         * Returns a persistent map with the same contents as this builder.
          *
          * This method can be called multiple times.
          *
          * If operations applied on this builder have caused no modifications:
          * - on the first call it returns the same persistent map instance this builder was obtained from.
          * - on subsequent calls it returns the same previously returned persistent map instance.
-         *
-         * @return a persistent map with the same contents as this builder.
          */
         public fun build(): PersistentMap<K, V>
     }
 
     /**
-     * Creates a new builder with the same contents as this map.
+     * Returns a new builder with the same contents as this map.
      *
      * The builder can be used to efficiently perform multiple modification operations.
-     *
-     * @return a new builder with the same contents as this map.
      */
     public fun builder(): Builder<K, @UnsafeVariance V>
 }

--- a/core/commonMain/src/ImmutableSet.kt
+++ b/core/commonMain/src/ImmutableSet.kt
@@ -202,12 +202,14 @@ public interface PersistentSet<out E> : ImmutableSet<E>, PersistentCollection<E>
     override fun retainAll(elements: Collection<@UnsafeVariance E>): PersistentSet<E>
 
     /**
-     * Returns an empty persistent set.
+     * Returns the result of removing all elements from this set.
+     *
+     * @return an empty persistent set.
      */
     override fun cleared(): PersistentSet<E> = @Suppress("DEPRECATION") clear()
 
     /**
-     * Returns an empty persistent set.
+     * Returns the result of removing all elements from this set.
      *
      * Use the function [cleared] to make it clear that a new set is returned.
      *
@@ -215,6 +217,8 @@ public interface PersistentSet<out E> : ImmutableSet<E>, PersistentCollection<E>
      * were deprecated and will be removed in future releases. Refer to the
      * [Migration guide](https://github.com/Kotlin/kotlinx.collections.immutable/blob/master/docs/0.5.0-MIGRATION.md)
      * for more details and guidance with the migration.
+     *
+     * @return an empty persistent set.
      */
     @Deprecated(
         "Use cleared() instead. For more details, read the documentation for this function.",

--- a/core/commonMain/src/ImmutableSet.kt
+++ b/core/commonMain/src/ImmutableSet.kt
@@ -28,15 +28,14 @@ public interface ImmutableSet<out E> : Set<E>, ImmutableCollection<E>
  */
 public interface PersistentSet<out E> : ImmutableSet<E>, PersistentCollection<E> {
     /**
-     * Returns the result of adding the specified [element] to this set.
-     *
-     * @return a new persistent set with the specified [element] added;
-     *         or this instance if it already contains the element.
+     * Returns a new persistent set with the specified [element] added,
+     * or this instance if it already contains the element.
      */
     override fun adding(element: @UnsafeVariance E): PersistentSet<E> = @Suppress("DEPRECATION") add(element)
 
     /**
-     * Returns the result of adding the specified [element] to this set.
+     * Returns a new persistent set with the specified [element] added,
+     * or this instance if it already contains the element.
      *
      * Use the function [adding] to make it clear that a new set is returned.
      *
@@ -44,9 +43,6 @@ public interface PersistentSet<out E> : ImmutableSet<E>, PersistentCollection<E>
      * were deprecated and will be removed in future releases. Refer to the
      * [Migration guide](https://github.com/Kotlin/kotlinx.collections.immutable/blob/master/docs/0.5.0-MIGRATION.md)
      * for more details and guidance with the migration.
-     *
-     * @return a new persistent set with the specified [element] added;
-     *         or this instance if it already contains the element.
      */
     @Deprecated(
         "Use adding() instead. For more details, read the documentation for this function.",
@@ -55,16 +51,15 @@ public interface PersistentSet<out E> : ImmutableSet<E>, PersistentCollection<E>
     override fun add(element: @UnsafeVariance E): PersistentSet<E>
 
     /**
-     * Returns the result of adding all elements of the specified [elements] collection to this set.
-     *
-     * @return a new persistent set with elements of the specified [elements] collection added;
-     *         or this instance if it already contains every element of the specified collection.
+     * Returns a new persistent set with elements of the specified [elements] collection added,
+     * or this instance if it already contains every element of the specified collection.
      */
     override fun addingAll(elements: Collection<@UnsafeVariance E>): PersistentSet<E> =
         @Suppress("DEPRECATION") addAll(elements)
 
     /**
-     * Returns the result of adding all elements of the specified [elements] collection to this set.
+     * Returns a new persistent set with elements of the specified [elements] collection added,
+     * or this instance if it already contains every element of the specified collection.
      *
      * Use the function [addingAll] to make it clear that a new set is returned.
      *
@@ -72,9 +67,6 @@ public interface PersistentSet<out E> : ImmutableSet<E>, PersistentCollection<E>
      * were deprecated and will be removed in future releases. Refer to the
      * [Migration guide](https://github.com/Kotlin/kotlinx.collections.immutable/blob/master/docs/0.5.0-MIGRATION.md)
      * for more details and guidance with the migration.
-     *
-     * @return a new persistent set with elements of the specified [elements] collection added;
-     *         or this instance if it already contains every element of the specified collection.
      */
     @Deprecated(
         "Use addingAll() instead. For more details, read the documentation for this function.",
@@ -83,15 +75,14 @@ public interface PersistentSet<out E> : ImmutableSet<E>, PersistentCollection<E>
     override fun addAll(elements: Collection<@UnsafeVariance E>): PersistentSet<E>
 
     /**
-     * Returns the result of removing the specified [element] from this set.
-     *
-     * @return a new persistent set with the specified [element] removed;
-     *         or this instance if there is no such element in this set.
+     * Returns a new persistent set with the specified [element] removed,
+     * or this instance if there is no such element in this set.
      */
     override fun removing(element: @UnsafeVariance E): PersistentSet<E> = @Suppress("DEPRECATION") remove(element)
 
     /**
-     * Returns the result of removing the specified [element] from this set.
+     * Returns a new persistent set with the specified [element] removed,
+     * or this instance if there is no such element in this set.
      *
      * Use the function [removing] to make it clear that a new set is returned.
      *
@@ -99,9 +90,6 @@ public interface PersistentSet<out E> : ImmutableSet<E>, PersistentCollection<E>
      * were deprecated and will be removed in future releases. Refer to the
      * [Migration guide](https://github.com/Kotlin/kotlinx.collections.immutable/blob/master/docs/0.5.0-MIGRATION.md)
      * for more details and guidance with the migration.
-     *
-     * @return a new persistent set with the specified [element] removed;
-     *         or this instance if there is no such element in this set.
      */
     @Deprecated(
         "Use removing() instead. For more details, read the documentation for this function.",
@@ -110,19 +98,17 @@ public interface PersistentSet<out E> : ImmutableSet<E>, PersistentCollection<E>
     override fun remove(element: @UnsafeVariance E): PersistentSet<E>
 
     /**
-     * Returns the result of removing all elements in this set that are also
-     * contained in the specified [elements] collection.
-     *
-     * @return a new persistent set with elements in this set that are also
-     *         contained in the specified [elements] collection removed;
-     *         or this instance if no modifications were made in the result of this operation.
+     * Returns a new persistent set with elements in this set that are also
+     * contained in the specified [elements] collection removed,
+     * or this instance if no modifications were made in the result of this operation.
      */
     override fun removingAll(elements: Collection<@UnsafeVariance E>): PersistentSet<E> =
         @Suppress("DEPRECATION") removeAll(elements)
 
     /**
-     * Returns the result of removing all elements in this set that are also
-     * contained in the specified [elements] collection.
+     * Returns a new persistent set with elements in this set that are also
+     * contained in the specified [elements] collection removed,
+     * or this instance if no modifications were made in the result of this operation.
      *
      * Use the function [removingAll] to make it clear that a new set is returned.
      *
@@ -130,10 +116,6 @@ public interface PersistentSet<out E> : ImmutableSet<E>, PersistentCollection<E>
      * were deprecated and will be removed in future releases. Refer to the
      * [Migration guide](https://github.com/Kotlin/kotlinx.collections.immutable/blob/master/docs/0.5.0-MIGRATION.md)
      * for more details and guidance with the migration.
-     *
-     * @return a new persistent set with elements in this set that are also
-     *         contained in the specified [elements] collection removed;
-     *         or this instance if no modifications were made in the result of this operation.
      */
     @Deprecated(
         "Use removingAll() instead. For more details, read the documentation for this function.",
@@ -142,16 +124,15 @@ public interface PersistentSet<out E> : ImmutableSet<E>, PersistentCollection<E>
     override fun removeAll(elements: Collection<@UnsafeVariance E>): PersistentSet<E>
 
     /**
-     * Returns the result of removing all elements in this set that match the specified [predicate].
-     *
-     * @return a new persistent set with elements matching the specified [predicate] removed;
-     *         or this instance if no elements match the predicate.
+     * Returns a new persistent set with elements matching the specified [predicate] removed,
+     * or this instance if no elements match the predicate.
      */
     override fun removingAll(predicate: (E) -> Boolean): PersistentSet<E> =
         @Suppress("DEPRECATION") removeAll(predicate)
 
     /**
-     * Returns the result of removing all elements in this set that match the specified [predicate].
+     * Returns a new persistent set with elements matching the specified [predicate] removed,
+     * or this instance if no elements match the predicate.
      *
      * Use the function [removingAll] to make it clear that a new set is returned.
      *
@@ -159,9 +140,6 @@ public interface PersistentSet<out E> : ImmutableSet<E>, PersistentCollection<E>
      * were deprecated and will be removed in future releases. Refer to the
      * [Migration guide](https://github.com/Kotlin/kotlinx.collections.immutable/blob/master/docs/0.5.0-MIGRATION.md)
      * for more details and guidance with the migration.
-     *
-     * @return a new persistent set with elements matching the specified [predicate] removed;
-     *         or this instance if no elements match the predicate.
      */
     @Deprecated(
         "Use removingAll() instead. For more details, read the documentation for this function.",
@@ -170,19 +148,17 @@ public interface PersistentSet<out E> : ImmutableSet<E>, PersistentCollection<E>
     override fun removeAll(predicate: (E) -> Boolean): PersistentSet<E>
 
     /**
-     * Returns all elements in this set that are also
-     * contained in the specified [elements] collection.
-     *
-     * @return a new persistent set with elements in this set that are also
-     *         contained in the specified [elements] collection;
-     *         or this instance if no modifications were made in the result of this operation.
+     * Returns a new persistent set with elements in this set that are also
+     * contained in the specified [elements] collection,
+     * or this instance if no modifications were made in the result of this operation.
      */
     override fun retainingAll(elements: Collection<@UnsafeVariance E>): PersistentSet<E> =
         @Suppress("DEPRECATION") retainAll(elements)
 
     /**
-     * Returns all elements in this set that are also
-     * contained in the specified [elements] collection.
+     * Returns a new persistent set with elements in this set that are also
+     * contained in the specified [elements] collection,
+     * or this instance if no modifications were made in the result of this operation.
      *
      * Use the function [retainingAll] to make it clear that a new set is returned.
      *
@@ -190,10 +166,6 @@ public interface PersistentSet<out E> : ImmutableSet<E>, PersistentCollection<E>
      * were deprecated and will be removed in future releases. Refer to the
      * [Migration guide](https://github.com/Kotlin/kotlinx.collections.immutable/blob/master/docs/0.5.0-MIGRATION.md)
      * for more details and guidance with the migration.
-     *
-     * @return a new persistent set with elements in this set that are also
-     *         contained in the specified [elements] collection;
-     *         or this instance if no modifications were made in the result of this operation.
      */
     @Deprecated(
         "Use retainingAll() instead. For more details, read the documentation for this function.",
@@ -202,14 +174,12 @@ public interface PersistentSet<out E> : ImmutableSet<E>, PersistentCollection<E>
     override fun retainAll(elements: Collection<@UnsafeVariance E>): PersistentSet<E>
 
     /**
-     * Returns the result of removing all elements from this set.
-     *
-     * @return an empty persistent set.
+     * Returns an empty persistent set.
      */
     override fun cleared(): PersistentSet<E> = @Suppress("DEPRECATION") clear()
 
     /**
-     * Returns the result of removing all elements from this set.
+     * Returns an empty persistent set.
      *
      * Use the function [cleared] to make it clear that a new set is returned.
      *
@@ -217,8 +187,6 @@ public interface PersistentSet<out E> : ImmutableSet<E>, PersistentCollection<E>
      * were deprecated and will be removed in future releases. Refer to the
      * [Migration guide](https://github.com/Kotlin/kotlinx.collections.immutable/blob/master/docs/0.5.0-MIGRATION.md)
      * for more details and guidance with the migration.
-     *
-     * @return an empty persistent set.
      */
     @Deprecated(
         "Use cleared() instead. For more details, read the documentation for this function.",

--- a/core/commonMain/src/ImmutableSet.kt
+++ b/core/commonMain/src/ImmutableSet.kt
@@ -98,17 +98,17 @@ public interface PersistentSet<out E> : ImmutableSet<E>, PersistentCollection<E>
     override fun remove(element: @UnsafeVariance E): PersistentSet<E>
 
     /**
-     * Returns a new persistent set with elements in this set that are also
-     * contained in the specified [elements] collection removed,
-     * or this instance if no modifications were made in the result of this operation.
+     * Returns a new persistent set containing all elements of this set
+     * except the elements contained in the specified [elements] collection,
+     * or this instance if there are no elements to remove.
      */
     override fun removingAll(elements: Collection<@UnsafeVariance E>): PersistentSet<E> =
         @Suppress("DEPRECATION") removeAll(elements)
 
     /**
-     * Returns a new persistent set with elements in this set that are also
-     * contained in the specified [elements] collection removed,
-     * or this instance if no modifications were made in the result of this operation.
+     * Returns a new persistent set containing all elements of this set
+     * except the elements contained in the specified [elements] collection,
+     * or this instance if there are no elements to remove.
      *
      * Use the function [removingAll] to make it clear that a new set is returned.
      *

--- a/core/commonMain/src/extensions.kt
+++ b/core/commonMain/src/extensions.kt
@@ -686,11 +686,11 @@ public fun <K, V> immutableHashMapOf(vararg pairs: Pair<K, V>): PersistentMap<K,
 
 
 /**
- * Converts this collection to an immutable list.
+ * Converts this iterable to an immutable list.
  *
  * If the receiver is already an immutable list, returns it as is.
  *
- * @return an immutable list containing all elements of this collection.
+ * @return an immutable list containing all elements of this iterable.
  */
 public fun <T> Iterable<T>.toImmutableList(): ImmutableList<T> =
         this as? ImmutableList
@@ -719,12 +719,12 @@ public fun CharSequence.toImmutableList(): ImmutableList<Char> = toPersistentLis
 
 
 /**
- * Converts this collection to a persistent list.
+ * Converts this iterable to a persistent list.
  *
  * If the receiver is already a persistent list, returns it as is.
  * If the receiver is a persistent list builder, calls `build` on it and returns the result.
  *
- * @return a persistent list containing all elements of this collection.
+ * @return a persistent list containing all elements of this iterable.
  */
 public fun <T> Iterable<T>.toPersistentList(): PersistentList<T> =
         this as? PersistentList
@@ -755,13 +755,13 @@ public fun CharSequence.toPersistentList(): PersistentList<Char> =
 
 
 /**
- * Converts this collection to an immutable set.
+ * Converts this iterable to an immutable set.
  *
  * If the receiver is already an immutable set, returns it as is.
  *
- * Elements of the returned set are iterated in the same order as in this collection.
+ * Elements of the returned set are iterated in the same order as in this iterable.
  *
- * @return an immutable set of all elements of this collection.
+ * @return an immutable set of all elements of this iterable.
  */
 public fun <T> Iterable<T>.toImmutableSet(): ImmutableSet<T> =
         this as? ImmutableSet<T>
@@ -797,14 +797,14 @@ public fun CharSequence.toImmutableSet(): PersistentSet<Char> = toPersistentSet(
 
 
 /**
- * Converts this collection to a persistent set.
+ * Converts this iterable to a persistent set.
  *
  * If the receiver is already a persistent set, returns it as is.
  * If the receiver is a persistent set builder, calls `build` on it and returns the result.
  *
- * Elements of the returned set are iterated in the same order as in this collection.
+ * Elements of the returned set are iterated in the same order as in this iterable.
  *
- * @return a persistent set of all elements of this collection.
+ * @return a persistent set of all elements of this iterable.
  */
 public fun <T> Iterable<T>.toPersistentSet(): PersistentSet<T> =
         this as? PersistentOrderedSet<T>
@@ -841,14 +841,14 @@ public fun CharSequence.toPersistentSet(): PersistentSet<Char> =
 
 
 /**
- * Converts this collection to a persistent hash set.
+ * Converts this iterable to a persistent hash set.
  *
  * If the receiver is already a persistent hash set, returns it as is.
  * If the receiver is a persistent hash set builder, calls `build` on it and returns the result.
  *
  * Order of the elements in the returned set is unspecified.
  *
- * @return a persistent set containing all elements from this collection.
+ * @return a persistent set containing all elements from this iterable.
  */
 public fun <T> Iterable<T>.toPersistentHashSet(): PersistentSet<T>
     = this as? PersistentHashSet

--- a/core/commonMain/src/extensions.kt
+++ b/core/commonMain/src/extensions.kt
@@ -26,7 +26,7 @@ import kotlinx.collections.immutable.implementations.persistentOrderedSet.Persis
  * The mutable set passed to the [mutator] closure has the same contents as this persistent set.
  *
  * @return a new persistent set with the provided modifications applied;
- * or this instance if no modifications were made in the result of this operation.
+ *         or this instance if no modifications were made in the result of this operation.
  */
 public inline fun <T> PersistentSet<T>.mutate(mutator: (MutableSet<T>) -> Unit): PersistentSet<T> = builder().apply(mutator).build()
 
@@ -36,7 +36,7 @@ public inline fun <T> PersistentSet<T>.mutate(mutator: (MutableSet<T>) -> Unit):
  * The mutable list passed to the [mutator] closure has the same contents as this persistent list.
  *
  * @return a new persistent list with the provided modifications applied;
- * or this instance if no modifications were made in the result of this operation.
+ *         or this instance if no modifications were made in the result of this operation.
  */
 public inline fun <T> PersistentList<T>.mutate(mutator: (MutableList<T>) -> Unit): PersistentList<T> = builder().apply(mutator).build()
 
@@ -46,7 +46,7 @@ public inline fun <T> PersistentList<T>.mutate(mutator: (MutableList<T>) -> Unit
  * The mutable map passed to the [mutator] closure has the same contents as this persistent map.
  *
  * @return a new persistent map with the provided modifications applied;
- * or this instance if no modifications were made in the result of this operation.
+ *         or this instance if no modifications were made in the result of this operation.
  */
 @Suppress("UNCHECKED_CAST")
 public inline fun <K, V> PersistentMap<out K, V>.mutate(mutator: (MutableMap<K, V>) -> Unit): PersistentMap<K, V> =
@@ -66,7 +66,7 @@ public inline operator fun <E> PersistentCollection<E>.plus(element: E): Persist
  * Returns the result of removing a single appearance of the specified [element] from this collection.
  *
  * @return a new persistent collection with a single appearance of the specified [element] removed;
- * or this instance if there is no such element in this collection.
+ *         or this instance if there is no such element in this collection.
  */
 public inline operator fun <E> PersistentCollection<E>.minus(element: E): PersistentCollection<E> = removing(element)
 
@@ -75,7 +75,7 @@ public inline operator fun <E> PersistentCollection<E>.minus(element: E): Persis
  * Returns the result of adding all elements of the specified [elements] collection to this collection.
  *
  * @return a new persistent collection with elements of the specified [elements] collection added;
- * or this instance if no modifications were made in the result of this operation.
+ *         or this instance if no modifications were made in the result of this operation.
  */
 public operator fun <E> PersistentCollection<E>.plus(elements: Iterable<E>): PersistentCollection<E>
         = if (elements is Collection) addingAll(elements) else builder().also { it.addAll(elements) }.build()
@@ -84,7 +84,7 @@ public operator fun <E> PersistentCollection<E>.plus(elements: Iterable<E>): Per
  * Returns the result of adding all elements of the specified [elements] array to this collection.
  *
  * @return a new persistent collection with elements of the specified [elements] array added;
- * or this instance if no modifications were made in the result of this operation.
+ *         or this instance if no modifications were made in the result of this operation.
  */
 public operator fun <E> PersistentCollection<E>.plus(elements: Array<out E>): PersistentCollection<E>
         = builder().also { it.addAll(elements) }.build()
@@ -93,7 +93,7 @@ public operator fun <E> PersistentCollection<E>.plus(elements: Array<out E>): Pe
  * Returns the result of adding all elements of the specified [elements] sequence to this collection.
  *
  * @return a new persistent collection with elements of the specified [elements] sequence added;
- * or this instance if no modifications were made in the result of this operation.
+ *         or this instance if no modifications were made in the result of this operation.
  */
 public operator fun <E> PersistentCollection<E>.plus(elements: Sequence<E>): PersistentCollection<E>
         = builder().also { it.addAll(elements) }.build()
@@ -104,8 +104,8 @@ public operator fun <E> PersistentCollection<E>.plus(elements: Sequence<E>): Per
  * contained in the specified [elements] collection.
  *
  * @return a new persistent collection with elements in this collection that are also
- * contained in the specified [elements] collection removed;
- * or this instance if no modifications were made in the result of this operation.
+ *         contained in the specified [elements] collection removed;
+ *         or this instance if no modifications were made in the result of this operation.
  */
 public operator fun <E> PersistentCollection<E>.minus(elements: Iterable<E>): PersistentCollection<E>
         = if (elements is Collection) removingAll(elements) else builder().also { it.removeAll(elements) }.build()
@@ -115,8 +115,8 @@ public operator fun <E> PersistentCollection<E>.minus(elements: Iterable<E>): Pe
  * contained in the specified [elements] array.
  *
  * @return a new persistent collection with elements in this collection that are also
- * contained in the specified [elements] array removed;
- * or this instance if no modifications were made in the result of this operation.
+ *         contained in the specified [elements] array removed;
+ *         or this instance if no modifications were made in the result of this operation.
  */
 public operator fun <E> PersistentCollection<E>.minus(elements: Array<out E>): PersistentCollection<E>
         = builder().also { it.removeAll(elements) }.build()
@@ -126,15 +126,17 @@ public operator fun <E> PersistentCollection<E>.minus(elements: Array<out E>): P
  * contained in the specified [elements] sequence.
  *
  * @return a new persistent collection with elements in this collection that are also
- * contained in the specified [elements] sequence removed;
- * or this instance if no modifications were made in the result of this operation.
+ *         contained in the specified [elements] sequence removed;
+ *         or this instance if no modifications were made in the result of this operation.
  */
 public operator fun <E> PersistentCollection<E>.minus(elements: Sequence<E>): PersistentCollection<E>
         =  builder().also { it.removeAll(elements) }.build()
 
 
 /**
- * Returns a new persistent list with the specified [element] appended.
+ * Returns the result of appending the specified [element] to this list.
+ *
+ * @return a new persistent list with the specified [element] appended.
  */
 public inline operator fun <E> PersistentList<E>.plus(element: E): PersistentList<E> = adding(element)
 
@@ -142,7 +144,7 @@ public inline operator fun <E> PersistentList<E>.plus(element: E): PersistentLis
  * Returns the result of removing the first appearance of the specified [element] from this list.
  *
  * @return a new persistent list with the first appearance of the specified [element] removed;
- * or this instance if there is no such element in this list.
+ *         or this instance if there is no such element in this list.
  */
 public inline operator fun <E> PersistentList<E>.minus(element: E): PersistentList<E> = removing(element)
 
@@ -153,7 +155,7 @@ public inline operator fun <E> PersistentList<E>.minus(element: E): PersistentLi
  * The elements are appended in the order they appear in the specified collection.
  *
  * @return a new persistent list with elements of the specified [elements] collection appended;
- * or this instance if the specified collection is empty.
+ *         or this instance if the specified collection is empty.
  */
 public operator fun <E> PersistentList<E>.plus(elements: Iterable<E>): PersistentList<E>
         = if (elements is Collection) addingAll(elements) else mutate { it.addAll(elements) }
@@ -164,7 +166,7 @@ public operator fun <E> PersistentList<E>.plus(elements: Iterable<E>): Persisten
  * The elements are appended in the order they appear in the specified array.
  *
  * @return a new persistent list with elements of the specified [elements] array appended;
- * or this instance if the specified array is empty.
+ *         or this instance if the specified array is empty.
  */
 public operator fun <E> PersistentList<E>.plus(elements: Array<out E>): PersistentList<E>
         = mutate { it.addAll(elements) }
@@ -175,7 +177,7 @@ public operator fun <E> PersistentList<E>.plus(elements: Array<out E>): Persiste
  * The elements are appended in the order they appear in the specified sequence.
  *
  * @return a new persistent list with elements of the specified [elements] sequence appended;
- * or this instance if the specified sequence is empty.
+ *         or this instance if the specified sequence is empty.
  */
 public operator fun <E> PersistentList<E>.plus(elements: Sequence<E>): PersistentList<E>
         = mutate { it.addAll(elements) }
@@ -186,8 +188,8 @@ public operator fun <E> PersistentList<E>.plus(elements: Sequence<E>): Persisten
  * contained in the specified [elements] collection.
  *
  * @return a new persistent list with elements in this list that are also
- * contained in the specified [elements] collection removed;
- * or this instance if no modifications were made in the result of this operation.
+ *         contained in the specified [elements] collection removed;
+ *         or this instance if no modifications were made in the result of this operation.
  */
 public operator fun <E> PersistentList<E>.minus(elements: Iterable<E>): PersistentList<E>
         = if (elements is Collection) removingAll(elements) else mutate { it.removeAll(elements) }
@@ -197,8 +199,8 @@ public operator fun <E> PersistentList<E>.minus(elements: Iterable<E>): Persiste
  * contained in the specified [elements] array.
  *
  * @return a new persistent list with elements in this list that are also
- * contained in the specified [elements] array removed;
- * or this instance if no modifications were made in the result of this operation.
+ *         contained in the specified [elements] array removed;
+ *         or this instance if no modifications were made in the result of this operation.
  */
 public operator fun <E> PersistentList<E>.minus(elements: Array<out E>): PersistentList<E>
         = mutate { it.removeAll(elements) }
@@ -208,8 +210,8 @@ public operator fun <E> PersistentList<E>.minus(elements: Array<out E>): Persist
  * contained in the specified [elements] sequence.
  *
  * @return a new persistent list with elements in this list that are also
- * contained in the specified [elements] sequence removed;
- * or this instance if no modifications were made in the result of this operation.
+ *         contained in the specified [elements] sequence removed;
+ *         or this instance if no modifications were made in the result of this operation.
  */
 public operator fun <E> PersistentList<E>.minus(elements: Sequence<E>): PersistentList<E>
         = mutate { it.removeAll(elements) }
@@ -219,7 +221,7 @@ public operator fun <E> PersistentList<E>.minus(elements: Sequence<E>): Persiste
  * Returns the result of adding the specified [element] to this set.
  *
  * @return a new persistent set with the specified [element] added;
- * or this instance if it already contains the element.
+ *         or this instance if it already contains the element.
  */
 public inline operator fun <E> PersistentSet<E>.plus(element: E): PersistentSet<E> = adding(element)
 
@@ -227,7 +229,7 @@ public inline operator fun <E> PersistentSet<E>.plus(element: E): PersistentSet<
  * Returns the result of removing the specified [element] from this set.
  *
  * @return a new persistent set with the specified [element] removed;
- * or this instance if there is no such element in this set.
+ *         or this instance if there is no such element in this set.
  */
 public inline operator fun <E> PersistentSet<E>.minus(element: E): PersistentSet<E> = removing(element)
 
@@ -236,7 +238,7 @@ public inline operator fun <E> PersistentSet<E>.minus(element: E): PersistentSet
  * Returns the result of adding all elements of the specified [elements] collection to this set.
  *
  * @return a new persistent set with elements of the specified [elements] collection added;
- * or this instance if it already contains every element of the specified collection.
+ *         or this instance if it already contains every element of the specified collection.
  */
 public operator fun <E> PersistentSet<E>.plus(elements: Iterable<E>): PersistentSet<E>
         = if (elements is Collection) addingAll(elements) else mutate { it.addAll(elements) }
@@ -245,7 +247,7 @@ public operator fun <E> PersistentSet<E>.plus(elements: Iterable<E>): Persistent
  * Returns the result of adding all elements of the specified [elements] array to this set.
  *
  * @return a new persistent set with elements of the specified [elements] array added;
- * or this instance if it already contains every element of the specified array.
+ *         or this instance if it already contains every element of the specified array.
  */
 public operator fun <E> PersistentSet<E>.plus(elements: Array<out E>): PersistentSet<E>
         = mutate { it.addAll(elements) }
@@ -254,7 +256,7 @@ public operator fun <E> PersistentSet<E>.plus(elements: Array<out E>): Persisten
  * Returns the result of adding all elements of the specified [elements] sequence to this set.
  *
  * @return a new persistent set with elements of the specified [elements] sequence added;
- * or this instance if it already contains every element of the specified sequence.
+ *         or this instance if it already contains every element of the specified sequence.
  */
 public operator fun <E> PersistentSet<E>.plus(elements: Sequence<E>): PersistentSet<E>
         = mutate { it.addAll(elements) }
@@ -265,8 +267,8 @@ public operator fun <E> PersistentSet<E>.plus(elements: Sequence<E>): Persistent
  * contained in the specified [elements] collection.
  *
  * @return a new persistent set with elements in this set that are also
- * contained in the specified [elements] collection removed;
- * or this instance if no modifications were made in the result of this operation.
+ *         contained in the specified [elements] collection removed;
+ *         or this instance if no modifications were made in the result of this operation.
  */
 public operator fun <E> PersistentSet<E>.minus(elements: Iterable<E>): PersistentSet<E>
         = if (elements is Collection) removingAll(elements) else mutate { it.removeAll(elements) }
@@ -276,8 +278,8 @@ public operator fun <E> PersistentSet<E>.minus(elements: Iterable<E>): Persisten
  * contained in the specified [elements] array.
  *
  * @return a new persistent set with elements in this set that are also
- * contained in the specified [elements] array removed;
- * or this instance if no modifications were made in the result of this operation.
+ *         contained in the specified [elements] array removed;
+ *         or this instance if no modifications were made in the result of this operation.
  */
 public operator fun <E> PersistentSet<E>.minus(elements: Array<out E>): PersistentSet<E>
         = mutate { it.removeAll(elements) }
@@ -287,8 +289,8 @@ public operator fun <E> PersistentSet<E>.minus(elements: Array<out E>): Persiste
  * contained in the specified [elements] sequence.
  *
  * @return a new persistent set with elements in this set that are also
- * contained in the specified [elements] sequence removed;
- * or this instance if no modifications were made in the result of this operation.
+ *         contained in the specified [elements] sequence removed;
+ *         or this instance if no modifications were made in the result of this operation.
  */
 public operator fun <E> PersistentSet<E>.minus(elements: Sequence<E>): PersistentSet<E>
         = mutate { it.removeAll(elements) }
@@ -298,8 +300,8 @@ public operator fun <E> PersistentSet<E>.minus(elements: Sequence<E>): Persisten
  * contained in the specified [elements] collection.
  *
  * @return a new persistent set with elements in this set that are also
- * contained in the specified [elements] collection;
- * or this instance if no modifications were made in the result of this operation.
+ *         contained in the specified [elements] collection;
+ *         or this instance if no modifications were made in the result of this operation.
  */
 public infix fun <E> PersistentSet<E>.intersect(elements: Iterable<E>): PersistentSet<E>
         = if (elements is Collection) retainingAll(elements) else mutate { it.retainAll(elements) }
@@ -309,7 +311,7 @@ public infix fun <E> PersistentSet<E>.intersect(elements: Iterable<E>): Persiste
  * contained in the specified [elements] collection.
  *
  * @return a new persistent set with elements in this collection that are also
- * contained in the specified [elements] collection
+ *         contained in the specified [elements] collection.
  */
 public infix fun <E> PersistentCollection<E>.intersect(elements: Iterable<E>): PersistentSet<E>
         = this.toPersistentSet().intersect(elements)
@@ -321,7 +323,7 @@ public infix fun <E> PersistentCollection<E>.intersect(elements: Iterable<E>): P
  * the old value is replaced by the value from the specified [pair].
  *
  * @return a new persistent map with an entry from the specified key-value [pair] added;
- * or this instance if no modifications were made in the result of this operation.
+ *         or this instance if no modifications were made in the result of this operation.
  */
 @Suppress("UNCHECKED_CAST")
 public inline operator fun <K, V> PersistentMap<out K, V>.plus(pair: Pair<K, V>): PersistentMap<K, V>
@@ -331,7 +333,7 @@ public inline operator fun <K, V> PersistentMap<out K, V>.plus(pair: Pair<K, V>)
  * Returns the result of replacing or adding entries to this map from the specified key-value pairs.
  *
  * @return a new persistent map with entries from the specified key-value pairs added;
- * or this instance if no modifications were made in the result of this operation.
+ *         or this instance if no modifications were made in the result of this operation.
  */
 public inline operator fun <K, V> PersistentMap<out K, V>.plus(pairs: Iterable<Pair<K, V>>): PersistentMap<K, V> = puttingAll(pairs)
 
@@ -339,7 +341,7 @@ public inline operator fun <K, V> PersistentMap<out K, V>.plus(pairs: Iterable<P
  * Returns the result of replacing or adding entries to this map from the specified key-value pairs.
  *
  * @return a new persistent map with entries from the specified key-value pairs added;
- * or this instance if no modifications were made in the result of this operation.
+ *         or this instance if no modifications were made in the result of this operation.
  */
 public inline operator fun <K, V> PersistentMap<out K, V>.plus(pairs: Array<out Pair<K, V>>): PersistentMap<K, V> = puttingAll(pairs)
 
@@ -347,7 +349,7 @@ public inline operator fun <K, V> PersistentMap<out K, V>.plus(pairs: Array<out 
  * Returns the result of replacing or adding entries to this map from the specified key-value pairs.
  *
  * @return a new persistent map with entries from the specified key-value pairs added;
- * or this instance if no modifications were made in the result of this operation.
+ *         or this instance if no modifications were made in the result of this operation.
  */
 public inline operator fun <K, V> PersistentMap<out K, V>.plus(pairs: Sequence<Pair<K, V>>): PersistentMap<K, V> = puttingAll(pairs)
 
@@ -358,7 +360,7 @@ public inline operator fun <K, V> PersistentMap<out K, V>.plus(pairs: Sequence<P
  * mapping from key `k` to value `v` in the specified map.
  *
  * @return a new persistent map with keys and values from the specified [map] associated;
- * or this instance if no modifications were made in the result of this operation.
+ *         or this instance if no modifications were made in the result of this operation.
  */
 public inline operator fun <K, V> PersistentMap<out K, V>.plus(map: Map<out K, V>): PersistentMap<K, V> = puttingAll(map)
 
@@ -486,7 +488,7 @@ public fun <K, V> PersistentMap<out K, V>.putAll(pairs: Sequence<Pair<K, V>>): P
  * Returns the result of removing the specified [key] and its corresponding value from this map.
  *
  * @return a new persistent map with the specified [key] and its corresponding value removed;
- * or this instance if it contains no mapping for the key.
+ *         or this instance if it contains no mapping for the key.
  */
 @Suppress("UNCHECKED_CAST")
 public operator fun <K, V> PersistentMap<out K, V>.minus(key: K): PersistentMap<K, V>
@@ -496,7 +498,7 @@ public operator fun <K, V> PersistentMap<out K, V>.minus(key: K): PersistentMap<
  * Returns the result of removing the specified [keys] and their corresponding values from this map.
  *
  * @return a new persistent map with the specified [keys] and their corresponding values removed;
- * or this instance if no modifications were made in the result of this operation.
+ *         or this instance if no modifications were made in the result of this operation.
  */
 public operator fun <K, V> PersistentMap<out K, V>.minus(keys: Iterable<K>): PersistentMap<K, V>
         = mutate { it.minusAssign(keys) }
@@ -505,7 +507,7 @@ public operator fun <K, V> PersistentMap<out K, V>.minus(keys: Iterable<K>): Per
  * Returns the result of removing the specified [keys] and their corresponding values from this map.
  *
  * @return a new persistent map with the specified [keys] and their corresponding values removed;
- * or this instance if no modifications were made in the result of this operation.
+ *         or this instance if no modifications were made in the result of this operation.
  */
 public operator fun <K, V> PersistentMap<out K, V>.minus(keys: Array<out K>): PersistentMap<K, V>
         = mutate { it.minusAssign(keys) }
@@ -514,171 +516,215 @@ public operator fun <K, V> PersistentMap<out K, V>.minus(keys: Array<out K>): Pe
  * Returns the result of removing the specified [keys] and their corresponding values from this map.
  *
  * @return a new persistent map with the specified [keys] and their corresponding values removed;
- * or this instance if no modifications were made in the result of this operation.
+ *         or this instance if no modifications were made in the result of this operation.
  */
 public operator fun <K, V> PersistentMap<out K, V>.minus(keys: Sequence<K>): PersistentMap<K, V>
         = mutate { it.minusAssign(keys) }
 
 
 /**
- * Returns a new persistent list of the specified elements.
+ * Creates a new persistent list of the specified elements.
+ *
+ * @return a new persistent list of the specified elements.
  */
 public fun <E> persistentListOf(vararg elements: E): PersistentList<E> = persistentVectorOf<E>().addingAll(elements.asList())
 
 /**
- * Returns an empty persistent list.
+ * Creates an empty persistent list.
+ *
+ * @return an empty persistent list.
  */
 public fun <E> persistentListOf(): PersistentList<E> = persistentVectorOf()
 
 
 /**
- * Returns a new persistent set with the given elements.
+ * Creates a new persistent set with the given elements.
  *
  * Elements of the returned set are iterated in the order they were specified.
+ *
+ * @return a new persistent set with the given elements.
  */
 public fun <E> persistentSetOf(vararg elements: E): PersistentSet<E> = PersistentOrderedSet.emptyOf<E>().addingAll(elements.asList())
 
 /**
- * Returns an empty persistent set.
+ * Creates an empty persistent set.
+ *
+ * @return an empty persistent set.
  */
 public fun <E> persistentSetOf(): PersistentSet<E> = PersistentOrderedSet.emptyOf<E>()
 
 
 /**
- * Returns a new persistent set with the given elements.
+ * Creates a new persistent set with the given elements.
  *
  * Order of the elements in the returned set is unspecified.
+ *
+ * @return a new persistent set with the given elements.
  */
 public fun <E> persistentHashSetOf(vararg elements: E): PersistentSet<E> = PersistentHashSet.emptyOf<E>().addingAll(elements.asList())
 
 /**
- * Returns an empty persistent set.
+ * Creates an empty persistent set.
+ *
+ * @return an empty persistent set.
  */
 public fun <E> persistentHashSetOf(): PersistentSet<E> = PersistentHashSet.emptyOf()
 
 
 /**
- * Returns a new persistent map with the specified contents, given as a list of pairs
+ * Creates a new persistent map with the specified contents, given as a list of pairs
  * where the first component is the key and the second is the value.
  *
  * If multiple pairs have the same key, the resulting map will contain the value from the last of those pairs.
  *
  * Entries of the map are iterated in the order they were specified.
+ *
+ * @return a new persistent map with the specified contents.
  */
 public fun <K, V> persistentMapOf(vararg pairs: Pair<K, V>): PersistentMap<K, V> = PersistentOrderedMap.emptyOf<K,V>().mutate { it += pairs }
 
 /**
- * Returns an empty persistent map.
+ * Creates an empty persistent map.
+ *
+ * @return an empty persistent map.
  */
 public fun <K, V> persistentMapOf(): PersistentMap<K, V> = PersistentOrderedMap.emptyOf()
 
 
 /**
- * Returns a new persistent map with the specified contents, given as a list of pairs
+ * Creates a new persistent map with the specified contents, given as a list of pairs
  * where the first component is the key and the second is the value.
  *
  * If multiple pairs have the same key, the resulting map will contain the value from the last of those pairs.
  *
  * Order of the entries in the returned map is unspecified.
+ *
+ * @return a new persistent map with the specified contents.
  */
 public fun <K, V> persistentHashMapOf(vararg pairs: Pair<K, V>): PersistentMap<K, V> = PersistentHashMap.emptyOf<K,V>().mutate { it += pairs }
 
 /**
- * Returns an empty persistent map.
+ * Creates an empty persistent map.
+ *
+ * @return an empty persistent map.
  */
 public fun <K, V> persistentHashMapOf(): PersistentMap<K, V> = PersistentHashMap.emptyOf()
 
 
 /**
- * Returns a new persistent list of the specified elements.
+ * Creates a new persistent list of the specified elements.
+ *
+ * @return a new persistent list of the specified elements.
  */
 @Deprecated("Use persistentListOf instead.", ReplaceWith("persistentListOf(*elements)"))
 public fun <E> immutableListOf(vararg elements: E): PersistentList<E> = persistentListOf(*elements)
 
 /**
- * Returns an empty persistent list.
+ * Creates an empty persistent list.
+ *
+ * @return an empty persistent list.
  */
 @Deprecated("Use persistentListOf instead.", ReplaceWith("persistentListOf()"))
 public fun <E> immutableListOf(): PersistentList<E> = persistentListOf()
 
 
 /**
- * Returns a new persistent set with the given elements.
+ * Creates a new persistent set with the given elements.
  *
  * Elements of the returned set are iterated in the order they were specified.
+ *
+ * @return a new persistent set with the given elements.
  */
 @Deprecated("Use persistentSetOf instead.", ReplaceWith("persistentSetOf(*elements)"))
 public fun <E> immutableSetOf(vararg elements: E): PersistentSet<E> = persistentSetOf(*elements)
 
 /**
- * Returns an empty persistent set.
+ * Creates an empty persistent set.
+ *
+ * @return an empty persistent set.
  */
 @Deprecated("Use persistentSetOf instead.", ReplaceWith("persistentSetOf()"))
 public fun <E> immutableSetOf(): PersistentSet<E> = persistentSetOf()
 
 
 /**
- * Returns a new persistent set with the given elements.
+ * Creates a new persistent set with the given elements.
  *
  * Order of the elements in the returned set is unspecified.
+ *
+ * @return a new persistent set with the given elements.
  */
 @Deprecated("Use persistentHashSetOf instead.", ReplaceWith("persistentHashSetOf(*elements)"))
 public fun <E> immutableHashSetOf(vararg elements: E): PersistentSet<E> = persistentHashSetOf(*elements)
 
 
 /**
- * Returns a new persistent map with the specified contents, given as a list of pairs
+ * Creates a new persistent map with the specified contents, given as a list of pairs
  * where the first component is the key and the second is the value.
  *
  * If multiple pairs have the same key, the resulting map will contain the value from the last of those pairs.
  *
  * Entries of the map are iterated in the order they were specified.
+ *
+ * @return a new persistent map with the specified contents.
  */
 @Deprecated("Use persistentMapOf instead.", ReplaceWith("persistentMapOf(*pairs)"))
 public fun <K, V> immutableMapOf(vararg pairs: Pair<K, V>): PersistentMap<K, V> = persistentMapOf(*pairs)
 
 /**
- * Returns a new persistent map with the specified contents, given as a list of pairs
+ * Creates a new persistent map with the specified contents, given as a list of pairs
  * where the first component is the key and the second is the value.
  *
  * If multiple pairs have the same key, the resulting map will contain the value from the last of those pairs.
  *
  * Order of the entries in the returned map is unspecified.
+ *
+ * @return a new persistent map with the specified contents.
  */
 @Deprecated("Use persistentHashMapOf instead.", ReplaceWith("persistentHashMapOf(*pairs)"))
 public fun <K, V> immutableHashMapOf(vararg pairs: Pair<K, V>): PersistentMap<K, V> = persistentHashMapOf(*pairs)
 
 
 /**
- * Returns an immutable list containing all elements of this collection.
+ * Converts this collection to an immutable list.
  *
  * If the receiver is already an immutable list, returns it as is.
+ *
+ * @return an immutable list containing all elements of this collection.
  */
 public fun <T> Iterable<T>.toImmutableList(): ImmutableList<T> =
         this as? ImmutableList
         ?: this.toPersistentList()
 
 /**
- * Returns an immutable list containing all elements of this array.
+ * Converts this array to an immutable list.
+ *
+ * @return an immutable list containing all elements of this array.
  */
 public fun <T> Array<out T>.toImmutableList(): ImmutableList<T> = toPersistentList()
 
 /**
- * Returns an immutable list containing all elements of this sequence.
+ * Converts this sequence to an immutable list.
+ *
+ * @return an immutable list containing all elements of this sequence.
  */
 public fun <T> Sequence<T>.toImmutableList(): ImmutableList<T> = toPersistentList()
 
 /**
- * Returns an immutable list containing all characters.
+ * Converts this char sequence to an immutable list.
+ *
+ * @return an immutable list containing all characters.
  */
 public fun CharSequence.toImmutableList(): ImmutableList<Char> = toPersistentList()
 
 
 /**
- * Returns a persistent list containing all elements of this collection.
+ * Converts this collection to a persistent list.
  *
  * If the receiver is already a persistent list, returns it as is.
  * If the receiver is a persistent list builder, calls `build` on it and returns the result.
+ *
+ * @return a persistent list containing all elements of this collection.
  */
 public fun <T> Iterable<T>.toPersistentList(): PersistentList<T> =
         this as? PersistentList
@@ -686,28 +732,36 @@ public fun <T> Iterable<T>.toPersistentList(): PersistentList<T> =
         ?: persistentListOf<T>() + this
 
 /**
- * Returns a persistent list containing all elements of this array.
+ * Converts this array to a persistent list.
+ *
+ * @return a persistent list containing all elements of this array.
  */
 public fun <T> Array<out T>.toPersistentList(): PersistentList<T> = persistentListOf<T>() + this
 
 /**
- * Returns a persistent list containing all elements of this sequence.
+ * Converts this sequence to a persistent list.
+ *
+ * @return a persistent list containing all elements of this sequence.
  */
 public fun <T> Sequence<T>.toPersistentList(): PersistentList<T> = persistentListOf<T>() + this
 
 /**
- * Returns a persistent list containing all characters.
+ * Converts this char sequence to a persistent list.
+ *
+ * @return a persistent list containing all characters.
  */
 public fun CharSequence.toPersistentList(): PersistentList<Char> =
     persistentListOf<Char>().mutate { this.toCollection(it) }
 
 
 /**
- * Returns an immutable set of all elements of this collection.
+ * Converts this collection to an immutable set.
  *
  * If the receiver is already an immutable set, returns it as is.
  *
  * Elements of the returned set are iterated in the same order as in this collection.
+ *
+ * @return an immutable set of all elements of this collection.
  */
 public fun <T> Iterable<T>.toImmutableSet(): ImmutableSet<T> =
         this as? ImmutableSet<T>
@@ -715,34 +769,42 @@ public fun <T> Iterable<T>.toImmutableSet(): ImmutableSet<T> =
         ?: persistentSetOf<T>() + this
 
 /**
- * Returns an immutable set of all elements of this array.
+ * Converts this array to an immutable set.
  *
  * Elements of the returned set are iterated in the same order as in this array.
+ *
+ * @return an immutable set of all elements of this array.
  */
 public fun <T> Array<out T>.toImmutableSet(): ImmutableSet<T> = toPersistentSet()
 
 /**
- * Returns an immutable set of all elements of this sequence.
+ * Converts this sequence to an immutable set.
  *
  * Elements of the returned set are iterated in the same order as in this sequence.
+ *
+ * @return an immutable set of all elements of this sequence.
  */
 public fun <T> Sequence<T>.toImmutableSet(): ImmutableSet<T> = toPersistentSet()
 
 /**
- * Returns an immutable set of all characters.
+ * Converts this char sequence to an immutable set.
  *
  * Elements of the returned set are iterated in the same order as in this char sequence.
+ *
+ * @return an immutable set of all characters.
  */
 public fun CharSequence.toImmutableSet(): PersistentSet<Char> = toPersistentSet()
 
 
 /**
- * Returns a persistent set of all elements of this collection.
+ * Converts this collection to a persistent set.
  *
  * If the receiver is already a persistent set, returns it as is.
  * If the receiver is a persistent set builder, calls `build` on it and returns the result.
  *
  * Elements of the returned set are iterated in the same order as in this collection.
+ *
+ * @return a persistent set of all elements of this collection.
  */
 public fun <T> Iterable<T>.toPersistentSet(): PersistentSet<T> =
         this as? PersistentOrderedSet<T>
@@ -750,35 +812,43 @@ public fun <T> Iterable<T>.toPersistentSet(): PersistentSet<T> =
         ?: PersistentOrderedSet.emptyOf<T>() + this
 
 /**
- * Returns a persistent set of all elements of this array.
+ * Converts this array to a persistent set.
  *
  * Elements of the returned set are iterated in the same order as in this array.
+ *
+ * @return a persistent set of all elements of this array.
  */
 public fun <T> Array<out T>.toPersistentSet(): PersistentSet<T> = persistentSetOf<T>() + this
 
 /**
- * Returns a persistent set of all elements of this sequence.
+ * Converts this sequence to a persistent set.
  *
  * Elements of the returned set are iterated in the same order as in this sequence.
+ *
+ * @return a persistent set of all elements of this sequence.
  */
 public fun <T> Sequence<T>.toPersistentSet(): PersistentSet<T> = persistentSetOf<T>() + this
 
 /**
- * Returns a persistent set of all characters.
+ * Converts this char sequence to a persistent set.
  *
  * Elements of the returned set are iterated in the same order as in this char sequence.
+ *
+ * @return a persistent set of all characters.
  */
 public fun CharSequence.toPersistentSet(): PersistentSet<Char> =
         persistentSetOf<Char>().mutate { this.toCollection(it) }
 
 
 /**
- * Returns a persistent set containing all elements from this set.
+ * Converts this collection to a persistent hash set.
  *
  * If the receiver is already a persistent hash set, returns it as is.
  * If the receiver is a persistent hash set builder, calls `build` on it and returns the result.
  *
  * Order of the elements in the returned set is unspecified.
+ *
+ * @return a persistent set containing all elements from this collection.
  */
 public fun <T> Iterable<T>.toPersistentHashSet(): PersistentSet<T>
     = this as? PersistentHashSet
@@ -786,34 +856,42 @@ public fun <T> Iterable<T>.toPersistentHashSet(): PersistentSet<T>
         ?: PersistentHashSet.emptyOf<T>() + this
 
 /**
- * Returns a persistent set of all elements of this array.
+ * Converts this array to a persistent hash set.
  *
  * Order of the elements in the returned set is unspecified.
+ *
+ * @return a persistent set of all elements of this array.
  */
 public fun <T> Array<out T>.toPersistentHashSet(): PersistentSet<T> = persistentHashSetOf<T>() + this
 
 /**
- * Returns a persistent set of all elements of this sequence.
+ * Converts this sequence to a persistent hash set.
  *
  * Order of the elements in the returned set is unspecified.
+ *
+ * @return a persistent set of all elements of this sequence.
  */
 public fun <T> Sequence<T>.toPersistentHashSet(): PersistentSet<T> = persistentHashSetOf<T>() + this
 
 /**
- * Returns a persistent set of all characters.
+ * Converts this char sequence to a persistent hash set.
  *
  * Order of the elements in the returned set is unspecified.
+ *
+ * @return a persistent set of all characters.
  */
 public fun CharSequence.toPersistentHashSet(): PersistentSet<Char> =
         persistentHashSetOf<Char>().mutate { this.toCollection(it) }
 
 
 /**
- * Returns an immutable map containing all entries from this map.
+ * Converts this map to an immutable map.
  *
  * If the receiver is already an immutable map, returns it as is.
  *
  * Entries of the returned map are iterated in the same order as in this map.
+ *
+ * @return an immutable map containing all entries from this map.
  */
 public fun <K, V> Map<K, V>.toImmutableMap(): ImmutableMap<K, V>
     = this as? ImmutableMap
@@ -821,12 +899,14 @@ public fun <K, V> Map<K, V>.toImmutableMap(): ImmutableMap<K, V>
         ?: persistentMapOf<K, V>().puttingAll(this)
 
 /**
- * Returns a persistent map containing all entries from this map.
+ * Converts this map to a persistent map.
  *
  * If the receiver is already a persistent map, returns it as is.
  * If the receiver is a persistent map builder, calls `build` on it and returns the result.
  *
  * Entries of the returned map are iterated in the same order as in this map.
+ *
+ * @return a persistent map containing all entries from this map.
  */
 public fun <K, V> Map<K, V>.toPersistentMap(): PersistentMap<K, V>
     = this as? PersistentOrderedMap<K, V>
@@ -834,12 +914,14 @@ public fun <K, V> Map<K, V>.toPersistentMap(): PersistentMap<K, V>
         ?: PersistentOrderedMap.emptyOf<K, V>().puttingAll(this)
 
 /**
- * Returns an immutable map containing all entries from this map.
+ * Converts this map to a persistent hash map.
  *
  * If the receiver is already a persistent hash map, returns it as is.
  * If the receiver is a persistent hash map builder, calls `build` on it and returns the result.
  *
  * Order of the entries in the returned map is unspecified.
+ *
+ * @return a persistent map containing all entries from this map.
  */
 public fun <K, V> Map<K, V>.toPersistentHashMap(): PersistentMap<K, V>
         = this as? PersistentHashMap

--- a/core/commonMain/src/extensions.kt
+++ b/core/commonMain/src/extensions.kt
@@ -21,32 +21,26 @@ import kotlinx.collections.immutable.implementations.persistentOrderedSet.Persis
 //inline fun <T> @kotlin.internal.Exact ImmutableCollection<T>.mutate(mutator: (MutableCollection<T>) -> Unit): ImmutableCollection<T> = builder().apply(mutator).build()
 // it or this?
 /**
- * Returns the result of applying the provided modifications on this set.
+ * Returns a new persistent set with the provided modifications applied,
+ * or this instance if no modifications were made in the result of this operation.
  *
  * The mutable set passed to the [mutator] closure has the same contents as this persistent set.
- *
- * @return a new persistent set with the provided modifications applied;
- *         or this instance if no modifications were made in the result of this operation.
  */
 public inline fun <T> PersistentSet<T>.mutate(mutator: (MutableSet<T>) -> Unit): PersistentSet<T> = builder().apply(mutator).build()
 
 /**
- * Returns the result of applying the provided modifications on this list.
+ * Returns a new persistent list with the provided modifications applied,
+ * or this instance if no modifications were made in the result of this operation.
  *
  * The mutable list passed to the [mutator] closure has the same contents as this persistent list.
- *
- * @return a new persistent list with the provided modifications applied;
- *         or this instance if no modifications were made in the result of this operation.
  */
 public inline fun <T> PersistentList<T>.mutate(mutator: (MutableList<T>) -> Unit): PersistentList<T> = builder().apply(mutator).build()
 
 /**
- * Returns the result of applying the provided modifications on this map.
+ * Returns a new persistent map with the provided modifications applied,
+ * or this instance if no modifications were made in the result of this operation.
  *
  * The mutable map passed to the [mutator] closure has the same contents as this persistent map.
- *
- * @return a new persistent map with the provided modifications applied;
- *         or this instance if no modifications were made in the result of this operation.
  */
 @Suppress("UNCHECKED_CAST")
 public inline fun <K, V> PersistentMap<out K, V>.mutate(mutator: (MutableMap<K, V>) -> Unit): PersistentMap<K, V> =
@@ -54,332 +48,257 @@ public inline fun <K, V> PersistentMap<out K, V>.mutate(mutator: (MutableMap<K, 
 
 
 /**
- * Returns the result of adding the specified [element] to this collection.
- *
- * @return a new persistent collection with the specified [element] added;
- *         or this instance if this collection does not support duplicates,
- *         and it already contains the element.
+ * Returns a new persistent collection with the specified [element] added,
+ * or this instance if this collection does not support duplicates and it already contains the element.
  */
 public inline operator fun <E> PersistentCollection<E>.plus(element: E): PersistentCollection<E> = adding(element)
 
 /**
- * Returns the result of removing a single appearance of the specified [element] from this collection.
- *
- * @return a new persistent collection with a single appearance of the specified [element] removed;
- *         or this instance if there is no such element in this collection.
+ * Returns a new persistent collection with a single appearance of the specified [element] removed,
+ * or this instance if there is no such element in this collection.
  */
 public inline operator fun <E> PersistentCollection<E>.minus(element: E): PersistentCollection<E> = removing(element)
 
 
 /**
- * Returns the result of adding all elements of the specified [elements] collection to this collection.
- *
- * @return a new persistent collection with elements of the specified [elements] collection added;
- *         or this instance if no modifications were made in the result of this operation.
+ * Returns a new persistent collection with elements of the specified [elements] collection added,
+ * or this instance if no modifications were made in the result of this operation.
  */
 public operator fun <E> PersistentCollection<E>.plus(elements: Iterable<E>): PersistentCollection<E>
         = if (elements is Collection) addingAll(elements) else builder().also { it.addAll(elements) }.build()
 
 /**
- * Returns the result of adding all elements of the specified [elements] array to this collection.
- *
- * @return a new persistent collection with elements of the specified [elements] array added;
- *         or this instance if no modifications were made in the result of this operation.
+ * Returns a new persistent collection with elements of the specified [elements] array added,
+ * or this instance if no modifications were made in the result of this operation.
  */
 public operator fun <E> PersistentCollection<E>.plus(elements: Array<out E>): PersistentCollection<E>
         = builder().also { it.addAll(elements) }.build()
 
 /**
- * Returns the result of adding all elements of the specified [elements] sequence to this collection.
- *
- * @return a new persistent collection with elements of the specified [elements] sequence added;
- *         or this instance if no modifications were made in the result of this operation.
+ * Returns a new persistent collection with elements of the specified [elements] sequence added,
+ * or this instance if no modifications were made in the result of this operation.
  */
 public operator fun <E> PersistentCollection<E>.plus(elements: Sequence<E>): PersistentCollection<E>
         = builder().also { it.addAll(elements) }.build()
 
 
 /**
- * Returns the result of removing all elements in this collection that are also
- * contained in the specified [elements] collection.
- *
- * @return a new persistent collection with elements in this collection that are also
- *         contained in the specified [elements] collection removed;
- *         or this instance if no modifications were made in the result of this operation.
+ * Returns a new persistent collection with elements in this collection that are also
+ * contained in the specified [elements] collection removed,
+ * or this instance if no modifications were made in the result of this operation.
  */
 public operator fun <E> PersistentCollection<E>.minus(elements: Iterable<E>): PersistentCollection<E>
         = if (elements is Collection) removingAll(elements) else builder().also { it.removeAll(elements) }.build()
 
 /**
- * Returns the result of removing all elements in this collection that are also
- * contained in the specified [elements] array.
- *
- * @return a new persistent collection with elements in this collection that are also
- *         contained in the specified [elements] array removed;
- *         or this instance if no modifications were made in the result of this operation.
+ * Returns a new persistent collection with elements in this collection that are also
+ * contained in the specified [elements] array removed,
+ * or this instance if no modifications were made in the result of this operation.
  */
 public operator fun <E> PersistentCollection<E>.minus(elements: Array<out E>): PersistentCollection<E>
         = builder().also { it.removeAll(elements) }.build()
 
 /**
- * Returns the result of removing all elements in this collection that are also
- * contained in the specified [elements] sequence.
- *
- * @return a new persistent collection with elements in this collection that are also
- *         contained in the specified [elements] sequence removed;
- *         or this instance if no modifications were made in the result of this operation.
+ * Returns a new persistent collection with elements in this collection that are also
+ * contained in the specified [elements] sequence removed,
+ * or this instance if no modifications were made in the result of this operation.
  */
 public operator fun <E> PersistentCollection<E>.minus(elements: Sequence<E>): PersistentCollection<E>
         =  builder().also { it.removeAll(elements) }.build()
 
 
 /**
- * Returns the result of appending the specified [element] to this list.
- *
- * @return a new persistent list with the specified [element] appended.
+ * Returns a new persistent list with the specified [element] appended.
  */
 public inline operator fun <E> PersistentList<E>.plus(element: E): PersistentList<E> = adding(element)
 
 /**
- * Returns the result of removing the first appearance of the specified [element] from this list.
- *
- * @return a new persistent list with the first appearance of the specified [element] removed;
- *         or this instance if there is no such element in this list.
+ * Returns a new persistent list with the first appearance of the specified [element] removed,
+ * or this instance if there is no such element in this list.
  */
 public inline operator fun <E> PersistentList<E>.minus(element: E): PersistentList<E> = removing(element)
 
 
 /**
- * Returns the result of appending all elements of the specified [elements] collection to this list.
+ * Returns a new persistent list with elements of the specified [elements] collection appended,
+ * or this instance if the specified collection is empty.
  *
  * The elements are appended in the order they appear in the specified collection.
- *
- * @return a new persistent list with elements of the specified [elements] collection appended;
- *         or this instance if the specified collection is empty.
  */
 public operator fun <E> PersistentList<E>.plus(elements: Iterable<E>): PersistentList<E>
         = if (elements is Collection) addingAll(elements) else mutate { it.addAll(elements) }
 
 /**
- * Returns the result of appending all elements of the specified [elements] array to this list.
+ * Returns a new persistent list with elements of the specified [elements] array appended,
+ * or this instance if the specified array is empty.
  *
  * The elements are appended in the order they appear in the specified array.
- *
- * @return a new persistent list with elements of the specified [elements] array appended;
- *         or this instance if the specified array is empty.
  */
 public operator fun <E> PersistentList<E>.plus(elements: Array<out E>): PersistentList<E>
         = mutate { it.addAll(elements) }
 
 /**
- * Returns the result of appending all elements of the specified [elements] sequence to this list.
+ * Returns a new persistent list with elements of the specified [elements] sequence appended,
+ * or this instance if the specified sequence is empty.
  *
  * The elements are appended in the order they appear in the specified sequence.
- *
- * @return a new persistent list with elements of the specified [elements] sequence appended;
- *         or this instance if the specified sequence is empty.
  */
 public operator fun <E> PersistentList<E>.plus(elements: Sequence<E>): PersistentList<E>
         = mutate { it.addAll(elements) }
 
 
 /**
- * Returns the result of removing all elements in this list that are also
- * contained in the specified [elements] collection.
- *
- * @return a new persistent list with elements in this list that are also
- *         contained in the specified [elements] collection removed;
- *         or this instance if no modifications were made in the result of this operation.
+ * Returns a new persistent list with elements in this list that are also
+ * contained in the specified [elements] collection removed,
+ * or this instance if no modifications were made in the result of this operation.
  */
 public operator fun <E> PersistentList<E>.minus(elements: Iterable<E>): PersistentList<E>
         = if (elements is Collection) removingAll(elements) else mutate { it.removeAll(elements) }
 
 /**
- * Returns the result of removing all elements in this list that are also
- * contained in the specified [elements] array.
- *
- * @return a new persistent list with elements in this list that are also
- *         contained in the specified [elements] array removed;
- *         or this instance if no modifications were made in the result of this operation.
+ * Returns a new persistent list with elements in this list that are also
+ * contained in the specified [elements] array removed,
+ * or this instance if no modifications were made in the result of this operation.
  */
 public operator fun <E> PersistentList<E>.minus(elements: Array<out E>): PersistentList<E>
         = mutate { it.removeAll(elements) }
 
 /**
- * Returns the result of removing all elements in this list that are also
- * contained in the specified [elements] sequence.
- *
- * @return a new persistent list with elements in this list that are also
- *         contained in the specified [elements] sequence removed;
- *         or this instance if no modifications were made in the result of this operation.
+ * Returns a new persistent list with elements in this list that are also
+ * contained in the specified [elements] sequence removed,
+ * or this instance if no modifications were made in the result of this operation.
  */
 public operator fun <E> PersistentList<E>.minus(elements: Sequence<E>): PersistentList<E>
         = mutate { it.removeAll(elements) }
 
 
 /**
- * Returns the result of adding the specified [element] to this set.
- *
- * @return a new persistent set with the specified [element] added;
- *         or this instance if it already contains the element.
+ * Returns a new persistent set with the specified [element] added,
+ * or this instance if it already contains the element.
  */
 public inline operator fun <E> PersistentSet<E>.plus(element: E): PersistentSet<E> = adding(element)
 
 /**
- * Returns the result of removing the specified [element] from this set.
- *
- * @return a new persistent set with the specified [element] removed;
- *         or this instance if there is no such element in this set.
+ * Returns a new persistent set with the specified [element] removed,
+ * or this instance if there is no such element in this set.
  */
 public inline operator fun <E> PersistentSet<E>.minus(element: E): PersistentSet<E> = removing(element)
 
 
 /**
- * Returns the result of adding all elements of the specified [elements] collection to this set.
- *
- * @return a new persistent set with elements of the specified [elements] collection added;
- *         or this instance if it already contains every element of the specified collection.
+ * Returns a new persistent set with elements of the specified [elements] collection added,
+ * or this instance if it already contains every element of the specified collection.
  */
 public operator fun <E> PersistentSet<E>.plus(elements: Iterable<E>): PersistentSet<E>
         = if (elements is Collection) addingAll(elements) else mutate { it.addAll(elements) }
 
 /**
- * Returns the result of adding all elements of the specified [elements] array to this set.
- *
- * @return a new persistent set with elements of the specified [elements] array added;
- *         or this instance if it already contains every element of the specified array.
+ * Returns a new persistent set with elements of the specified [elements] array added,
+ * or this instance if it already contains every element of the specified array.
  */
 public operator fun <E> PersistentSet<E>.plus(elements: Array<out E>): PersistentSet<E>
         = mutate { it.addAll(elements) }
 
 /**
- * Returns the result of adding all elements of the specified [elements] sequence to this set.
- *
- * @return a new persistent set with elements of the specified [elements] sequence added;
- *         or this instance if it already contains every element of the specified sequence.
+ * Returns a new persistent set with elements of the specified [elements] sequence added,
+ * or this instance if it already contains every element of the specified sequence.
  */
 public operator fun <E> PersistentSet<E>.plus(elements: Sequence<E>): PersistentSet<E>
         = mutate { it.addAll(elements) }
 
 
 /**
- * Returns the result of removing all elements in this set that are also
- * contained in the specified [elements] collection.
- *
- * @return a new persistent set with elements in this set that are also
- *         contained in the specified [elements] collection removed;
- *         or this instance if no modifications were made in the result of this operation.
+ * Returns a new persistent set with elements in this set that are also
+ * contained in the specified [elements] collection removed,
+ * or this instance if no modifications were made in the result of this operation.
  */
 public operator fun <E> PersistentSet<E>.minus(elements: Iterable<E>): PersistentSet<E>
         = if (elements is Collection) removingAll(elements) else mutate { it.removeAll(elements) }
 
 /**
- * Returns the result of removing all elements in this set that are also
- * contained in the specified [elements] array.
- *
- * @return a new persistent set with elements in this set that are also
- *         contained in the specified [elements] array removed;
- *         or this instance if no modifications were made in the result of this operation.
+ * Returns a new persistent set with elements in this set that are also
+ * contained in the specified [elements] array removed,
+ * or this instance if no modifications were made in the result of this operation.
  */
 public operator fun <E> PersistentSet<E>.minus(elements: Array<out E>): PersistentSet<E>
         = mutate { it.removeAll(elements) }
 
 /**
- * Returns the result of removing all elements in this set that are also
- * contained in the specified [elements] sequence.
- *
- * @return a new persistent set with elements in this set that are also
- *         contained in the specified [elements] sequence removed;
- *         or this instance if no modifications were made in the result of this operation.
+ * Returns a new persistent set with elements in this set that are also
+ * contained in the specified [elements] sequence removed,
+ * or this instance if no modifications were made in the result of this operation.
  */
 public operator fun <E> PersistentSet<E>.minus(elements: Sequence<E>): PersistentSet<E>
         = mutate { it.removeAll(elements) }
 
 /**
- * Returns all elements in this set that are also
- * contained in the specified [elements] collection.
- *
- * @return a new persistent set with elements in this set that are also
- *         contained in the specified [elements] collection;
- *         or this instance if no modifications were made in the result of this operation.
+ * Returns a new persistent set with elements in this set that are also
+ * contained in the specified [elements] collection,
+ * or this instance if no modifications were made in the result of this operation.
  */
 public infix fun <E> PersistentSet<E>.intersect(elements: Iterable<E>): PersistentSet<E>
         = if (elements is Collection) retainingAll(elements) else mutate { it.retainAll(elements) }
 
 /**
- * Returns all elements in this collection that are also
+ * Returns a new persistent set with elements in this collection that are also
  * contained in the specified [elements] collection.
- *
- * @return a new persistent set with elements in this collection that are also
- *         contained in the specified [elements] collection.
  */
 public infix fun <E> PersistentCollection<E>.intersect(elements: Iterable<E>): PersistentSet<E>
         = this.toPersistentSet().intersect(elements)
 
 /**
- * Returns the result of adding an entry to this map from the specified key-value [pair].
+ * Returns a new persistent map with an entry from the specified key-value [pair] added,
+ * or this instance if no modifications were made in the result of this operation.
  *
  * If this map already contains a mapping for the key,
  * the old value is replaced by the value from the specified [pair].
- *
- * @return a new persistent map with an entry from the specified key-value [pair] added;
- *         or this instance if no modifications were made in the result of this operation.
  */
 @Suppress("UNCHECKED_CAST")
 public inline operator fun <K, V> PersistentMap<out K, V>.plus(pair: Pair<K, V>): PersistentMap<K, V>
         = (this as PersistentMap<K, V>).putting(pair.first, pair.second)
 
 /**
- * Returns the result of replacing or adding entries to this map from the specified key-value pairs.
- *
- * @return a new persistent map with entries from the specified key-value pairs added;
- *         or this instance if no modifications were made in the result of this operation.
+ * Returns a new persistent map with entries from the specified key-value pairs added,
+ * or this instance if no modifications were made in the result of this operation.
  */
 public inline operator fun <K, V> PersistentMap<out K, V>.plus(pairs: Iterable<Pair<K, V>>): PersistentMap<K, V> = puttingAll(pairs)
 
 /**
- * Returns the result of replacing or adding entries to this map from the specified key-value pairs.
- *
- * @return a new persistent map with entries from the specified key-value pairs added;
- *         or this instance if no modifications were made in the result of this operation.
+ * Returns a new persistent map with entries from the specified key-value pairs added,
+ * or this instance if no modifications were made in the result of this operation.
  */
 public inline operator fun <K, V> PersistentMap<out K, V>.plus(pairs: Array<out Pair<K, V>>): PersistentMap<K, V> = puttingAll(pairs)
 
 /**
- * Returns the result of replacing or adding entries to this map from the specified key-value pairs.
- *
- * @return a new persistent map with entries from the specified key-value pairs added;
- *         or this instance if no modifications were made in the result of this operation.
+ * Returns a new persistent map with entries from the specified key-value pairs added,
+ * or this instance if no modifications were made in the result of this operation.
  */
 public inline operator fun <K, V> PersistentMap<out K, V>.plus(pairs: Sequence<Pair<K, V>>): PersistentMap<K, V> = puttingAll(pairs)
 
 /**
- * Returns the result of merging the specified [map] with this map.
+ * Returns a new persistent map with keys and values from the specified [map] associated,
+ * or this instance if no modifications were made in the result of this operation.
  *
  * The effect of this call is equivalent to that of calling `put(k, v)` once for each
  * mapping from key `k` to value `v` in the specified map.
- *
- * @return a new persistent map with keys and values from the specified [map] associated;
- *         or this instance if no modifications were made in the result of this operation.
  */
 public inline operator fun <K, V> PersistentMap<out K, V>.plus(map: Map<out K, V>): PersistentMap<K, V> = puttingAll(map)
 
 
 /**
- * Returns the result of merging the specified [map] with this map.
+ * Returns a new persistent map with keys and values from the specified [map] associated,
+ * or this instance if no modifications were made in the result of this operation.
  *
  * The effect of this call is equivalent to that of calling `put(k, v)` once for each
  * mapping from key `k` to value `v` in the specified map.
- *
- * @return a new persistent map with keys and values from the specified [map] associated;
- *         or this instance if no modifications were made in the result of this operation.
  */
 @Suppress("UNCHECKED_CAST")
 public fun <K, V> PersistentMap<out K, V>.puttingAll(map: Map<out K, V>): PersistentMap<K, V> =
     (this as PersistentMap<K, V>).puttingAll(map)
 
 /**
- * Returns the result of merging the specified [map] with this map.
+ * Returns a new persistent map with keys and values from the specified [map] associated,
+ * or this instance if no modifications were made in the result of this operation.
  *
  * The effect of this call is equivalent to that of calling `put(k, v)` once for each
  * mapping from key `k` to value `v` in the specified map.
@@ -390,9 +309,6 @@ public fun <K, V> PersistentMap<out K, V>.puttingAll(map: Map<out K, V>): Persis
  * were deprecated and will be removed in future releases. Refer to the
  * [Migration guide](https://github.com/Kotlin/kotlinx.collections.immutable/blob/master/docs/0.5.0-MIGRATION.md)
  * for more details and guidance with the migration.
- *
- * @return a new persistent map with keys and values from the specified [map] associated;
- *         or this instance if no modifications were made in the result of this operation.
  */
 @Deprecated(
     "Use puttingAll() instead. For more details, read the documentation for this function.",
@@ -401,16 +317,15 @@ public fun <K, V> PersistentMap<out K, V>.puttingAll(map: Map<out K, V>): Persis
 public fun <K, V> PersistentMap<out K, V>.putAll(map: Map<out K, V>): PersistentMap<K, V> = puttingAll(map)
 
 /**
- * Returns the result of replacing or adding entries to this map from the specified key-value pairs.
- *
- * @return a new persistent map with entries from the specified key-value pairs added;
- *         or this instance if no modifications were made in the result of this operation.
+ * Returns a new persistent map with entries from the specified key-value pairs added,
+ * or this instance if no modifications were made in the result of this operation.
  */
 public fun <K, V> PersistentMap<out K, V>.puttingAll(pairs: Iterable<Pair<K, V>>): PersistentMap<K, V> =
     mutate { it.putAll(pairs) }
 
 /**
- * Returns the result of replacing or adding entries to this map from the specified key-value pairs.
+ * Returns a new persistent map with entries from the specified key-value pairs added,
+ * or this instance if no modifications were made in the result of this operation.
  *
  * Use the function [puttingAll] to make it clear that a new map is returned.
  *
@@ -418,9 +333,6 @@ public fun <K, V> PersistentMap<out K, V>.puttingAll(pairs: Iterable<Pair<K, V>>
  * were deprecated and will be removed in future releases.
  * Refer to the [Migration guide](https://github.com/Kotlin/kotlinx.collections.immutable/blob/master/docs/0.5.0-MIGRATION.md)
  * for more details and guidance with the migration.
- *
- * @return a new persistent map with entries from the specified key-value pairs added;
- *         or this instance if no modifications were made in the result of this operation.
  */
 @Deprecated(
     "Use puttingAll() instead. For more details, read the documentation for this function.",
@@ -429,16 +341,15 @@ public fun <K, V> PersistentMap<out K, V>.puttingAll(pairs: Iterable<Pair<K, V>>
 public fun <K, V> PersistentMap<out K, V>.putAll(pairs: Iterable<Pair<K, V>>): PersistentMap<K, V> = puttingAll(pairs)
 
 /**
- * Returns the result of replacing or adding entries to this map from the specified key-value pairs.
- *
- * @return a new persistent map with entries from the specified key-value pairs added;
- *         or this instance if no modifications were made in the result of this operation.
+ * Returns a new persistent map with entries from the specified key-value pairs added,
+ * or this instance if no modifications were made in the result of this operation.
  */
 public fun <K, V> PersistentMap<out K, V>.puttingAll(pairs: Array<out Pair<K, V>>): PersistentMap<K, V> =
     mutate { it.putAll(pairs) }
 
 /**
- * Returns the result of replacing or adding entries to this map from the specified key-value pairs.
+ * Returns a new persistent map with entries from the specified key-value pairs added,
+ * or this instance if no modifications were made in the result of this operation.
  *
  * Use the function [puttingAll] to make it clear that a new map is returned.
  *
@@ -446,9 +357,6 @@ public fun <K, V> PersistentMap<out K, V>.puttingAll(pairs: Array<out Pair<K, V>
  * were deprecated and will be removed in future releases.
  * Refer to the [Migration guide](https://github.com/Kotlin/kotlinx.collections.immutable/blob/master/docs/0.5.0-MIGRATION.md)
  * for more details and guidance with the migration.
- *
- * @return a new persistent map with entries from the specified key-value pairs added;
- *         or this instance if no modifications were made in the result of this operation.
  */
 @Deprecated(
     "Use puttingAll() instead. For more details, read the documentation for this function.",
@@ -457,16 +365,15 @@ public fun <K, V> PersistentMap<out K, V>.puttingAll(pairs: Array<out Pair<K, V>
 public fun <K, V> PersistentMap<out K, V>.putAll(pairs: Array<out Pair<K, V>>): PersistentMap<K, V> = puttingAll(pairs)
 
 /**
- * Returns the result of replacing or adding entries to this map from the specified key-value pairs.
- *
- * @return a new persistent map with entries from the specified key-value pairs added;
- *         or this instance if no modifications were made in the result of this operation.
+ * Returns a new persistent map with entries from the specified key-value pairs added,
+ * or this instance if no modifications were made in the result of this operation.
  */
 public fun <K, V> PersistentMap<out K, V>.puttingAll(pairs: Sequence<Pair<K, V>>): PersistentMap<K, V> =
     mutate { it.putAll(pairs) }
 
 /**
- * Returns the result of replacing or adding entries to this map from the specified key-value pairs.
+ * Returns a new persistent map with entries from the specified key-value pairs added,
+ * or this instance if no modifications were made in the result of this operation.
  *
  * Use the function [puttingAll] to make it clear that a new map is returned.
  *
@@ -474,9 +381,6 @@ public fun <K, V> PersistentMap<out K, V>.puttingAll(pairs: Sequence<Pair<K, V>>
  * were deprecated and will be removed in future releases.
  * Refer to the [Migration guide](https://github.com/Kotlin/kotlinx.collections.immutable/blob/master/docs/0.5.0-MIGRATION.md)
  * for more details and guidance with the migration.
- *
- * @return a new persistent map with entries from the specified key-value pairs added;
- *         or this instance if no modifications were made in the result of this operation.
  */
 @Deprecated(
     "Use puttingAll() instead. For more details, read the documentation for this function.",
@@ -485,246 +389,194 @@ public fun <K, V> PersistentMap<out K, V>.puttingAll(pairs: Sequence<Pair<K, V>>
 public fun <K, V> PersistentMap<out K, V>.putAll(pairs: Sequence<Pair<K, V>>): PersistentMap<K, V> = puttingAll(pairs)
 
 /**
- * Returns the result of removing the specified [key] and its corresponding value from this map.
- *
- * @return a new persistent map with the specified [key] and its corresponding value removed;
- *         or this instance if it contains no mapping for the key.
+ * Returns a new persistent map with the specified [key] and its corresponding value removed,
+ * or this instance if it contains no mapping for the key.
  */
 @Suppress("UNCHECKED_CAST")
 public operator fun <K, V> PersistentMap<out K, V>.minus(key: K): PersistentMap<K, V>
         = (this as PersistentMap<K, V>).removing(key)
 
 /**
- * Returns the result of removing the specified [keys] and their corresponding values from this map.
- *
- * @return a new persistent map with the specified [keys] and their corresponding values removed;
- *         or this instance if no modifications were made in the result of this operation.
+ * Returns a new persistent map with the specified [keys] and their corresponding values removed,
+ * or this instance if no modifications were made in the result of this operation.
  */
 public operator fun <K, V> PersistentMap<out K, V>.minus(keys: Iterable<K>): PersistentMap<K, V>
         = mutate { it.minusAssign(keys) }
 
 /**
- * Returns the result of removing the specified [keys] and their corresponding values from this map.
- *
- * @return a new persistent map with the specified [keys] and their corresponding values removed;
- *         or this instance if no modifications were made in the result of this operation.
+ * Returns a new persistent map with the specified [keys] and their corresponding values removed,
+ * or this instance if no modifications were made in the result of this operation.
  */
 public operator fun <K, V> PersistentMap<out K, V>.minus(keys: Array<out K>): PersistentMap<K, V>
         = mutate { it.minusAssign(keys) }
 
 /**
- * Returns the result of removing the specified [keys] and their corresponding values from this map.
- *
- * @return a new persistent map with the specified [keys] and their corresponding values removed;
- *         or this instance if no modifications were made in the result of this operation.
+ * Returns a new persistent map with the specified [keys] and their corresponding values removed,
+ * or this instance if no modifications were made in the result of this operation.
  */
 public operator fun <K, V> PersistentMap<out K, V>.minus(keys: Sequence<K>): PersistentMap<K, V>
         = mutate { it.minusAssign(keys) }
 
 
 /**
- * Creates a new persistent list of the specified elements.
- *
- * @return a new persistent list of the specified elements.
+ * Returns a new persistent list of the specified elements.
  */
 public fun <E> persistentListOf(vararg elements: E): PersistentList<E> = persistentVectorOf<E>().addingAll(elements.asList())
 
 /**
- * Creates an empty persistent list.
- *
- * @return an empty persistent list.
+ * Returns an empty persistent list.
  */
 public fun <E> persistentListOf(): PersistentList<E> = persistentVectorOf()
 
 
 /**
- * Creates a new persistent set with the given elements.
+ * Returns a new persistent set with the given elements.
  *
  * Elements of the returned set are iterated in the order they were specified.
- *
- * @return a new persistent set with the given elements.
  */
 public fun <E> persistentSetOf(vararg elements: E): PersistentSet<E> = PersistentOrderedSet.emptyOf<E>().addingAll(elements.asList())
 
 /**
- * Creates an empty persistent set.
- *
- * @return an empty persistent set.
+ * Returns an empty persistent set.
  */
 public fun <E> persistentSetOf(): PersistentSet<E> = PersistentOrderedSet.emptyOf<E>()
 
 
 /**
- * Creates a new persistent set with the given elements.
+ * Returns a new persistent set with the given elements.
  *
  * Order of the elements in the returned set is unspecified.
- *
- * @return a new persistent set with the given elements.
  */
 public fun <E> persistentHashSetOf(vararg elements: E): PersistentSet<E> = PersistentHashSet.emptyOf<E>().addingAll(elements.asList())
 
 /**
- * Creates an empty persistent set.
- *
- * @return an empty persistent set.
+ * Returns an empty persistent set.
  */
 public fun <E> persistentHashSetOf(): PersistentSet<E> = PersistentHashSet.emptyOf()
 
 
 /**
- * Creates a new persistent map with the specified contents, given as a list of pairs
+ * Returns a new persistent map with the specified contents, given as a list of pairs
  * where the first component is the key and the second is the value.
  *
  * If multiple pairs have the same key, the resulting map will contain the value from the last of those pairs.
  *
  * Entries of the map are iterated in the order they were specified.
- *
- * @return a new persistent map with the specified contents.
  */
 public fun <K, V> persistentMapOf(vararg pairs: Pair<K, V>): PersistentMap<K, V> = PersistentOrderedMap.emptyOf<K,V>().mutate { it += pairs }
 
 /**
- * Creates an empty persistent map.
- *
- * @return an empty persistent map.
+ * Returns an empty persistent map.
  */
 public fun <K, V> persistentMapOf(): PersistentMap<K, V> = PersistentOrderedMap.emptyOf()
 
 
 /**
- * Creates a new persistent map with the specified contents, given as a list of pairs
+ * Returns a new persistent map with the specified contents, given as a list of pairs
  * where the first component is the key and the second is the value.
  *
  * If multiple pairs have the same key, the resulting map will contain the value from the last of those pairs.
  *
  * Order of the entries in the returned map is unspecified.
- *
- * @return a new persistent map with the specified contents.
  */
 public fun <K, V> persistentHashMapOf(vararg pairs: Pair<K, V>): PersistentMap<K, V> = PersistentHashMap.emptyOf<K,V>().mutate { it += pairs }
 
 /**
- * Creates an empty persistent map.
- *
- * @return an empty persistent map.
+ * Returns an empty persistent map.
  */
 public fun <K, V> persistentHashMapOf(): PersistentMap<K, V> = PersistentHashMap.emptyOf()
 
 
 /**
- * Creates a new persistent list of the specified elements.
- *
- * @return a new persistent list of the specified elements.
+ * Returns a new persistent list of the specified elements.
  */
 @Deprecated("Use persistentListOf instead.", ReplaceWith("persistentListOf(*elements)"))
 public fun <E> immutableListOf(vararg elements: E): PersistentList<E> = persistentListOf(*elements)
 
 /**
- * Creates an empty persistent list.
- *
- * @return an empty persistent list.
+ * Returns an empty persistent list.
  */
 @Deprecated("Use persistentListOf instead.", ReplaceWith("persistentListOf()"))
 public fun <E> immutableListOf(): PersistentList<E> = persistentListOf()
 
 
 /**
- * Creates a new persistent set with the given elements.
+ * Returns a new persistent set with the given elements.
  *
  * Elements of the returned set are iterated in the order they were specified.
- *
- * @return a new persistent set with the given elements.
  */
 @Deprecated("Use persistentSetOf instead.", ReplaceWith("persistentSetOf(*elements)"))
 public fun <E> immutableSetOf(vararg elements: E): PersistentSet<E> = persistentSetOf(*elements)
 
 /**
- * Creates an empty persistent set.
- *
- * @return an empty persistent set.
+ * Returns an empty persistent set.
  */
 @Deprecated("Use persistentSetOf instead.", ReplaceWith("persistentSetOf()"))
 public fun <E> immutableSetOf(): PersistentSet<E> = persistentSetOf()
 
 
 /**
- * Creates a new persistent set with the given elements.
+ * Returns a new persistent set with the given elements.
  *
  * Order of the elements in the returned set is unspecified.
- *
- * @return a new persistent set with the given elements.
  */
 @Deprecated("Use persistentHashSetOf instead.", ReplaceWith("persistentHashSetOf(*elements)"))
 public fun <E> immutableHashSetOf(vararg elements: E): PersistentSet<E> = persistentHashSetOf(*elements)
 
 
 /**
- * Creates a new persistent map with the specified contents, given as a list of pairs
+ * Returns a new persistent map with the specified contents, given as a list of pairs
  * where the first component is the key and the second is the value.
  *
  * If multiple pairs have the same key, the resulting map will contain the value from the last of those pairs.
  *
  * Entries of the map are iterated in the order they were specified.
- *
- * @return a new persistent map with the specified contents.
  */
 @Deprecated("Use persistentMapOf instead.", ReplaceWith("persistentMapOf(*pairs)"))
 public fun <K, V> immutableMapOf(vararg pairs: Pair<K, V>): PersistentMap<K, V> = persistentMapOf(*pairs)
 
 /**
- * Creates a new persistent map with the specified contents, given as a list of pairs
+ * Returns a new persistent map with the specified contents, given as a list of pairs
  * where the first component is the key and the second is the value.
  *
  * If multiple pairs have the same key, the resulting map will contain the value from the last of those pairs.
  *
  * Order of the entries in the returned map is unspecified.
- *
- * @return a new persistent map with the specified contents.
  */
 @Deprecated("Use persistentHashMapOf instead.", ReplaceWith("persistentHashMapOf(*pairs)"))
 public fun <K, V> immutableHashMapOf(vararg pairs: Pair<K, V>): PersistentMap<K, V> = persistentHashMapOf(*pairs)
 
 
 /**
- * Converts this iterable to an immutable list.
+ * Returns an immutable list containing all elements of this iterable.
  *
  * If the receiver is already an immutable list, returns it as is.
- *
- * @return an immutable list containing all elements of this iterable.
  */
 public fun <T> Iterable<T>.toImmutableList(): ImmutableList<T> =
         this as? ImmutableList
         ?: this.toPersistentList()
 
 /**
- * Converts this array to an immutable list.
- *
- * @return an immutable list containing all elements of this array.
+ * Returns an immutable list containing all elements of this array.
  */
 public fun <T> Array<out T>.toImmutableList(): ImmutableList<T> = toPersistentList()
 
 /**
- * Converts this sequence to an immutable list.
- *
- * @return an immutable list containing all elements of this sequence.
+ * Returns an immutable list containing all elements of this sequence.
  */
 public fun <T> Sequence<T>.toImmutableList(): ImmutableList<T> = toPersistentList()
 
 /**
- * Converts this char sequence to an immutable list.
- *
- * @return an immutable list containing all characters.
+ * Returns an immutable list containing all characters.
  */
 public fun CharSequence.toImmutableList(): ImmutableList<Char> = toPersistentList()
 
 
 /**
- * Converts this iterable to a persistent list.
+ * Returns a persistent list containing all elements of this iterable.
  *
  * If the receiver is already a persistent list, returns it as is.
  * If the receiver is a persistent list builder, calls `build` on it and returns the result.
- *
- * @return a persistent list containing all elements of this iterable.
  */
 public fun <T> Iterable<T>.toPersistentList(): PersistentList<T> =
         this as? PersistentList
@@ -732,36 +584,28 @@ public fun <T> Iterable<T>.toPersistentList(): PersistentList<T> =
         ?: persistentListOf<T>() + this
 
 /**
- * Converts this array to a persistent list.
- *
- * @return a persistent list containing all elements of this array.
+ * Returns a persistent list containing all elements of this array.
  */
 public fun <T> Array<out T>.toPersistentList(): PersistentList<T> = persistentListOf<T>() + this
 
 /**
- * Converts this sequence to a persistent list.
- *
- * @return a persistent list containing all elements of this sequence.
+ * Returns a persistent list containing all elements of this sequence.
  */
 public fun <T> Sequence<T>.toPersistentList(): PersistentList<T> = persistentListOf<T>() + this
 
 /**
- * Converts this char sequence to a persistent list.
- *
- * @return a persistent list containing all characters.
+ * Returns a persistent list containing all characters.
  */
 public fun CharSequence.toPersistentList(): PersistentList<Char> =
     persistentListOf<Char>().mutate { this.toCollection(it) }
 
 
 /**
- * Converts this iterable to an immutable set.
+ * Returns an immutable set of all elements of this iterable.
  *
  * If the receiver is already an immutable set, returns it as is.
  *
  * Elements of the returned set are iterated in the same order as in this iterable.
- *
- * @return an immutable set of all elements of this iterable.
  */
 public fun <T> Iterable<T>.toImmutableSet(): ImmutableSet<T> =
         this as? ImmutableSet<T>
@@ -769,42 +613,34 @@ public fun <T> Iterable<T>.toImmutableSet(): ImmutableSet<T> =
         ?: persistentSetOf<T>() + this
 
 /**
- * Converts this array to an immutable set.
+ * Returns an immutable set of all elements of this array.
  *
  * Elements of the returned set are iterated in the same order as in this array.
- *
- * @return an immutable set of all elements of this array.
  */
 public fun <T> Array<out T>.toImmutableSet(): ImmutableSet<T> = toPersistentSet()
 
 /**
- * Converts this sequence to an immutable set.
+ * Returns an immutable set of all elements of this sequence.
  *
  * Elements of the returned set are iterated in the same order as in this sequence.
- *
- * @return an immutable set of all elements of this sequence.
  */
 public fun <T> Sequence<T>.toImmutableSet(): ImmutableSet<T> = toPersistentSet()
 
 /**
- * Converts this char sequence to an immutable set.
+ * Returns an immutable set of all characters.
  *
  * Elements of the returned set are iterated in the same order as in this char sequence.
- *
- * @return an immutable set of all characters.
  */
 public fun CharSequence.toImmutableSet(): PersistentSet<Char> = toPersistentSet()
 
 
 /**
- * Converts this iterable to a persistent set.
+ * Returns a persistent set of all elements of this iterable.
  *
  * If the receiver is already a persistent set, returns it as is.
  * If the receiver is a persistent set builder, calls `build` on it and returns the result.
  *
  * Elements of the returned set are iterated in the same order as in this iterable.
- *
- * @return a persistent set of all elements of this iterable.
  */
 public fun <T> Iterable<T>.toPersistentSet(): PersistentSet<T> =
         this as? PersistentOrderedSet<T>
@@ -812,43 +648,35 @@ public fun <T> Iterable<T>.toPersistentSet(): PersistentSet<T> =
         ?: PersistentOrderedSet.emptyOf<T>() + this
 
 /**
- * Converts this array to a persistent set.
+ * Returns a persistent set of all elements of this array.
  *
  * Elements of the returned set are iterated in the same order as in this array.
- *
- * @return a persistent set of all elements of this array.
  */
 public fun <T> Array<out T>.toPersistentSet(): PersistentSet<T> = persistentSetOf<T>() + this
 
 /**
- * Converts this sequence to a persistent set.
+ * Returns a persistent set of all elements of this sequence.
  *
  * Elements of the returned set are iterated in the same order as in this sequence.
- *
- * @return a persistent set of all elements of this sequence.
  */
 public fun <T> Sequence<T>.toPersistentSet(): PersistentSet<T> = persistentSetOf<T>() + this
 
 /**
- * Converts this char sequence to a persistent set.
+ * Returns a persistent set of all characters.
  *
  * Elements of the returned set are iterated in the same order as in this char sequence.
- *
- * @return a persistent set of all characters.
  */
 public fun CharSequence.toPersistentSet(): PersistentSet<Char> =
         persistentSetOf<Char>().mutate { this.toCollection(it) }
 
 
 /**
- * Converts this iterable to a persistent hash set.
+ * Returns a persistent set containing all elements from this iterable.
  *
  * If the receiver is already a persistent hash set, returns it as is.
  * If the receiver is a persistent hash set builder, calls `build` on it and returns the result.
  *
  * Order of the elements in the returned set is unspecified.
- *
- * @return a persistent set containing all elements from this iterable.
  */
 public fun <T> Iterable<T>.toPersistentHashSet(): PersistentSet<T>
     = this as? PersistentHashSet
@@ -856,42 +684,34 @@ public fun <T> Iterable<T>.toPersistentHashSet(): PersistentSet<T>
         ?: PersistentHashSet.emptyOf<T>() + this
 
 /**
- * Converts this array to a persistent hash set.
+ * Returns a persistent set of all elements of this array.
  *
  * Order of the elements in the returned set is unspecified.
- *
- * @return a persistent set of all elements of this array.
  */
 public fun <T> Array<out T>.toPersistentHashSet(): PersistentSet<T> = persistentHashSetOf<T>() + this
 
 /**
- * Converts this sequence to a persistent hash set.
+ * Returns a persistent set of all elements of this sequence.
  *
  * Order of the elements in the returned set is unspecified.
- *
- * @return a persistent set of all elements of this sequence.
  */
 public fun <T> Sequence<T>.toPersistentHashSet(): PersistentSet<T> = persistentHashSetOf<T>() + this
 
 /**
- * Converts this char sequence to a persistent hash set.
+ * Returns a persistent set of all characters.
  *
  * Order of the elements in the returned set is unspecified.
- *
- * @return a persistent set of all characters.
  */
 public fun CharSequence.toPersistentHashSet(): PersistentSet<Char> =
         persistentHashSetOf<Char>().mutate { this.toCollection(it) }
 
 
 /**
- * Converts this map to an immutable map.
+ * Returns an immutable map containing all entries from this map.
  *
  * If the receiver is already an immutable map, returns it as is.
  *
  * Entries of the returned map are iterated in the same order as in this map.
- *
- * @return an immutable map containing all entries from this map.
  */
 public fun <K, V> Map<K, V>.toImmutableMap(): ImmutableMap<K, V>
     = this as? ImmutableMap
@@ -899,14 +719,12 @@ public fun <K, V> Map<K, V>.toImmutableMap(): ImmutableMap<K, V>
         ?: persistentMapOf<K, V>().puttingAll(this)
 
 /**
- * Converts this map to a persistent map.
+ * Returns a persistent map containing all entries from this map.
  *
  * If the receiver is already a persistent map, returns it as is.
  * If the receiver is a persistent map builder, calls `build` on it and returns the result.
  *
  * Entries of the returned map are iterated in the same order as in this map.
- *
- * @return a persistent map containing all entries from this map.
  */
 public fun <K, V> Map<K, V>.toPersistentMap(): PersistentMap<K, V>
     = this as? PersistentOrderedMap<K, V>
@@ -914,14 +732,12 @@ public fun <K, V> Map<K, V>.toPersistentMap(): PersistentMap<K, V>
         ?: PersistentOrderedMap.emptyOf<K, V>().puttingAll(this)
 
 /**
- * Converts this map to a persistent hash map.
+ * Returns a persistent map containing all entries from this map.
  *
  * If the receiver is already a persistent hash map, returns it as is.
  * If the receiver is a persistent hash map builder, calls `build` on it and returns the result.
  *
  * Order of the entries in the returned map is unspecified.
- *
- * @return a persistent map containing all entries from this map.
  */
 public fun <K, V> Map<K, V>.toPersistentHashMap(): PersistentMap<K, V>
         = this as? PersistentHashMap

--- a/core/commonMain/src/extensions.kt
+++ b/core/commonMain/src/extensions.kt
@@ -83,25 +83,25 @@ public operator fun <E> PersistentCollection<E>.plus(elements: Sequence<E>): Per
 
 
 /**
- * Returns a new persistent collection with elements in this collection that are also
- * contained in the specified [elements] collection removed,
- * or this instance if no modifications were made in the result of this operation.
+ * Returns a new persistent collection containing all elements of this collection
+ * except the elements contained in the specified [elements] collection,
+ * or this instance if there are no elements to remove.
  */
 public operator fun <E> PersistentCollection<E>.minus(elements: Iterable<E>): PersistentCollection<E>
         = if (elements is Collection) removingAll(elements) else builder().also { it.removeAll(elements) }.build()
 
 /**
- * Returns a new persistent collection with elements in this collection that are also
- * contained in the specified [elements] array removed,
- * or this instance if no modifications were made in the result of this operation.
+ * Returns a new persistent collection containing all elements of this collection
+ * except the elements contained in the specified [elements] array,
+ * or this instance if there are no elements to remove.
  */
 public operator fun <E> PersistentCollection<E>.minus(elements: Array<out E>): PersistentCollection<E>
         = builder().also { it.removeAll(elements) }.build()
 
 /**
- * Returns a new persistent collection with elements in this collection that are also
- * contained in the specified [elements] sequence removed,
- * or this instance if no modifications were made in the result of this operation.
+ * Returns a new persistent collection containing all elements of this collection
+ * except the elements contained in the specified [elements] sequence,
+ * or this instance if there are no elements to remove.
  */
 public operator fun <E> PersistentCollection<E>.minus(elements: Sequence<E>): PersistentCollection<E>
         =  builder().also { it.removeAll(elements) }.build()
@@ -148,25 +148,25 @@ public operator fun <E> PersistentList<E>.plus(elements: Sequence<E>): Persisten
 
 
 /**
- * Returns a new persistent list with elements in this list that are also
- * contained in the specified [elements] collection removed,
- * or this instance if no modifications were made in the result of this operation.
+ * Returns a new persistent list containing all elements of this list
+ * except the elements contained in the specified [elements] collection,
+ * or this instance if there are no elements to remove.
  */
 public operator fun <E> PersistentList<E>.minus(elements: Iterable<E>): PersistentList<E>
         = if (elements is Collection) removingAll(elements) else mutate { it.removeAll(elements) }
 
 /**
- * Returns a new persistent list with elements in this list that are also
- * contained in the specified [elements] array removed,
- * or this instance if no modifications were made in the result of this operation.
+ * Returns a new persistent list containing all elements of this list
+ * except the elements contained in the specified [elements] array,
+ * or this instance if there are no elements to remove.
  */
 public operator fun <E> PersistentList<E>.minus(elements: Array<out E>): PersistentList<E>
         = mutate { it.removeAll(elements) }
 
 /**
- * Returns a new persistent list with elements in this list that are also
- * contained in the specified [elements] sequence removed,
- * or this instance if no modifications were made in the result of this operation.
+ * Returns a new persistent list containing all elements of this list
+ * except the elements contained in the specified [elements] sequence,
+ * or this instance if there are no elements to remove.
  */
 public operator fun <E> PersistentList<E>.minus(elements: Sequence<E>): PersistentList<E>
         = mutate { it.removeAll(elements) }
@@ -208,25 +208,25 @@ public operator fun <E> PersistentSet<E>.plus(elements: Sequence<E>): Persistent
 
 
 /**
- * Returns a new persistent set with elements in this set that are also
- * contained in the specified [elements] collection removed,
- * or this instance if no modifications were made in the result of this operation.
+ * Returns a new persistent set containing all elements of this set
+ * except the elements contained in the specified [elements] collection,
+ * or this instance if there are no elements to remove.
  */
 public operator fun <E> PersistentSet<E>.minus(elements: Iterable<E>): PersistentSet<E>
         = if (elements is Collection) removingAll(elements) else mutate { it.removeAll(elements) }
 
 /**
- * Returns a new persistent set with elements in this set that are also
- * contained in the specified [elements] array removed,
- * or this instance if no modifications were made in the result of this operation.
+ * Returns a new persistent set containing all elements of this set
+ * except the elements contained in the specified [elements] array,
+ * or this instance if there are no elements to remove.
  */
 public operator fun <E> PersistentSet<E>.minus(elements: Array<out E>): PersistentSet<E>
         = mutate { it.removeAll(elements) }
 
 /**
- * Returns a new persistent set with elements in this set that are also
- * contained in the specified [elements] sequence removed,
- * or this instance if no modifications were made in the result of this operation.
+ * Returns a new persistent set containing all elements of this set
+ * except the elements contained in the specified [elements] sequence,
+ * or this instance if there are no elements to remove.
  */
 public operator fun <E> PersistentSet<E>.minus(elements: Sequence<E>): PersistentSet<E>
         = mutate { it.removeAll(elements) }
@@ -397,22 +397,25 @@ public operator fun <K, V> PersistentMap<out K, V>.minus(key: K): PersistentMap<
         = (this as PersistentMap<K, V>).removing(key)
 
 /**
- * Returns a new persistent map with the specified [keys] and their corresponding values removed,
- * or this instance if no modifications were made in the result of this operation.
+ * Returns a new persistent map containing all entries of this map
+ * except those whose keys are contained in the specified [keys] collection,
+ * or this instance if there are no entries to remove.
  */
 public operator fun <K, V> PersistentMap<out K, V>.minus(keys: Iterable<K>): PersistentMap<K, V>
         = mutate { it.minusAssign(keys) }
 
 /**
- * Returns a new persistent map with the specified [keys] and their corresponding values removed,
- * or this instance if no modifications were made in the result of this operation.
+ * Returns a new persistent map containing all entries of this map
+ * except those whose keys are contained in the specified [keys] array,
+ * or this instance if there are no entries to remove.
  */
 public operator fun <K, V> PersistentMap<out K, V>.minus(keys: Array<out K>): PersistentMap<K, V>
         = mutate { it.minusAssign(keys) }
 
 /**
- * Returns a new persistent map with the specified [keys] and their corresponding values removed,
- * or this instance if no modifications were made in the result of this operation.
+ * Returns a new persistent map containing all entries of this map
+ * except those whose keys are contained in the specified [keys] sequence,
+ * or this instance if there are no entries to remove.
  */
 public operator fun <K, V> PersistentMap<out K, V>.minus(keys: Sequence<K>): PersistentMap<K, V>
         = mutate { it.minusAssign(keys) }

--- a/core/commonMain/src/implementations/immutableList/PersistentVector.kt
+++ b/core/commonMain/src/implementations/immutableList/PersistentVector.kt
@@ -118,11 +118,10 @@ internal class PersistentVector<E>(private val root: Array<Any?>,
     }
 
     /**
-     * Insert the specified [element] into the [root] trie at the specified trie [index].
+     * Inserts the specified [element] into the [root] trie at the specified trie [index]
+     * and returns the new root trie.
      *
      * [elementCarry] contains the last element of this trie that was popped out by the insertion operation.
-     *
-     * @return new root trie
      */
     private fun insertIntoRoot(root: Array<Any?>, shift: Int, index: Int, element: Any?, elementCarry: ObjectRef): Array<Any?> {
         val bufferIndex = indexSegment(index, shift)
@@ -235,12 +234,11 @@ internal class PersistentVector<E>(private val root: Array<Any?>,
     }
 
     /**
-     * Removes element from trie at the specified trie [index].
+     * Removes the element from the trie at the specified trie [index]
+     * and returns the new root of the trie.
      *
      * [tailCarry] on input contains the first element of the adjacent trie to fill the last vacant element with.
      * [tailCarry] on output contains the first element of this trie.
-     *
-     * @return the new root of the trie.
      */
     private fun removeFromRootAt(root: Array<Any?>, shift: Int, index: Int, tailCarry: ObjectRef): Array<Any?> {
         val bufferIndex = indexSegment(index, shift)

--- a/core/commonMain/src/implementations/immutableList/PersistentVectorBuilder.kt
+++ b/core/commonMain/src/implementations/immutableList/PersistentVectorBuilder.kt
@@ -316,11 +316,10 @@ internal class PersistentVectorBuilder<E>(vector: PersistentList<E>,
     }
 
     /**
-     * Insert the specified [element] into the [root] trie at the specified trie [index].
+     * Inserts the specified [element] into the [root] trie at the specified trie [index]
+     * and returns the new root trie, or this modified trie if it's already mutable.
      *
      * [elementCarry] contains the last element of this trie that was popped out by the insertion operation.
-     *
-     * @return new root trie or this modified trie, if it's already mutable
      */
     private fun insertIntoRoot(root: Array<Any?>, shift: Int, index: Int, element: Any?, elementCarry: ObjectRef): Array<Any?> {
         val bufferIndex = indexSegment(index, shift)
@@ -589,12 +588,11 @@ internal class PersistentVectorBuilder<E>(vector: PersistentList<E>,
     }
 
     /**
-     * Removes element from trie at the specified trie [index].
+     * Removes the element from the trie at the specified trie [index]
+     * and returns the new root of the trie.
      *
      * [tailCarry] on input contains the first element of the adjacent trie to fill the last vacant element with.
      * [tailCarry] on output contains the first element of this trie.
-     *
-     * @return the new root of the trie.
      */
     private fun removeFromRootAt(root: Array<Any?>, shift: Int, index: Int, tailCarry: ObjectRef): Array<Any?> {
         val bufferIndex = indexSegment(index, shift)


### PR DESCRIPTION
Drops `@return` across the project, moving the return value into the KDoc summary.

`@param` is kept in the two cases the convention still allows: type parameters (documented as in the stdlib), and the internal `PersistentVector` constructor, whose parameter descriptions are too long to inline.

Fixes #254
