### PR TITLE
Fix equals/hashCode contract violation in randomOperationsTests test data

### DIFF
--- a/core/commonTest/src/ObjectWrapper.kt
+++ b/core/commonTest/src/ObjectWrapper.kt
@@ -20,6 +20,11 @@ class ObjectWrapper<K: Comparable<K>>(
         if (other !is ObjectWrapper<*>) {
             return false
         }
+        val objEq = obj == other.obj
+        val hashEq = hashCode == other.hashCode
+        if (objEq && !hashEq) {
+            println("VIOLATION: this.obj=$obj other.obj=${other.obj} (objEq=$objEq) | this.hashCode=$hashCode other.hashCode=${other.hashCode} (hashEq=$hashEq)")
+        }
         assert(obj != other.obj || hashCode == other.hashCode)  // if elements are equal hashCodes must be equal
         return obj == other.obj
     }

--- a/core/commonTest/src/ObjectWrapper.kt
+++ b/core/commonTest/src/ObjectWrapper.kt
@@ -20,11 +20,6 @@ class ObjectWrapper<K: Comparable<K>>(
         if (other !is ObjectWrapper<*>) {
             return false
         }
-        val objEq = obj == other.obj
-        val hashEq = hashCode == other.hashCode
-        if (objEq && !hashEq) {
-            println("VIOLATION: this.obj=$obj other.obj=${other.obj} (objEq=$objEq) | this.hashCode=$hashCode other.hashCode=${other.hashCode} (hashEq=$hashEq)")
-        }
         assert(obj != other.obj || hashCode == other.hashCode)  // if elements are equal hashCodes must be equal
         return obj == other.obj
     }

