### PR TITLE
Surface pull request branches on CI for manually started builds

### DIFF
--- a/.teamcity/additionalConfiguration.kt
+++ b/.teamcity/additionalConfiguration.kt
@@ -1,10 +1,14 @@
 /*
- * Copyright 2016-2020 JetBrains s.r.o.
+ * Copyright 2016-2026 JetBrains s.r.o.
  * Use of this source code is governed by the Apache 2.0 License that can be found in the LICENSE.txt file.
  */
 
 import jetbrains.buildServer.configs.kotlin.*
+import jetbrains.buildServer.configs.kotlin.buildFeatures.PullRequests
 import jetbrains.buildServer.configs.kotlin.buildFeatures.commitStatusPublisher
+import jetbrains.buildServer.configs.kotlin.buildFeatures.pullRequests
+
+const val githubTokenId = "tc_token_id:CID_7db3007c46f7e30124f81ef54591b223:-1:f604c3ec-6391-4e29-a6e4-e59397b4622d"
 
 fun Project.additionalConfiguration() {
     subProject(benchmarksProject(knownBuilds.buildVersion))
@@ -15,8 +19,17 @@ fun Project.additionalConfiguration() {
             publisher = github {
                 githubUrl = "https://api.github.com"
                 authType = storedToken {
-                    tokenId = "tc_token_id:CID_7db3007c46f7e30124f81ef54591b223:-1:f604c3ec-6391-4e29-a6e4-e59397b4622d"
+                    tokenId = githubTokenId
                 }
+            }
+        }
+        pullRequests {
+            vcsRootExtId = "${DslContext.settingsRoot.id}"
+            provider = github {
+                authType = storedToken {
+                    tokenId = githubTokenId
+                }
+                filterAuthorRole = PullRequests.GitHubRoleFilter.EVERYBODY
             }
         }
     }

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -127,6 +127,10 @@ fun Project.buildAll(versionBuild: BuildType) = BuildType {
                     -:*.md
                     -:.gitignore
                 """.trimIndent()
+            branchFilter = """
+                    +:*
+                    -:refs/pull/*
+                """.trimIndent()
         }
     }
 


### PR DESCRIPTION
Adds the Pull Requests build feature to `Build (All)` so PR branches, fork ones included, become visible on TeamCity, and excludes `refs/pull/*` from the VCS trigger. As in other kotlinx libraries, a build for a fork PR is started manually from TeamCity and the existing commit-status publisher posts the result back to the PR, so no untrusted code runs on the agents automatically. Branches pushed to this repository keep triggering builds as before.

Fixes #265