### PR TITLE
Update version to 0.5.0-beta01

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # CHANGELOG
 
+## 0.5.0-beta01
+
+- Renamed `PersistentCollection` mutating-copy methods to participial forms (`add`/`remove`/`set`/`put`/`clear` → `adding`/`removing`/`setting`/`putting`/`clearing` and `*ed` variants) and deprecated the original names [#233](https://github.com/Kotlin/kotlinx.collections.immutable/pull/233)
+- Enabled the Kotlin return-value checker (`-Xreturn-value-checker=full`) for the core module and annotated select internal helpers with `@IgnorableReturnValue` where discarding the result is intentional [#243](https://github.com/Kotlin/kotlinx.collections.immutable/pull/243)
+- Updated Kotlin to version 2.3.0 [#242](https://github.com/Kotlin/kotlinx.collections.immutable/pull/242)
+- Configured JDK release to 8 for the Kotlin compiler [#239](https://github.com/Kotlin/kotlinx.collections.immutable/pull/239)
+- Populated `Implementation-Title`/`Implementation-Version`/`Implementation-Vendor` in published JAR manifests [#237](https://github.com/Kotlin/kotlinx.collections.immutable/pull/237)
+- Enabled Dokka documentation generation and upgraded Dokka to 2.2.0 [#225](https://github.com/Kotlin/kotlinx.collections.immutable/pull/225), [#245](https://github.com/Kotlin/kotlinx.collections.immutable/pull/245), [#248](https://github.com/Kotlin/kotlinx.collections.immutable/pull/248)
+
 ## 0.4.0
 
 - Fixed the equality bug in PersistentMap — Added proper node promotion during mutable operations to ensure a consistent internal tree structure [#217](https://github.com/Kotlin/kotlinx.collections.immutable/pull/217)

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 [![Maven Central](https://img.shields.io/maven-central/v/org.jetbrains.kotlinx/kotlinx-collections-immutable.svg?label=Maven%20Central)](https://central.sonatype.com/artifact/org.jetbrains.kotlinx/kotlinx-collections-immutable)
 [![Kotlin](https://img.shields.io/badge/kotlin-2.3.0-blue.svg?logo=kotlin)](http://kotlinlang.org)
 [![KDoc link](https://img.shields.io/badge/API_reference-KDoc-blue)](https://kotlin.github.io/kotlinx.collections.immutable/)
+[![Slack channel](https://img.shields.io/badge/chat-slack-blue.svg?logo=slack)](https://kotlinlang.slack.com/messages/kotlinx-collections-immutable/)
 
 Immutable collection interfaces and implementation prototypes for Kotlin.
 

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ kotlin {
     sourceSets {
         commonMain {
              dependencies {
-                 implementation("org.jetbrains.kotlinx:kotlinx-collections-immutable:0.4.0")
+                 implementation("org.jetbrains.kotlinx:kotlinx-collections-immutable:0.5.0-beta01")
              }
         }
     }
@@ -155,7 +155,7 @@ Add dependencies (you can also add other modules that you need):
 <dependency>
     <groupId>org.jetbrains.kotlinx</groupId>
     <artifactId>kotlinx-collections-immutable-jvm</artifactId>
-    <version>0.4.0</version>
+    <version>0.5.0-beta01</version>
 </dependency>
 ```
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=org.jetbrains.kotlinx
-version=0.4.0
+version=0.5.0-beta01
 versionSuffix=SNAPSHOT
 
 kotlin_version=2.3.0


### PR DESCRIPTION
- Bumps `version` in `gradle.properties` from 0.4.0 to 0.5.0-beta01 and updates the Gradle/Maven snippets in `README.md`.
- Adds a `## 0.5.0-beta01` CHANGELOG section summarizing changes since 0.4.0 (participial method names on `PersistentCollection`, return-value checker + `@IgnorableReturnValue` on internal helpers, Kotlin 2.3.0, JDK 8 release target, JAR manifest attributes, Dokka 2.2.0).
- Adds a Slack channel badge to `README.md` pointing at `#kotlinx-collections-immutable`, matching the placement and style used by `kotlinx-datetime`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)