### PR TITLE
Updated team infra plugin

### DIFF
--- a/.teamcity/additionalConfiguration.kt
+++ b/.teamcity/additionalConfiguration.kt
@@ -24,7 +24,4 @@ fun Project.additionalConfiguration() {
     val deploymentProject = knownBuilds.deploymentSubproject
     val startTask = deploymentProject.knownBuilds.deployStart
     startTask.params.param("reverse.dep.*.DeploymentName", "kotlinx.collections.immutable %releaseVersion%")
-    deploymentProject.knownBuilds.deployPublish.params {
-        param("DeploymentId", "${deploymentProject.knownBuilds.deployUpload.depParamRefs["output.DeploymentId"]}")
-    }
 }

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -72,9 +72,7 @@ project {
                 }
             }
         }
-        val deployPublish = deployPublish(deployVersion).apply {
-            dependsOnSnapshot(deployUpload)
-        }
+        val deployPublish = deployPublish(deployVersion, deployUpload)
 
         deploys.forEach { deployAll.dependsOnSnapshot(it) }
         deployAll.dependsOnSnapshot(deployUpload) {
@@ -235,7 +233,7 @@ fun Project.deployUpload(deployVersion: BuildType) = BuildType {
     }
 }.also { buildType(it) }
 
-fun Project.deployPublish(deployVersion: BuildType) = BuildType {
+fun Project.deployPublish(deployVersion: BuildType, deployUpload: BuildType) = BuildType {
     templates(PUBLISH_DEPLOYMENT_TEMPLATE_ID)
     id(DEPLOY_PUBLISH_ID)
     name = "Publish deployment"
@@ -250,9 +248,11 @@ fun Project.deployPublish(deployVersion: BuildType) = BuildType {
 
     buildNumberPattern = deployVersion.depParamRefs.buildNumber.ref
     dependsOnSnapshot(deployVersion)
+    dependsOnSnapshot(deployUpload)
 
     params {
         param("DeployVersion", "%$releaseVersionParameter%")
+        param("DeploymentId", "${deployUpload.depParamRefs["output.DeploymentId"]}")
         // Override parameter from the template
         param("Approvers", DslContext.getParameter("Approvers", "<nobody>"))
     }

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -56,10 +56,10 @@ project {
 
         val deployVersion = deployVersion()
         val deployAll = deployAll(deployVersion)
-        val deploys = platforms.map { buildArtifacts(deployVersion, it) }
+        val deploys = platforms.associateWith { buildArtifacts(deployVersion, it) }
         val deployUpload = deployUpload(deployVersion).apply {
             dependencies {
-                deploys.forEach { dep ->
+                deploys.forEach { (_, dep) ->
                     dependency(dep) {
                         snapshot {
                             onDependencyFailure = FailureAction.FAIL_TO_START
@@ -74,7 +74,10 @@ project {
         }
         val deployPublish = deployPublish(deployVersion, deployUpload)
 
-        deploys.forEach { deployAll.dependsOnSnapshot(it) }
+        deploys
+            .filter { (platform, _) -> !singleAgentMacDeployment || platform == Platform.MacOS }
+            .forEach { deployAll.dependsOnSnapshot(it.value) }
+
         deployAll.dependsOnSnapshot(deployUpload) {
             reuseBuilds = ReuseBuilds.NO
         }
@@ -82,7 +85,7 @@ project {
             reuseBuilds = ReuseBuilds.NO
         }
 
-        buildTypesOrder = listOf(deployAll, deployVersion, *deploys.toTypedArray(), deployUpload, deployPublish)
+        buildTypesOrder = listOf(deployAll, deployVersion, *deploys.values.toTypedArray(), deployUpload, deployPublish)
     }
 
     additionalConfiguration()

--- a/.teamcity/utils.kt
+++ b/.teamcity/utils.kt
@@ -10,6 +10,8 @@ const val teamcitySuffixParameter = "teamcitySuffix"
 const val releaseVersionParameter = "releaseVersion"
 const val publicationCommandParameter = "publicationCommand"
 
+const val singleAgentMacDeployment: Boolean = true
+
 val platforms = Platform.values()
 const val jdk = "JDK_18"
 

--- a/.teamcity/utils.kt
+++ b/.teamcity/utils.kt
@@ -10,8 +10,6 @@ const val teamcitySuffixParameter = "teamcitySuffix"
 const val releaseVersionParameter = "releaseVersion"
 const val publicationCommandParameter = "publicationCommand"
 
-const val libraryStagingRepoDescription = "<<LIBRARY_STAGING_REPO_DESCRIPTION>>"
-
 val platforms = Platform.values()
 const val jdk = "JDK_18"
 
@@ -36,7 +34,7 @@ const val BUILD_CONFIGURE_VERSION_ID = "Build_Version"
 const val BUILD_ALL_ID = "Build_All"
 const val DEPLOY_ALL_ID = "Deploy_All"
 const val DEPLOY_CONFIGURE_VERSION_ID = "Deploy_Configure"
-const val DEPLOY_UPLOAD_ID = "Deplpy_Upload"
+const val DEPLOY_UPLOAD_ID = "Deploy_Upload"
 const val DEPLOY_PUBLISH_ID = "Deploy_Publish"
 
 val UPLOAD_DEPLOYMENT_TEMPLATE_ID = AbsoluteId("KotlinTools_KotlinLibrariesDeployLocalBundleToCentral")
@@ -55,7 +53,7 @@ class KnownBuilds(private val project: Project) {
     val deployStart: BuildType get() = buildWithId(DEPLOY_ALL_ID)
     val deployVersion: BuildType get() = buildWithId(DEPLOY_CONFIGURE_VERSION_ID)
     val deployPublish: BuildType get() = buildWithId(DEPLOY_PUBLISH_ID)
-    val deployUpload: BuildType get() = buildWithId(DEPLOY_PUBLISH_ID)
+    val deployUpload: BuildType get() = buildWithId(DEPLOY_UPLOAD_ID)
     fun deployOn(platform: Platform): BuildType = buildWithId("Deploy_${platform.buildTypeId()}")
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,7 +9,7 @@ buildscript {
 }
 
 plugins {
-    id("kotlinx.team.infra") version "0.4.0-dev-88"
+    id("kotlinx.team.infra") version "0.4.0-dev-90"
     id("org.jetbrains.kotlinx.binary-compatibility-validator") version "0.17.0"
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,7 +9,7 @@ buildscript {
 }
 
 plugins {
-    id("kotlinx.team.infra") version "0.4.0-dev-87"
+    id("kotlinx.team.infra") version "0.4.0-dev-88"
     id("org.jetbrains.kotlinx.binary-compatibility-validator") version "0.17.0"
 }
 


### PR DESCRIPTION
- Resolved issue with unresolved `DeploymentId` parameter
- Published artifacts will be built on macOs agent only (a new feature for the latest infra plugin version)