### PR TITLE
Restore the direct links write in the ordered map builder entry

### DIFF
--- a/core/commonMain/src/implementations/persistentOrderedMap/PersistentOrderedMapBuilder.kt
+++ b/core/commonMain/src/implementations/persistentOrderedMap/PersistentOrderedMapBuilder.kt
@@ -86,7 +86,7 @@ internal class PersistentOrderedMapBuilder<K, V>(map: PersistentOrderedMap<K, V>
         }
     }
 
-    internal fun updateLinks(key: K, links: LinkedValue<V>) {
+    internal fun setLinkedValue(key: K, links: LinkedValue<V>) {
         builtMap = null
         hashMapBuilder[key] = links
     }

--- a/core/commonMain/src/implementations/persistentOrderedMap/PersistentOrderedMapBuilder.kt
+++ b/core/commonMain/src/implementations/persistentOrderedMap/PersistentOrderedMapBuilder.kt
@@ -86,6 +86,11 @@ internal class PersistentOrderedMapBuilder<K, V>(map: PersistentOrderedMap<K, V>
         }
     }
 
+    internal fun updateLinks(key: K, links: LinkedValue<V>) {
+        builtMap = null
+        hashMapBuilder[key] = links
+    }
+
     override fun remove(key: K): V? {
         val links = hashMapBuilder.remove(key) ?: return null
         builtMap = null

--- a/core/commonMain/src/implementations/persistentOrderedMap/PersistentOrderedMapBuilderContentIterators.kt
+++ b/core/commonMain/src/implementations/persistentOrderedMap/PersistentOrderedMapBuilderContentIterators.kt
@@ -83,13 +83,19 @@ internal class PersistentOrderedMapBuilderEntriesIterator<K, V>(map: PersistentO
 private class MutableMapEntry<K, V>(private val builder: PersistentOrderedMapBuilder<K, V>,
                                     key: K,
                                     private var links: LinkedValue<V>) : MapEntry<K, V>(key, links.value), MutableMap.MutableEntry<K, V> {
+    private val expectedModCount = builder.hashMapBuilder.modCount
+
     override val value: V
         get() = links.value
 
     override fun setValue(newValue: V): V {
         val result = links.value
         links = links.withValue(newValue)
-        builder[key] = newValue
+        if (builder.hashMapBuilder.modCount == expectedModCount) {
+            builder.updateLinks(key, links)
+        } else {
+            builder[key] = newValue
+        }
         return result
     }
 }

--- a/core/commonMain/src/implementations/persistentOrderedMap/PersistentOrderedMapBuilderContentIterators.kt
+++ b/core/commonMain/src/implementations/persistentOrderedMap/PersistentOrderedMapBuilderContentIterators.kt
@@ -92,7 +92,7 @@ private class MutableMapEntry<K, V>(private val builder: PersistentOrderedMapBui
         val result = links.value
         links = links.withValue(newValue)
         if (builder.hashMapBuilder.modCount == expectedModCount) {
-            builder.updateLinks(key, links)
+            builder.setLinkedValue(key, links)
         } else {
             builder[key] = newValue
         }

--- a/core/commonTest/src/contract/map/PersistentOrderedMapTest.kt
+++ b/core/commonTest/src/contract/map/PersistentOrderedMapTest.kt
@@ -22,6 +22,33 @@ class PersistentOrderedMapTest {
         assertEquals(persistentMapOf("a" to 2), builder.build())
     }
 
+    @Test
+    fun `builder entry setValue preserves entry order`() {
+        val builder = persistentMapOf("a" to 1, "b" to 2, "c" to 3).builder()
+        val iterator = builder.entries.iterator()
+        assertEquals("a", iterator.next().key)
+        val entry = iterator.next()
+        assertEquals(2, entry.setValue(20))
+
+        assertEquals(20, entry.value)
+        assertEquals(listOf("a", "b", "c"), builder.build().keys.toList())
+        assertEquals(20, builder["b"])
+    }
+
+    @Test
+    fun `builder entry setValue after a structural change updates the current links`() {
+        val builder = persistentMapOf("a" to 1, "b" to 2, "c" to 3).builder()
+        val entry = builder.entries.iterator().next()
+        assertEquals(2, builder.remove("b"))
+        assertEquals(persistentMapOf("a" to 1, "c" to 3), builder.build())
+
+        assertEquals(1, entry.setValue(10))
+
+        val built = builder.build()
+        assertEquals(persistentMapOf("a" to 10, "c" to 3), built)
+        assertEquals(listOf("a", "c"), built.keys.toList())
+    }
+
     /**
      * Test from issue: https://github.com/Kotlin/kotlinx.collections.immutable/issues/198
      */


### PR DESCRIPTION
Routing entry value updates through the builder's put fixed the stale build() result but made setValue look up the links the entry already caches. Now the entry writes them back directly while the hash builder's mod count is unchanged since the entry was created, and falls back to put otherwise. This is safe because chain pointers change only together with the map size and every size change bumps the mod count.

Follow-up to #253.
