### PR TITLE
Update version to 0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## 0.5.1
+
+- Fixed `PersistentOrderedMapBuilder` returning a previously built map from `build()` after updating an entry value through `MutableMap.MutableEntry.setValue` [#253](https://github.com/Kotlin/kotlinx.collections.immutable/pull/253), [#274](https://github.com/Kotlin/kotlinx.collections.immutable/pull/274)
+- Fixed an assertion failure in `PersistentOrderedSetBuilder.build()` after interleaved `build` and `remove`/`removeAll` calls [#251](https://github.com/Kotlin/kotlinx.collections.immutable/pull/251)
+- Provided a JPMS module descriptor for the JVM artifact — module `kotlinx.collections.immutable` compiled into `META-INF/versions/9`, the artifact stays Java 8-compatible [#268](https://github.com/Kotlin/kotlinx.collections.immutable/pull/268)
+
 ## 0.5.0
 
 - Promoted `0.5.0-beta01` to stable; no API or behavior changes

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ kotlin {
     sourceSets {
         commonMain {
              dependencies {
-                 implementation("org.jetbrains.kotlinx:kotlinx-collections-immutable:0.5.0")
+                 implementation("org.jetbrains.kotlinx:kotlinx-collections-immutable:0.5.1")
              }
         }
     }
@@ -156,7 +156,7 @@ Add dependencies (you can also add other modules that you need):
 <dependency>
     <groupId>org.jetbrains.kotlinx</groupId>
     <artifactId>kotlinx-collections-immutable-jvm</artifactId>
-    <version>0.5.0</version>
+    <version>0.5.1</version>
 </dependency>
 ```
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=org.jetbrains.kotlinx
-version=0.5.0
+version=0.5.1
 versionSuffix=SNAPSHOT
 
 kotlin_version=2.3.0


### PR DESCRIPTION
Prepares the 0.5.1 patch release: two ordered-builder caching fixes (#251, #253 with follow-up #274) and the JPMS module descriptor for the JVM artifact (#268).