--- a/core/commonTest/src/stress/map/PersistentHashMapBuilderTest.kt
+++ b/core/commonTest/src/stress/map/PersistentHashMapBuilderTest.kt
@@ -433,15 +433,14 @@ class PersistentHashMapBuilderTest : ExecutionTimeMeasuringTest() {
         val mapGen = mutableListOf(List(20) { persistentHashMapOf<IntWrapper, Int>() })
         val expected = mutableListOf(List(20) { mapOf<IntWrapper, Int>() })
 
+        val operationCount = NForAlgorithmComplexity.O_NlogN
+        val numberOfDistinctHashCodes = operationCount / 2  // less than `operationCount` to increase collision cases
+        val keyGen = WrapperGenerator<Int>(numberOfDistinctHashCodes)
+
         repeat(times = 5) {
 
             val builders = mapGen.last().map { it.builder() }
             val maps = builders.map { it.toMutableMap() }
-
-            val operationCount = NForAlgorithmComplexity.O_NlogN
-
-            val numberOfDistinctHashCodes = operationCount / 2  // less than `operationCount` to increase collision cases
-            val hashCodes = List(numberOfDistinctHashCodes) { Random.nextInt() }
 
             repeat(times = operationCount) {
                 val index = Random.nextInt(maps.size)
@@ -451,7 +450,7 @@ class PersistentHashMapBuilderTest : ExecutionTimeMeasuringTest() {
                 val shouldRemove = Random.nextDouble() < 0.3
                 val shouldOperateOnExistingKey = map.isNotEmpty() && Random.nextDouble().let { if (shouldRemove) it < 0.8 else it < 0.2 }
 
-                val key = if (shouldOperateOnExistingKey) map.keys.first() else IntWrapper(Random.nextInt(), hashCodes.random())
+                val key = if (shouldOperateOnExistingKey) map.keys.first() else keyGen.wrapper(Random.nextInt())
 
                 val shouldRemoveByKey = shouldRemove && Random.nextBoolean()
                 val shouldRemoveByKeyAndValue = shouldRemove && !shouldRemoveByKey

--- a/core/commonTest/src/stress/map/PersistentHashMapTest.kt
+++ b/core/commonTest/src/stress/map/PersistentHashMapTest.kt
@@ -289,7 +289,7 @@ class PersistentHashMapTest : ExecutionTimeMeasuringTest() {
             val operationCount = NForAlgorithmComplexity.O_NlogN
 
             val numberOfDistinctHashCodes = operationCount / 3  // less than `operationCount` to increase collision cases
-            val hashCodes = List(numberOfDistinctHashCodes) { Random.nextInt() }
+            val keyGen = WrapperGenerator<Int>(numberOfDistinctHashCodes)
 
             repeat(times = operationCount) {
                 val index = Random.nextInt(mutableMaps.size)
@@ -302,7 +302,7 @@ class PersistentHashMapTest : ExecutionTimeMeasuringTest() {
                 val key = when {
                     shouldOperateOnExistingKey -> mutableMap.keys.first()
                     Random.nextDouble() < 0.001 -> null
-                    else -> IntWrapper(Random.nextInt(), hashCodes.random())
+                    else -> keyGen.wrapper(Random.nextInt())
                 }
 
                 val shouldRemoveByKey = shouldRemove && Random.nextBoolean()

--- a/core/commonTest/src/stress/set/PersistentHashSetBuilderTest.kt
+++ b/core/commonTest/src/stress/set/PersistentHashSetBuilderTest.kt
@@ -274,15 +274,14 @@ class PersistentHashSetBuilderTest : ExecutionTimeMeasuringTest() {
         val setGen = mutableListOf(List(20) { persistentHashSetOf<IntWrapper>() })
         val expected = mutableListOf(List(20) { setOf<IntWrapper>() })
 
+        val operationCount = NForAlgorithmComplexity.O_NlogN
+        val numberOfDistinctHashCodes = operationCount / 2  // less than `operationCount` to increase collision cases
+        val eGen = WrapperGenerator<Int>(numberOfDistinctHashCodes)
+
         repeat(times = 5) {
 
             val builders = setGen.last().map { it.builder() }
             val sets = builders.map { it.toMutableSet() }
-
-            val operationCount = NForAlgorithmComplexity.O_NlogN
-
-            val numberOfDistinctHashCodes = operationCount / 2  // less than `operationCount` to increase collision cases
-            val hashCodes = List(numberOfDistinctHashCodes) { random.nextInt() }
 
             repeat(times = operationCount) {
                 val index = random.nextInt(sets.size)
@@ -292,7 +291,7 @@ class PersistentHashSetBuilderTest : ExecutionTimeMeasuringTest() {
                 val shouldRemove = random.nextDouble() < 0.3
                 val shouldOperateOnExistingElement = set.isNotEmpty() && random.nextDouble().let { if (shouldRemove) it < 0.8 else it < 0.001 }
 
-                val element = if (shouldOperateOnExistingElement) set.first() else IntWrapper(random.nextInt(), hashCodes.random(random))
+                val element = if (shouldOperateOnExistingElement) set.first() else eGen.wrapper(random.nextInt())
 
                 when {
                     shouldRemove -> {

--- a/core/commonTest/src/stress/set/PersistentHashSetBuilderTest.kt
+++ b/core/commonTest/src/stress/set/PersistentHashSetBuilderTest.kt
@@ -260,6 +260,17 @@ class PersistentHashSetBuilderTest : ExecutionTimeMeasuringTest() {
 
     @Test
     fun randomOperationsTests() {
+        randomOperations(Random.Default)
+    }
+
+    // Deterministic reproducer for the wasmJs failure seen in the K2 user-projects build.
+    // See https://github.com/Kotlin/kotlinx.collections.immutable/issues/261
+    @Test
+    fun randomOperationsWithFixedSeedTests() {
+        randomOperations(Random(21303))
+    }
+
+    private fun randomOperations(random: Random) {
         val setGen = mutableListOf(List(20) { persistentHashSetOf<IntWrapper>() })
         val expected = mutableListOf(List(20) { setOf<IntWrapper>() })
 
@@ -271,17 +282,17 @@ class PersistentHashSetBuilderTest : ExecutionTimeMeasuringTest() {
             val operationCount = NForAlgorithmComplexity.O_NlogN
 
             val numberOfDistinctHashCodes = operationCount / 2  // less than `operationCount` to increase collision cases
-            val hashCodes = List(numberOfDistinctHashCodes) { Random.nextInt() }
+            val hashCodes = List(numberOfDistinctHashCodes) { random.nextInt() }
 
             repeat(times = operationCount) {
-                val index = Random.nextInt(sets.size)
+                val index = random.nextInt(sets.size)
                 val set = sets[index]
                 val builder = builders[index]
 
-                val shouldRemove = Random.nextDouble() < 0.3
-                val shouldOperateOnExistingElement = set.isNotEmpty() && Random.nextDouble().let { if (shouldRemove) it < 0.8 else it < 0.001 }
+                val shouldRemove = random.nextDouble() < 0.3
+                val shouldOperateOnExistingElement = set.isNotEmpty() && random.nextDouble().let { if (shouldRemove) it < 0.8 else it < 0.001 }
 
-                val element = if (shouldOperateOnExistingElement) set.first() else IntWrapper(Random.nextInt(), hashCodes.random())
+                val element = if (shouldOperateOnExistingElement) set.first() else IntWrapper(random.nextInt(), hashCodes.random(random))
 
                 when {
                     shouldRemove -> {

--- a/core/commonTest/src/stress/set/PersistentHashSetTest.kt
+++ b/core/commonTest/src/stress/set/PersistentHashSetTest.kt
@@ -237,7 +237,7 @@ class PersistentHashSetTest : ExecutionTimeMeasuringTest() {
             val operationCount = NForAlgorithmComplexity.O_NlogN
 
             val numberOfDistinctHashCodes = operationCount / 3  // less than `operationCount` to increase collision cases
-            val hashCodes = List(numberOfDistinctHashCodes) { Random.nextInt() }
+            val eGen = WrapperGenerator<Int>(numberOfDistinctHashCodes)
 
             repeat(times = operationCount) {
                 val index = Random.nextInt(mutableSets.size)
@@ -250,7 +250,7 @@ class PersistentHashSetTest : ExecutionTimeMeasuringTest() {
                 val element = when {
                     shouldOperateOnExistingElement -> mutableSet.first()
                     Random.nextDouble() < 0.001 -> null
-                    else -> IntWrapper(Random.nextInt(), hashCodes.random())
+                    else -> eGen.wrapper(Random.nextInt())
                 }
 
                 val newImmutableSet = when {


### PR DESCRIPTION
`randomOperationsTests` wraps values into `ObjectWrapper(value, hashCode)` with a randomly chosen hash code, so the same value can get different hash codes on different draws, violating the equals/hashCode contract. It only surfaces when such a pair collides in the same hash bucket — rare and data-dependent: reproduces with seed `21303`, independent of the Kotlin version and the platform.

Switch the affected random-operations tests (`PersistentHashSetBuilderTest`, `PersistentHashSetTest`, `PersistentHashMapTest`, `PersistentHashMapBuilderTest`) to a shared `WrapperGenerator`, which always maps a given value to the same hash code while still allowing collisions between distinct values.

Fixes #261.
