### PR TITLE
Build pull requests from forks on CI

### DIFF
--- a/.teamcity/additionalConfiguration.kt
+++ b/.teamcity/additionalConfiguration.kt
@@ -1,10 +1,14 @@
 /*
- * Copyright 2016-2020 JetBrains s.r.o.
+ * Copyright 2016-2026 JetBrains s.r.o.
  * Use of this source code is governed by the Apache 2.0 License that can be found in the LICENSE.txt file.
  */
 
 import jetbrains.buildServer.configs.kotlin.*
+import jetbrains.buildServer.configs.kotlin.buildFeatures.PullRequests
 import jetbrains.buildServer.configs.kotlin.buildFeatures.commitStatusPublisher
+import jetbrains.buildServer.configs.kotlin.buildFeatures.pullRequests
+
+const val githubTokenId = "tc_token_id:CID_7db3007c46f7e30124f81ef54591b223:-1:f604c3ec-6391-4e29-a6e4-e59397b4622d"
 
 fun Project.additionalConfiguration() {
     subProject(benchmarksProject(knownBuilds.buildVersion))
@@ -15,8 +19,17 @@ fun Project.additionalConfiguration() {
             publisher = github {
                 githubUrl = "https://api.github.com"
                 authType = storedToken {
-                    tokenId = "tc_token_id:CID_7db3007c46f7e30124f81ef54591b223:-1:f604c3ec-6391-4e29-a6e4-e59397b4622d"
+                    tokenId = githubTokenId
                 }
+            }
+        }
+        pullRequests {
+            vcsRootExtId = "${DslContext.settingsRoot.id}"
+            provider = github {
+                authType = storedToken {
+                    tokenId = githubTokenId
+                }
+                filterAuthorRole = PullRequests.GitHubRoleFilter.EVERYBODY
             }
         }
     }


### PR DESCRIPTION
Adds the Pull Requests build feature to `Build (All)`, reusing the commit-status publisher's GitHub token and the build's existing VCS trigger. `filterAuthorRole` is `EVERYBODY`, so PRs from any fork build automatically; these builds only run `clean publishToBuildLocal check`, so no deployment secrets are exposed to them.

Fixes #265