### PR TITLE
Update version to 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.5.0
 
-- Introduced the [kotlinx.collections.immutable 0.5.x migration skill](https://github.com/Kotlin/kotlin-agent-skills/blob/main/skills/kotlin-tooling-immutable-collections-0-5-x-migration/SKILL.md) — an agent skill that drives the participial-naming migration from the compiler's deprecation warnings
+- Promoted `0.5.0-beta01` to stable; no API or behavior changes
 
 ## 0.5.0-beta01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 0.5.0
+
+- Introduced the [kotlinx.collections.immutable 0.5.x migration skill](https://github.com/Kotlin/kotlin-agent-skills/blob/main/skills/kotlin-tooling-immutable-collections-0-5-x-migration/SKILL.md) — an agent skill that drives the participial-naming migration from the compiler's deprecation warnings
+
 ## 0.5.0-beta01
 
 - Renamed `PersistentCollection` mutating-copy methods to participial forms (`add`/`remove`/`set`/`put`/`clear` → `adding`/`removing`/`setting`/`putting`/`clearing` and `*ed` variants) and deprecated the original names [#233](https://github.com/Kotlin/kotlinx.collections.immutable/pull/233)

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ kotlin {
     sourceSets {
         commonMain {
              dependencies {
-                 implementation("org.jetbrains.kotlinx:kotlinx-collections-immutable:0.5.0-beta01")
+                 implementation("org.jetbrains.kotlinx:kotlinx-collections-immutable:0.5.0")
              }
         }
     }
@@ -156,7 +156,7 @@ Add dependencies (you can also add other modules that you need):
 <dependency>
     <groupId>org.jetbrains.kotlinx</groupId>
     <artifactId>kotlinx-collections-immutable-jvm</artifactId>
-    <version>0.5.0-beta01</version>
+    <version>0.5.0</version>
 </dependency>
 ```
 

--- a/docs/0.5.0-MIGRATION.md
+++ b/docs/0.5.0-MIGRATION.md
@@ -96,7 +96,9 @@ upgrade.
 - **Use the migration agent skill.** With an AI coding assistant, the
   [kotlinx.collections.immutable 0.5.x migration skill](https://github.com/Kotlin/kotlin-agent-skills/blob/main/skills/kotlin-tooling-immutable-collections-0-5-x-migration/SKILL.md)
   drives the whole upgrade from the compiler: it bumps the version, recompiles,
-  and applies the replacement that each deprecation warning names.
+  and applies the replacement that each deprecation warning names. Refer to
+  [kotlin-agent-skills](https://github.com/Kotlin/kotlin-agent-skills/blob/main/README.md)
+  for details on how to apply the skill to your project.
 - **No behavior changes.** The new methods are exact renames — same semantics,
   same return types, same complexity. No call-site logic needs to be adjusted.
 

--- a/docs/0.5.0-MIGRATION.md
+++ b/docs/0.5.0-MIGRATION.md
@@ -93,6 +93,10 @@ upgrade.
   place the caret on the warning and choose *Replace with …*, or run
   *Code → Inspect Code → Deprecated API usages* to apply replacements across
   the whole module.
+- **Use the migration agent skill.** With an AI coding assistant, the
+  [kotlinx.collections.immutable 0.5.x migration skill](https://github.com/Kotlin/kotlin-agent-skills/blob/main/skills/kotlin-tooling-immutable-collections-0-5-x-migration/SKILL.md)
+  drives the whole upgrade from the compiler: it bumps the version, recompiles,
+  and applies the replacement that each deprecation warning names.
 - **No behavior changes.** The new methods are exact renames — same semantics,
   same return types, same complexity. No call-site logic needs to be adjusted.
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=org.jetbrains.kotlinx
-version=0.5.0-beta01
+version=0.5.0
 versionSuffix=SNAPSHOT
 
 kotlin_version=2.3.0


### PR DESCRIPTION
Promotes the 0.5.x line from beta to stable release.

Also introduces the [kotlinx.collections.immutable 0.5.x migration skill](https://github.com/Kotlin/kotlin-agent-skills/blob/main/skills/kotlin-tooling-immutable-collections-0-5-x-migration/SKILL.md), an agent skill that automates the [KEEP-0459](https://github.com/Kotlin/KEEP/blob/main/proposals/KEEP-0459-naming-conventions-for-copy-returning-operations.md) renames by driving the compiler's deprecation warnings. It's linked from the "How to migrate" section of the migration guide and recorded under a new 0.5.0 CHANGELOG entry.
