### PR TITLE
Add `.kotlin` to `.gitignore` to exclude build metadata produced by KGP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 *.iml
 target
 build
+.kotlin
 /kotlinx-collections-immutable/dependency-reduced-pom.xml
 /benchmarks-runner/benchmarkResults
 /benchmarks-runner/localReferenceBenchmarkResults


### PR DESCRIPTION
See https://kotlinlang.org/docs/gradle-configure-project.html#kotlin-gradle-plugin-data-in-a-project

Otherwise, you will see something like:

<img width="1008" height="303" alt="image" src="https://github.com/user-attachments/assets/303c1380-d129-4d8c-8730-89be400f6483" />
