### PR TITLE
Fix the pull request exclusion in the VCS trigger branch filter

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -129,6 +129,7 @@ fun Project.buildAll(versionBuild: BuildType) = BuildType {
                 """.trimIndent()
             branchFilter = """
                     +:*
+                    -:pull/*
                     -:refs/pull/*
                 """.trimIndent()
         }


### PR DESCRIPTION
The live check with a fork PR (#275) showed that the filter added in #273 does not work: the branches surfaced by the Pull Requests feature get logical names like `pull/275`, so `-:refs/pull/*` does not match them and the VCS trigger auto-started a build (id 6278933, `triggered: vcs`). This matches how kotlinx.serialization filters its PR branches (`-:pull/*`). The fully qualified form is kept as a guard since TeamCity docs reference it for other setups.

Fixes the follow-up to #265.