### PR TITLE
Fix the package-list location

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -148,6 +148,7 @@ kotlin {
 
 dependencies {
     dokkaHtmlPlugin("org.jetbrains.dokka:kotlin-playground-samples-plugin")
+    dokka(project)
 }
 
 dokka {


### PR DESCRIPTION
This effectively makes the output look like a multi-module build, with `package-list` in the correct location.
See https://github.com/Kotlin/kotlinx-datetime/pull/580 / https://github.com/Kotlin/kotlinx-datetime/issues/268