### PR TITLE
Cover persistent list implementation gaps with tests

### DIFF
--- a/core/commonTest/src/contract/list/PersistentListBuilderInsertionTest.kt
+++ b/core/commonTest/src/contract/list/PersistentListBuilderInsertionTest.kt
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2016-2026 JetBrains s.r.o.
+ * Use of this source code is governed by the Apache 2.0 License that can be found in the LICENSE.txt file.
+ */
+
+package tests.contract.list
+
+import kotlinx.collections.immutable.PersistentList
+import kotlinx.collections.immutable.implementations.immutableList.MAX_BUFFER_SIZE
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.toPersistentList
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class PersistentListBuilderInsertionTest {
+
+    init {
+        check(MAX_BUFFER_SIZE == 32) { "Test sizes assume a trie buffer size of 32" }
+    }
+
+    private fun ownedBuilderOf(size: Int): PersistentList.Builder<Int> {
+        val builder = persistentListOf<Int>().builder()
+        for (element in 0..<size) {
+            assertTrue(builder.add(element))
+        }
+        return builder
+    }
+
+    private fun assertBuilderContents(expected: List<Int>, builder: PersistentList.Builder<Int>) {
+        assertEquals(expected.size, builder.size)
+        assertEquals(expected, builder)
+        for (index in expected.indices) {
+            assertEquals(expected[index], builder[index], "element at index $index")
+        }
+        assertEquals(expected, builder.build())
+    }
+
+    @Test
+    fun `add grows the builder through root creation and root pushes and trie height increases`() {
+        val expected = List(1100) { it }
+        val checkpoints = setOf(33, 64, 65, 97, 1056, 1057, 1089)
+
+        val builder = persistentListOf<Int>().builder()
+        for (element in 0..<1100) {
+            assertTrue(builder.add(element))
+            assertEquals(element + 1, builder.size)
+            if (builder.size in checkpoints) {
+                assertEquals(expected.subList(0, builder.size), builder)
+            }
+        }
+
+        assertBuilderContents(expected, builder)
+    }
+
+    @Test
+    fun `add at an index in a full tail pushes the filled tail into the root as a leaf`() {
+        val builder = ownedBuilderOf(64)
+        val reference = (0..<64).toMutableList()
+
+        builder.add(40, -1)
+        reference.add(40, -1)
+
+        assertBuilderContents(reference, builder)
+    }
+
+    @Test
+    fun `add at an index in the root carries overflowing elements through the leaves into the tail`() {
+        val builder = ownedBuilderOf(100)
+        val reference = (0..<100).toMutableList()
+
+        builder.add(0, -1)
+        reference.add(0, -1)
+
+        builder.add(40, -2)
+        reference.add(40, -2)
+
+        assertBuilderContents(reference, builder)
+    }
+
+    @Test
+    fun `addAll at an index in the tail region splits elements into new leaf buffers and promotes the full root`() {
+        val builder = ownedBuilderOf(40)
+        val reference = (0..<40).toMutableList()
+        val elements = List(70) { 100 + it }
+
+        assertTrue(builder.addAll(35, elements))
+        assertTrue(reference.addAll(35, elements))
+
+        assertBuilderContents(reference, builder)
+    }
+
+    @Test
+    fun `addAll at an index in the single-leaf root of an owned builder shifts its tail in place`() {
+        val builder = ownedBuilderOf(40)
+        val reference = (0..<40).toMutableList()
+        val elements = List(10) { 100 + it }
+
+        assertTrue(builder.addAll(5, elements))
+        assertTrue(reference.addAll(5, elements))
+
+        assertBuilderContents(reference, builder)
+    }
+
+    @Test
+    fun `addAll at an index in the first of two frozen root leaves shifts the following leaf into new buffers`() {
+        val vector = (0..<70).toPersistentList()
+        val builder = vector.builder()
+        val reference = (0..<70).toMutableList()
+        val elements = List(10) { 100 + it }
+
+        assertTrue(builder.addAll(10, elements))
+        assertTrue(reference.addAll(10, elements))
+
+        assertBuilderContents(reference, builder)
+
+        assertEquals((0..<70).toList(), vector)
+    }
+
+    @Test
+    fun `addAll at an index in the last root leaf overflows into an extra fresh buffer`() {
+        val builder = ownedBuilderOf(70)
+        val reference = (0..<70).toMutableList()
+        val elements = List(40) { 100 + it }
+
+        assertTrue(builder.addAll(40, elements))
+        assertTrue(reference.addAll(40, elements))
+
+        assertBuilderContents(reference, builder)
+    }
+
+    @Test
+    fun `addAll at an index preserving the tail size shifts whole leaves to the right`() {
+        val builder = ownedBuilderOf(70)
+        val reference = (0..<70).toMutableList()
+        val elements = List(32) { 100 + it }
+
+        assertTrue(builder.addAll(10, elements))
+        assertTrue(reference.addAll(10, elements))
+
+        assertBuilderContents(reference, builder)
+    }
+}

--- a/core/commonTest/src/contract/list/PersistentListBuilderInsertionTest.kt
+++ b/core/commonTest/src/contract/list/PersistentListBuilderInsertionTest.kt
@@ -6,7 +6,6 @@
 package tests.contract.list
 
 import kotlinx.collections.immutable.PersistentList
-import kotlinx.collections.immutable.implementations.immutableList.MAX_BUFFER_SIZE
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toPersistentList
 import kotlin.test.Test
@@ -16,13 +15,7 @@ import kotlin.test.assertTrue
 class PersistentListBuilderInsertionTest {
 
     init {
-        check(MAX_BUFFER_SIZE == 32) {
-            """
-            The sizes in this class are hand-picked trie shape boundaries for the buffer size of 32.
-            If MAX_BUFFER_SIZE changes, revisit each size manually
-            and verify that all branches of the code under test are still covered.
-            """.trimIndent()
-        }
+        checkTrieShapeAssumptions()
     }
 
     private fun ownedBuilderOf(size: Int): PersistentList.Builder<Int> {

--- a/core/commonTest/src/contract/list/PersistentListBuilderInsertionTest.kt
+++ b/core/commonTest/src/contract/list/PersistentListBuilderInsertionTest.kt
@@ -16,7 +16,13 @@ import kotlin.test.assertTrue
 class PersistentListBuilderInsertionTest {
 
     init {
-        check(MAX_BUFFER_SIZE == 32) { "Test sizes assume a trie buffer size of 32" }
+        check(MAX_BUFFER_SIZE == 32) {
+            """
+            The sizes in this class are hand-picked trie shape boundaries for the buffer size of 32.
+            If MAX_BUFFER_SIZE changes, revisit each size manually
+            and verify that all branches of the code under test are still covered.
+            """.trimIndent()
+        }
     }
 
     private fun ownedBuilderOf(size: Int): PersistentList.Builder<Int> {

--- a/core/commonTest/src/contract/list/PersistentListBuilderInsertionTest.kt
+++ b/core/commonTest/src/contract/list/PersistentListBuilderInsertionTest.kt
@@ -9,6 +9,7 @@ import kotlinx.collections.immutable.PersistentList
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toPersistentList
 import kotlin.test.Test
+import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
@@ -18,20 +19,8 @@ class PersistentListBuilderInsertionTest {
         checkTrieShapeAssumptions()
     }
 
-    private fun ownedBuilderOf(size: Int): PersistentList.Builder<Int> {
-        val builder = persistentListOf<Int>().builder()
-        for (element in 0..<size) {
-            assertTrue(builder.add(element))
-        }
-        return builder
-    }
-
     private fun assertBuilderContents(expected: List<Int>, builder: PersistentList.Builder<Int>) {
-        assertEquals(expected.size, builder.size)
-        assertEquals(expected, builder)
-        for (index in expected.indices) {
-            assertEquals(expected[index], builder[index], "element at index $index")
-        }
+        assertContentEquals(expected, builder)
         assertEquals(expected, builder.build())
     }
 

--- a/core/commonTest/src/contract/list/PersistentListBuilderRemovalTest.kt
+++ b/core/commonTest/src/contract/list/PersistentListBuilderRemovalTest.kt
@@ -6,7 +6,6 @@
 package tests.contract.list
 
 import kotlinx.collections.immutable.PersistentList
-import kotlinx.collections.immutable.implementations.immutableList.MAX_BUFFER_SIZE
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toPersistentList
 import kotlin.test.Test
@@ -18,13 +17,7 @@ import kotlin.test.assertTrue
 class PersistentListBuilderRemovalTest {
 
     init {
-        check(MAX_BUFFER_SIZE == 32) {
-            """
-            The sizes in this class are hand-picked trie shape boundaries for the buffer size of 32.
-            If MAX_BUFFER_SIZE changes, revisit each size manually
-            and verify that all branches of the code under test are still covered.
-            """.trimIndent()
-        }
+        checkTrieShapeAssumptions()
     }
 
     private fun ownedBuilderOf(range: IntRange): PersistentList.Builder<Int> {

--- a/core/commonTest/src/contract/list/PersistentListBuilderRemovalTest.kt
+++ b/core/commonTest/src/contract/list/PersistentListBuilderRemovalTest.kt
@@ -1,0 +1,211 @@
+/*
+ * Copyright 2016-2026 JetBrains s.r.o.
+ * Use of this source code is governed by the Apache 2.0 License that can be found in the LICENSE.txt file.
+ */
+
+package tests.contract.list
+
+import kotlinx.collections.immutable.PersistentList
+import kotlinx.collections.immutable.implementations.immutableList.MAX_BUFFER_SIZE
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.toPersistentList
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class PersistentListBuilderRemovalTest {
+
+    init {
+        check(MAX_BUFFER_SIZE == 32) { "Test sizes assume a trie buffer size of 32" }
+    }
+
+    private fun ownedBuilderOf(range: IntRange): PersistentList.Builder<Int> {
+        val builder = persistentListOf<Int>().builder()
+        for (element in range) {
+            assertTrue(builder.add(element))
+        }
+        return builder
+    }
+
+    @Test
+    fun `get descends the root trie for indices before the tail`() {
+        val builder = ownedBuilderOf(0..1090)
+        for (index in 0..1090) {
+            assertEquals(index, builder[index])
+        }
+        assertFailsWith<IndexOutOfBoundsException> { builder[1091] }
+        assertFailsWith<IndexOutOfBoundsException> { builder[-1] }
+    }
+
+    @Test
+    fun `set at an index in the root of an owned builder replaces in place without invalidating iterators`() {
+        val builder = ownedBuilderOf(0..99)
+        val iterator = builder.listIterator()
+
+        assertEquals(0, builder.set(0, -1))
+        assertEquals(40, builder.set(40, -2))
+        assertEquals(63, builder.set(63, -3))
+        assertEquals(95, builder.set(95, -4))
+
+        assertEquals(-1, iterator.next())
+        assertEquals(1, iterator.next())
+
+        val expected = (0..99).toMutableList()
+        expected[0] = -1
+        expected[40] = -2
+        expected[63] = -3
+        expected[95] = -4
+        assertEquals<List<Int>>(expected, builder)
+        assertEquals<List<Int>>(expected, builder.build())
+    }
+
+    @Test
+    fun `set at an index in the root of a vector-backed builder copies the frozen leaf and invalidates iterators`() {
+        val vector = (0..99).toPersistentList()
+        val builder = vector.builder()
+        val iterator = builder.listIterator()
+
+        assertEquals(10, builder.set(10, -10))
+        assertFailsWith<ConcurrentModificationException> { iterator.next() }
+
+        val freshIterator = builder.listIterator()
+        assertEquals(11, builder.set(11, -11))
+        for (index in 0..9) {
+            assertEquals(index, freshIterator.next())
+        }
+        assertEquals(-10, freshIterator.next())
+        assertEquals(-11, freshIterator.next())
+
+        val expected = (0..99).toMutableList()
+        expected[10] = -10
+        expected[11] = -11
+        assertEquals<List<Int>>(expected, builder)
+        assertEquals<List<Int>>(expected, builder.build())
+
+        assertEquals(100, vector.size)
+        assertEquals(10, vector[10])
+        assertEquals(11, vector[11])
+    }
+
+    @Test
+    fun `removeAt an index in the root shifts elements across leaves like a mutable list`() {
+        val builder = ownedBuilderOf(0..99)
+        val reference = (0..99).toMutableList()
+
+        assertEquals(reference.removeAt(0), builder.removeAt(0))
+        assertEquals(reference.removeAt(40), builder.removeAt(40))
+
+        assertEquals(reference.size, builder.size)
+        assertEquals<List<Int>>(reference, builder)
+        assertEquals<List<Int>>(reference, builder.build())
+    }
+
+    @Test
+    fun `removeAt zero on a two-level trie rotates the tail element through all leaves and pulls the emptied tail`() {
+        val builder = ownedBuilderOf(0..1056)
+
+        assertEquals(0, builder.removeAt(0))
+
+        assertEquals(1056, builder.size)
+        assertEquals(1, builder[0])
+        assertEquals(1056, builder[1055])
+        assertEquals((1..1056).toList(), builder)
+        assertEquals((1..1056).toList(), builder.build())
+    }
+
+    @Test
+    fun `removing elements from the end pulls leaf buffers back from the trie until the root disappears`() {
+        val builder = ownedBuilderOf(0..1056)
+
+        for (element in 1056 downTo 25) {
+            assertEquals(element, builder.removeAt(builder.size - 1))
+            if (builder.size == 1000) {
+                assertEquals((0..999).toList(), builder)
+            }
+        }
+
+        assertEquals(25, builder.size)
+        assertEquals((0..24).toList(), builder)
+        assertEquals((0..24).toList(), builder.build())
+    }
+
+    @Test
+    fun `removeAll matching only tail elements pulls the last leaf when the tail empties`() {
+        val builder = ownedBuilderOf(0..99)
+
+        assertFalse(builder.removeAll(listOf(200, 300)))
+        assertEquals((0..99).toList(), builder)
+
+        assertTrue(builder.removeAll(listOf(97, 99)))
+        assertEquals((0..96).toList() + 98, builder)
+
+        assertTrue(builder.removeAll(listOf(96, 98)))
+        assertEquals(96, builder.size)
+        assertEquals((0..95).toList(), builder)
+
+        assertTrue(builder.add(96))
+        assertEquals((0..96).toList(), builder)
+        assertEquals((0..96).toList(), builder.build())
+    }
+
+    @Test
+    fun `removeAll spanning several owned leaves recycles buffers and trims stale root entries`() {
+        val builder = ownedBuilderOf(0..135)
+
+        assertTrue(builder.removeAll((33..100).toList()))
+
+        val expected = (0..32).toList() + (101..135).toList()
+        assertEquals(68, builder.size)
+        assertEquals(expected, builder)
+        assertEquals(expected, builder.build())
+
+        assertTrue(builder.add(999))
+        assertEquals(expected + 999, builder)
+    }
+
+    @Test
+    fun `removeAll trimming a two-level trie nullifies the dropped child on every level`() {
+        val ownedBuilder = ownedBuilderOf(0..2145)
+        assertTrue(ownedBuilder.removeAll((1057..2145).toList()))
+        assertEquals(1057, ownedBuilder.size)
+        assertEquals((0..1056).toList(), ownedBuilder)
+        assertTrue(ownedBuilder.add(1057))
+        assertEquals(1057, ownedBuilder[1057])
+        assertEquals((0..1057).toList(), ownedBuilder.build())
+
+        val vector = (0..2145).toPersistentList()
+        val vectorBackedBuilder = vector.builder()
+        assertTrue(vectorBackedBuilder.removeAll((1057..2145).toList()))
+        assertEquals((0..1056).toList(), vectorBackedBuilder)
+        assertEquals(2146, vector.size)
+        assertEquals(1060, vector[1060])
+        assertEquals(2145, vector[2145])
+    }
+
+    @Test
+    fun `removeAll keeping only tail survivors drops the root entirely`() {
+        val builder = ownedBuilderOf(0..99)
+
+        assertTrue(builder.removeAll((0..95).toList()))
+        assertEquals(4, builder.size)
+        assertEquals(listOf(96, 97, 98, 99), builder)
+
+        assertTrue(builder.add(100))
+        assertEquals(listOf(96, 97, 98, 99, 100), builder)
+        assertEquals(listOf(96, 97, 98, 99, 100), builder.build())
+    }
+
+    @Test
+    fun `removeAll on a builder with a single-leaf root scans the root as one leaf buffer`() {
+        val builder = ownedBuilderOf(0..<40)
+        val reference = (0..<40).toMutableList()
+
+        assertTrue(builder.removeAll(listOf(5, 38, 100)))
+        assertTrue(reference.removeAll(listOf(5, 38, 100)))
+
+        assertEquals<List<Int>>(reference, builder)
+        assertEquals<List<Int>>(reference, builder.build())
+    }
+}

--- a/core/commonTest/src/contract/list/PersistentListBuilderRemovalTest.kt
+++ b/core/commonTest/src/contract/list/PersistentListBuilderRemovalTest.kt
@@ -18,7 +18,13 @@ import kotlin.test.assertTrue
 class PersistentListBuilderRemovalTest {
 
     init {
-        check(MAX_BUFFER_SIZE == 32) { "Test sizes assume a trie buffer size of 32" }
+        check(MAX_BUFFER_SIZE == 32) {
+            """
+            The sizes in this class are hand-picked trie shape boundaries for the buffer size of 32.
+            If MAX_BUFFER_SIZE changes, revisit each size manually
+            and verify that all branches of the code under test are still covered.
+            """.trimIndent()
+        }
     }
 
     private fun ownedBuilderOf(range: IntRange): PersistentList.Builder<Int> {

--- a/core/commonTest/src/contract/list/PersistentListBuilderRemovalTest.kt
+++ b/core/commonTest/src/contract/list/PersistentListBuilderRemovalTest.kt
@@ -5,8 +5,6 @@
 
 package tests.contract.list
 
-import kotlinx.collections.immutable.PersistentList
-import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toPersistentList
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -20,17 +18,9 @@ class PersistentListBuilderRemovalTest {
         checkTrieShapeAssumptions()
     }
 
-    private fun ownedBuilderOf(range: IntRange): PersistentList.Builder<Int> {
-        val builder = persistentListOf<Int>().builder()
-        for (element in range) {
-            assertTrue(builder.add(element))
-        }
-        return builder
-    }
-
     @Test
     fun `get descends the root trie for indices before the tail`() {
-        val builder = ownedBuilderOf(0..1090)
+        val builder = ownedBuilderOf(1091)
         for (index in 0..1090) {
             assertEquals(index, builder[index])
         }
@@ -40,7 +30,7 @@ class PersistentListBuilderRemovalTest {
 
     @Test
     fun `set at an index in the root of an owned builder replaces in place without invalidating iterators`() {
-        val builder = ownedBuilderOf(0..99)
+        val builder = ownedBuilderOf(100)
         val iterator = builder.listIterator()
 
         assertEquals(0, builder.set(0, -1))
@@ -90,7 +80,7 @@ class PersistentListBuilderRemovalTest {
 
     @Test
     fun `removeAt an index in the root shifts elements across leaves like a mutable list`() {
-        val builder = ownedBuilderOf(0..99)
+        val builder = ownedBuilderOf(100)
         val reference = (0..99).toMutableList()
 
         assertEquals(reference.removeAt(0), builder.removeAt(0))
@@ -103,7 +93,7 @@ class PersistentListBuilderRemovalTest {
 
     @Test
     fun `removeAt zero on a two-level trie rotates the tail element through all leaves and pulls the emptied tail`() {
-        val builder = ownedBuilderOf(0..1056)
+        val builder = ownedBuilderOf(1057)
 
         assertEquals(0, builder.removeAt(0))
 
@@ -116,7 +106,7 @@ class PersistentListBuilderRemovalTest {
 
     @Test
     fun `removing elements from the end pulls leaf buffers back from the trie until the root disappears`() {
-        val builder = ownedBuilderOf(0..1056)
+        val builder = ownedBuilderOf(1057)
 
         for (element in 1056 downTo 25) {
             assertEquals(element, builder.removeAt(builder.size - 1))
@@ -132,7 +122,7 @@ class PersistentListBuilderRemovalTest {
 
     @Test
     fun `removeAll matching only tail elements pulls the last leaf when the tail empties`() {
-        val builder = ownedBuilderOf(0..99)
+        val builder = ownedBuilderOf(100)
 
         assertFalse(builder.removeAll(listOf(200, 300)))
         assertEquals((0..99).toList(), builder)
@@ -151,7 +141,7 @@ class PersistentListBuilderRemovalTest {
 
     @Test
     fun `removeAll spanning several owned leaves recycles buffers and trims stale root entries`() {
-        val builder = ownedBuilderOf(0..135)
+        val builder = ownedBuilderOf(136)
 
         assertTrue(builder.removeAll((33..100).toList()))
 
@@ -166,7 +156,7 @@ class PersistentListBuilderRemovalTest {
 
     @Test
     fun `removeAll trimming a two-level trie nullifies the dropped child on every level`() {
-        val ownedBuilder = ownedBuilderOf(0..2145)
+        val ownedBuilder = ownedBuilderOf(2146)
         assertTrue(ownedBuilder.removeAll((1057..2145).toList()))
         assertEquals(1057, ownedBuilder.size)
         assertEquals((0..1056).toList(), ownedBuilder)
@@ -185,7 +175,7 @@ class PersistentListBuilderRemovalTest {
 
     @Test
     fun `removeAll keeping only tail survivors drops the root entirely`() {
-        val builder = ownedBuilderOf(0..99)
+        val builder = ownedBuilderOf(100)
 
         assertTrue(builder.removeAll((0..95).toList()))
         assertEquals(4, builder.size)
@@ -198,7 +188,7 @@ class PersistentListBuilderRemovalTest {
 
     @Test
     fun `removeAll on a builder with a single-leaf root scans the root as one leaf buffer`() {
-        val builder = ownedBuilderOf(0..<40)
+        val builder = ownedBuilderOf(40)
         val reference = (0..<40).toMutableList()
 
         assertTrue(builder.removeAll(listOf(5, 38, 100)))

--- a/core/commonTest/src/contract/list/PersistentListIteratorTest.kt
+++ b/core/commonTest/src/contract/list/PersistentListIteratorTest.kt
@@ -5,20 +5,13 @@
 
 package tests.contract.list
 
-import kotlinx.collections.immutable.implementations.immutableList.MAX_BUFFER_SIZE
 import kotlinx.collections.immutable.toPersistentList
 import kotlin.test.*
 
 class PersistentListIteratorTest {
 
     init {
-        check(MAX_BUFFER_SIZE == 32) {
-            """
-            The sizes in this class are hand-picked trie shape boundaries for the buffer size of 32.
-            If MAX_BUFFER_SIZE changes, revisit each size manually
-            and verify that all branches of the code under test are still covered.
-            """.trimIndent()
-        }
+        checkTrieShapeAssumptions()
     }
 
     @Test

--- a/core/commonTest/src/contract/list/PersistentListIteratorTest.kt
+++ b/core/commonTest/src/contract/list/PersistentListIteratorTest.kt
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2016-2026 JetBrains s.r.o.
+ * Use of this source code is governed by the Apache 2.0 License that can be found in the LICENSE.txt file.
+ */
+
+package tests.contract.list
+
+import kotlinx.collections.immutable.implementations.immutableList.MAX_BUFFER_SIZE
+import kotlinx.collections.immutable.toPersistentList
+import kotlin.test.*
+
+class PersistentListIteratorTest {
+
+    init {
+        check(MAX_BUFFER_SIZE == 32) { "Test sizes assume a trie buffer size of 32" }
+    }
+
+    @Test
+    fun `persistent list iterator walks backward from the end across tail and trie`() {
+        val list = List(70) { it }.toPersistentList()
+        val iterator = list.listIterator(list.size)
+
+        assertFalse(iterator.hasNext())
+        assertTrue(iterator.hasPrevious())
+
+        for (i in 69 downTo 0) {
+            assertEquals(i, iterator.previousIndex())
+            assertEquals(i, iterator.previous())
+            assertEquals(i, iterator.nextIndex())
+        }
+        assertFalse(iterator.hasPrevious())
+        assertFailsWith<NoSuchElementException> { iterator.previous() }
+
+        for (i in 0..69) {
+            assertEquals(i, iterator.next())
+        }
+        assertFalse(iterator.hasNext())
+        assertFailsWith<NoSuchElementException> { iterator.next() }
+    }
+
+    @Test
+    fun `builder list iterator supports mutation mid-iteration across trie and tail`() {
+        val builder = List(40) { it }.toPersistentList().builder()
+        val expected = MutableList(40) { it }
+        val actual = builder.listIterator()
+        val expectedIterator = expected.listIterator()
+
+        repeat(10) {
+            assertEquals(expectedIterator.next(), actual.next())
+        }
+
+        expectedIterator.set(-10)
+        actual.set(-10)
+
+        while (expectedIterator.hasNext()) {
+            assertEquals(expectedIterator.next(), actual.next())
+        }
+        assertFalse(actual.hasNext())
+
+        repeat(8) {
+            assertEquals(expectedIterator.previous(), actual.previous())
+        }
+
+        expectedIterator.remove()
+        actual.remove()
+        expectedIterator.add(100)
+        actual.add(100)
+
+        while (expectedIterator.hasPrevious()) {
+            assertEquals(expectedIterator.previous(), actual.previous())
+        }
+        assertFalse(actual.hasPrevious())
+        assertFailsWith<NoSuchElementException> { actual.previous() }
+
+        assertEquals<List<Int>>(expected, builder)
+        assertEquals<List<Int>>(expected, builder.build())
+    }
+
+    @Test
+    fun `builder list iterator add grows the trie and keeps iterating after resets`() {
+        val builder = List(33) { it }.toPersistentList().builder()
+        val iterator = builder.listIterator(builder.size)
+
+        while (builder.size < 1057) {
+            iterator.add(builder.size)
+        }
+        assertEquals(1057, builder.size)
+        assertFalse(iterator.hasNext())
+        assertEquals(1057, iterator.nextIndex())
+
+        for (i in 1056 downTo 0) {
+            assertEquals(i, iterator.previous())
+        }
+        assertFalse(iterator.hasPrevious())
+        assertEquals(0, iterator.next())
+
+        assertEquals(List(1057) { it }, builder.build())
+    }
+
+    @Test
+    fun `builder list iterator remove and set throw IllegalStateException without a preceding next or previous`() {
+        val builder = List(40) { it }.toPersistentList().builder()
+        val iterator = builder.listIterator()
+
+        assertFailsWith<IllegalStateException> { iterator.remove() }
+        assertFailsWith<IllegalStateException> { iterator.set(-1) }
+
+        assertEquals(0, iterator.next())
+        iterator.remove()
+        assertFailsWith<IllegalStateException> { iterator.remove() }
+        assertFailsWith<IllegalStateException> { iterator.set(-1) }
+
+        assertEquals(1, iterator.next())
+        iterator.add(100)
+        assertFailsWith<IllegalStateException> { iterator.remove() }
+        assertFailsWith<IllegalStateException> { iterator.set(-2) }
+
+        val expected = listOf(1, 100) + (2..<40)
+        assertEquals(expected, builder)
+        assertEquals(expected, builder.build())
+    }
+}

--- a/core/commonTest/src/contract/list/PersistentListIteratorTest.kt
+++ b/core/commonTest/src/contract/list/PersistentListIteratorTest.kt
@@ -12,7 +12,13 @@ import kotlin.test.*
 class PersistentListIteratorTest {
 
     init {
-        check(MAX_BUFFER_SIZE == 32) { "Test sizes assume a trie buffer size of 32" }
+        check(MAX_BUFFER_SIZE == 32) {
+            """
+            The sizes in this class are hand-picked trie shape boundaries for the buffer size of 32.
+            If MAX_BUFFER_SIZE changes, revisit each size manually
+            and verify that all branches of the code under test are still covered.
+            """.trimIndent()
+        }
     }
 
     @Test

--- a/core/commonTest/src/contract/list/PersistentVectorTest.kt
+++ b/core/commonTest/src/contract/list/PersistentVectorTest.kt
@@ -1,0 +1,162 @@
+/*
+ * Copyright 2016-2026 JetBrains s.r.o.
+ * Use of this source code is governed by the Apache 2.0 License that can be found in the LICENSE.txt file.
+ */
+
+package tests.contract.list
+
+import kotlinx.collections.immutable.PersistentList
+import kotlinx.collections.immutable.implementations.immutableList.MAX_BUFFER_SIZE
+import kotlinx.collections.immutable.persistentListOf
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+
+class PersistentVectorTest {
+
+    init {
+        check(MAX_BUFFER_SIZE == 32) { "Test sizes assume a trie buffer size of 32" }
+    }
+
+    private fun vectorOfSize(size: Int): PersistentList<Int> {
+        var vector: PersistentList<Int> = persistentListOf()
+        for (element in 0..<size) {
+            vector = vector.adding(element)
+        }
+        return vector
+    }
+
+    private fun assertElementsEqual(expected: List<Int>, actual: List<Int>) {
+        assertEquals(expected.size, actual.size)
+        for (index in expected.indices) {
+            assertEquals(expected[index], actual[index], "element at index $index")
+        }
+    }
+
+    private fun insertedReference(size: Int, index: Int): List<Int> =
+        (0..<index) + listOf(-1) + (index..<size)
+
+    @Test
+    fun `appending elements one by one grows the vector through the buffer and trie height boundaries`() {
+        val boundarySizes = setOf(32, 33, 64, 65, 96, 1056, 1057)
+        val snapshots = mutableListOf<PersistentList<Int>>()
+
+        var vector: PersistentList<Int> = persistentListOf()
+        for (element in 0..<1200) {
+            vector = vector.adding(element)
+            assertEquals(element + 1, vector.size)
+            assertEquals(element, vector[element])
+            if (vector.size in boundarySizes) snapshots += vector
+        }
+
+        assertElementsEqual(List(1200) { it }, vector)
+
+        assertEquals(boundarySizes.size, snapshots.size)
+        for (snapshot in snapshots) {
+            assertElementsEqual(List(snapshot.size) { it }, snapshot)
+        }
+    }
+
+    @Test
+    fun `addingAt inserts into the trie root carrying elements over the full buffers`() {
+        val fullTailBase = vectorOfSize(96)
+        for (index in listOf(0, 5, 40, 70, 96)) {
+            assertElementsEqual(insertedReference(96, index), fullTailBase.addingAt(index, -1))
+        }
+
+        val shortTailBase = vectorOfSize(97)
+        for (index in listOf(0, 96, 97)) {
+            assertElementsEqual(insertedReference(97, index), shortTailBase.addingAt(index, -1))
+        }
+
+        assertFailsWith<IndexOutOfBoundsException> { fullTailBase.addingAt(97, -1) }
+
+        assertElementsEqual(List(96) { it }, fullTailBase)
+        assertElementsEqual(List(97) { it }, shortTailBase)
+    }
+
+    @Test
+    fun `removingAt shifts elements from the trie root through the tail`() {
+        val base = vectorOfSize(100)
+        for (index in listOf(0, 40, 97, 99)) {
+            assertElementsEqual((0..<100).filter { it != index }, base.removingAt(index))
+        }
+
+        assertFailsWith<IndexOutOfBoundsException> { base.removingAt(100) }
+
+        assertElementsEqual(List(100) { it }, base)
+    }
+
+    @Test
+    fun `removingAt the only tail element pulls the last leaf buffer out of the trie`() {
+        val singleLeaf = vectorOfSize(33)
+        assertElementsEqual((0..<32).toList(), singleLeaf.removingAt(32))
+        assertElementsEqual((1..<33).toList(), singleLeaf.removingAt(0))
+
+        val multiLeaf = vectorOfSize(97)
+        assertElementsEqual((0..<96).toList(), multiLeaf.removingAt(96))
+
+        val twoLevels = vectorOfSize(1057)
+        assertElementsEqual((0..<1056).toList(), twoLevels.removingAt(1056))
+        assertElementsEqual((0..<1057).toList(), twoLevels)
+    }
+
+    @Test
+    fun `replacingAt updates elements in the root and in the tail creating a new vector`() {
+        val base = vectorOfSize(100)
+
+        val rootReplaced = base.replacingAt(10, -1)
+        assertElementsEqual((0..<100).map { if (it == 10) -1 else it }, rootReplaced)
+
+        val tailReplaced = base.replacingAt(98, -2)
+        assertElementsEqual((0..<100).map { if (it == 98) -2 else it }, tailReplaced)
+
+        assertEquals(10, base[10])
+        assertEquals(98, base[98])
+        assertFailsWith<IndexOutOfBoundsException> { base.replacingAt(100, 0) }
+    }
+
+    @Test
+    fun `bulk additions to a trie-backed vector append and insert collections`() {
+        val base = vectorOfSize(40)
+
+        assertSame(base, base.addingAll(emptyList()))
+        assertSame(base, base.addingAllAt(20, emptyList()))
+
+        assertElementsEqual((0..<40) + listOf(-1, -2, -3), base.addingAll(listOf(-1, -2, -3)))
+        assertElementsEqual((0..<20) + listOf(-1, -2, -3) + (20..<40), base.addingAllAt(20, listOf(-1, -2, -3)))
+
+        assertFailsWith<IndexOutOfBoundsException> { base.addingAllAt(41, listOf(-1)) }
+        assertElementsEqual(List(40) { it }, base)
+    }
+
+    @Test
+    fun `retainingAll keeps matching elements and returns an empty vector for an empty argument`() {
+        val base = vectorOfSize(40)
+
+        assertElementsEqual(listOf(3, 7), base.retainingAll(listOf(3, 7, 100)))
+
+        val emptied = base.retainingAll(emptyList())
+        assertTrue(emptied.isEmpty())
+        assertEquals(emptyList(), emptied)
+
+        assertElementsEqual(List(40) { it }, base)
+    }
+
+    @Test
+    fun `small vector operations at the buffer size boundaries`() {
+        val small = vectorOfSize(30)
+        assertElementsEqual((0..<15) + (100..<110) + (15..<30), small.addingAllAt(15, (100..<110).toList()))
+
+        assertElementsEqual((0..<30) + listOf(99), small.addingAt(30, 99))
+
+        val full = vectorOfSize(32)
+        assertElementsEqual((0..<10) + listOf(-1) + (10..<32), full.addingAt(10, -1))
+        assertElementsEqual(List(32) { it }, full)
+
+        val emptied = persistentListOf<Int>().adding(7).removingAt(0)
+        assertTrue(emptied.isEmpty())
+    }
+}

--- a/core/commonTest/src/contract/list/PersistentVectorTest.kt
+++ b/core/commonTest/src/contract/list/PersistentVectorTest.kt
@@ -17,7 +17,13 @@ import kotlin.test.assertTrue
 class PersistentVectorTest {
 
     init {
-        check(MAX_BUFFER_SIZE == 32) { "Test sizes assume a trie buffer size of 32" }
+        check(MAX_BUFFER_SIZE == 32) {
+            """
+            The sizes in this class are hand-picked trie shape boundaries for the buffer size of 32.
+            If MAX_BUFFER_SIZE changes, revisit each size manually
+            and verify that all branches of the code under test are still covered.
+            """.trimIndent()
+        }
     }
 
     private fun vectorOfSize(size: Int): PersistentList<Int> {

--- a/core/commonTest/src/contract/list/PersistentVectorTest.kt
+++ b/core/commonTest/src/contract/list/PersistentVectorTest.kt
@@ -6,7 +6,6 @@
 package tests.contract.list
 
 import kotlinx.collections.immutable.PersistentList
-import kotlinx.collections.immutable.implementations.immutableList.MAX_BUFFER_SIZE
 import kotlinx.collections.immutable.persistentListOf
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -17,13 +16,7 @@ import kotlin.test.assertTrue
 class PersistentVectorTest {
 
     init {
-        check(MAX_BUFFER_SIZE == 32) {
-            """
-            The sizes in this class are hand-picked trie shape boundaries for the buffer size of 32.
-            If MAX_BUFFER_SIZE changes, revisit each size manually
-            and verify that all branches of the code under test are still covered.
-            """.trimIndent()
-        }
+        checkTrieShapeAssumptions()
     }
 
     private fun vectorOfSize(size: Int): PersistentList<Int> {

--- a/core/commonTest/src/contract/list/PersistentVectorTest.kt
+++ b/core/commonTest/src/contract/list/PersistentVectorTest.kt
@@ -8,6 +8,7 @@ package tests.contract.list
 import kotlinx.collections.immutable.PersistentList
 import kotlinx.collections.immutable.persistentListOf
 import kotlin.test.Test
+import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertSame
@@ -27,13 +28,6 @@ class PersistentVectorTest {
         return vector
     }
 
-    private fun assertElementsEqual(expected: List<Int>, actual: List<Int>) {
-        assertEquals(expected.size, actual.size)
-        for (index in expected.indices) {
-            assertEquals(expected[index], actual[index], "element at index $index")
-        }
-    }
-
     private fun insertedReference(size: Int, index: Int): List<Int> =
         (0..<index) + listOf(-1) + (index..<size)
 
@@ -50,11 +44,11 @@ class PersistentVectorTest {
             if (vector.size in boundarySizes) snapshots += vector
         }
 
-        assertElementsEqual(List(1200) { it }, vector)
+        assertContentEquals(List(1200) { it }, vector)
 
         assertEquals(boundarySizes.size, snapshots.size)
         for (snapshot in snapshots) {
-            assertElementsEqual(List(snapshot.size) { it }, snapshot)
+            assertContentEquals(List(snapshot.size) { it }, snapshot)
         }
     }
 
@@ -62,44 +56,44 @@ class PersistentVectorTest {
     fun `addingAt inserts into the trie root carrying elements over the full buffers`() {
         val fullTailBase = vectorOfSize(96)
         for (index in listOf(0, 5, 40, 70, 96)) {
-            assertElementsEqual(insertedReference(96, index), fullTailBase.addingAt(index, -1))
+            assertContentEquals(insertedReference(96, index), fullTailBase.addingAt(index, -1))
         }
 
         val shortTailBase = vectorOfSize(97)
         for (index in listOf(0, 96, 97)) {
-            assertElementsEqual(insertedReference(97, index), shortTailBase.addingAt(index, -1))
+            assertContentEquals(insertedReference(97, index), shortTailBase.addingAt(index, -1))
         }
 
         assertFailsWith<IndexOutOfBoundsException> { fullTailBase.addingAt(97, -1) }
 
-        assertElementsEqual(List(96) { it }, fullTailBase)
-        assertElementsEqual(List(97) { it }, shortTailBase)
+        assertContentEquals(List(96) { it }, fullTailBase)
+        assertContentEquals(List(97) { it }, shortTailBase)
     }
 
     @Test
     fun `removingAt shifts elements from the trie root through the tail`() {
         val base = vectorOfSize(100)
         for (index in listOf(0, 40, 97, 99)) {
-            assertElementsEqual((0..<100).filter { it != index }, base.removingAt(index))
+            assertContentEquals((0..<100).filter { it != index }, base.removingAt(index))
         }
 
         assertFailsWith<IndexOutOfBoundsException> { base.removingAt(100) }
 
-        assertElementsEqual(List(100) { it }, base)
+        assertContentEquals(List(100) { it }, base)
     }
 
     @Test
     fun `removingAt the only tail element pulls the last leaf buffer out of the trie`() {
         val singleLeaf = vectorOfSize(33)
-        assertElementsEqual((0..<32).toList(), singleLeaf.removingAt(32))
-        assertElementsEqual((1..<33).toList(), singleLeaf.removingAt(0))
+        assertContentEquals((0..<32).toList(), singleLeaf.removingAt(32))
+        assertContentEquals((1..<33).toList(), singleLeaf.removingAt(0))
 
         val multiLeaf = vectorOfSize(97)
-        assertElementsEqual((0..<96).toList(), multiLeaf.removingAt(96))
+        assertContentEquals((0..<96).toList(), multiLeaf.removingAt(96))
 
         val twoLevels = vectorOfSize(1057)
-        assertElementsEqual((0..<1056).toList(), twoLevels.removingAt(1056))
-        assertElementsEqual((0..<1057).toList(), twoLevels)
+        assertContentEquals((0..<1056).toList(), twoLevels.removingAt(1056))
+        assertContentEquals((0..<1057).toList(), twoLevels)
     }
 
     @Test
@@ -107,10 +101,10 @@ class PersistentVectorTest {
         val base = vectorOfSize(100)
 
         val rootReplaced = base.replacingAt(10, -1)
-        assertElementsEqual((0..<100).map { if (it == 10) -1 else it }, rootReplaced)
+        assertContentEquals((0..<100).map { if (it == 10) -1 else it }, rootReplaced)
 
         val tailReplaced = base.replacingAt(98, -2)
-        assertElementsEqual((0..<100).map { if (it == 98) -2 else it }, tailReplaced)
+        assertContentEquals((0..<100).map { if (it == 98) -2 else it }, tailReplaced)
 
         assertEquals(10, base[10])
         assertEquals(98, base[98])
@@ -124,36 +118,36 @@ class PersistentVectorTest {
         assertSame(base, base.addingAll(emptyList()))
         assertSame(base, base.addingAllAt(20, emptyList()))
 
-        assertElementsEqual((0..<40) + listOf(-1, -2, -3), base.addingAll(listOf(-1, -2, -3)))
-        assertElementsEqual((0..<20) + listOf(-1, -2, -3) + (20..<40), base.addingAllAt(20, listOf(-1, -2, -3)))
+        assertContentEquals((0..<40) + listOf(-1, -2, -3), base.addingAll(listOf(-1, -2, -3)))
+        assertContentEquals((0..<20) + listOf(-1, -2, -3) + (20..<40), base.addingAllAt(20, listOf(-1, -2, -3)))
 
         assertFailsWith<IndexOutOfBoundsException> { base.addingAllAt(41, listOf(-1)) }
-        assertElementsEqual(List(40) { it }, base)
+        assertContentEquals(List(40) { it }, base)
     }
 
     @Test
     fun `retainingAll keeps matching elements and returns an empty vector for an empty argument`() {
         val base = vectorOfSize(40)
 
-        assertElementsEqual(listOf(3, 7), base.retainingAll(listOf(3, 7, 100)))
+        assertContentEquals(listOf(3, 7), base.retainingAll(listOf(3, 7, 100)))
 
         val emptied = base.retainingAll(emptyList())
         assertTrue(emptied.isEmpty())
         assertEquals(emptyList(), emptied)
 
-        assertElementsEqual(List(40) { it }, base)
+        assertContentEquals(List(40) { it }, base)
     }
 
     @Test
     fun `small vector operations at the buffer size boundaries`() {
         val small = vectorOfSize(30)
-        assertElementsEqual((0..<15) + (100..<110) + (15..<30), small.addingAllAt(15, (100..<110).toList()))
+        assertContentEquals((0..<15) + (100..<110) + (15..<30), small.addingAllAt(15, (100..<110).toList()))
 
-        assertElementsEqual((0..<30) + listOf(99), small.addingAt(30, 99))
+        assertContentEquals((0..<30) + listOf(99), small.addingAt(30, 99))
 
         val full = vectorOfSize(32)
-        assertElementsEqual((0..<10) + listOf(-1) + (10..<32), full.addingAt(10, -1))
-        assertElementsEqual(List(32) { it }, full)
+        assertContentEquals((0..<10) + listOf(-1) + (10..<32), full.addingAt(10, -1))
+        assertContentEquals(List(32) { it }, full)
 
         val emptied = persistentListOf<Int>().adding(7).removingAt(0)
         assertTrue(emptied.isEmpty())

--- a/core/commonTest/src/contract/list/listTestUtils.kt
+++ b/core/commonTest/src/contract/list/listTestUtils.kt
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2016-2026 JetBrains s.r.o.
+ * Use of this source code is governed by the Apache 2.0 License that can be found in the LICENSE.txt file.
+ */
+
+package tests.contract.list
+
+import kotlinx.collections.immutable.PersistentList
+import kotlinx.collections.immutable.persistentListOf
+import kotlin.test.assertTrue
+
+internal fun ownedBuilderOf(size: Int): PersistentList.Builder<Int> {
+    val builder = persistentListOf<Int>().builder()
+    for (element in 0..<size) {
+        assertTrue(builder.add(element))
+    }
+    return builder
+}

--- a/core/commonTest/src/contract/list/trieShapeAssumptions.kt
+++ b/core/commonTest/src/contract/list/trieShapeAssumptions.kt
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2016-2026 JetBrains s.r.o.
+ * Use of this source code is governed by the Apache 2.0 License that can be found in the LICENSE.txt file.
+ */
+
+package tests.contract.list
+
+import kotlinx.collections.immutable.implementations.immutableList.MAX_BUFFER_SIZE
+
+internal fun checkTrieShapeAssumptions() {
+    check(MAX_BUFFER_SIZE == 32) {
+        """
+        The sizes in this class are hand-picked trie shape boundaries for the buffer size of 32.
+        If MAX_BUFFER_SIZE changes, revisit each size manually
+        and verify that all branches of the code under test are still covered.
+        """.trimIndent()
+    }
+}

--- a/core/commonTest/src/contract/list/trieShapeAssumptions.kt
+++ b/core/commonTest/src/contract/list/trieShapeAssumptions.kt
@@ -7,10 +7,34 @@ package tests.contract.list
 
 import kotlinx.collections.immutable.implementations.immutableList.MAX_BUFFER_SIZE
 
+/**
+ * Checks the assumption behind the hand-picked sizes in the list contract tests.
+ *
+ * The persistent list is a 32-way trie plus a tail buffer, so it changes shape at fixed sizes.
+ * With [MAX_BUFFER_SIZE] = 32 the boundaries used across these tests are:
+ * - 32: a full tail and no trie, the largest small vector;
+ * - 33: the first leaf is pushed into the root;
+ * - 64, 96: the tail is full again, with one and two leaves in the root;
+ * - 65, 97: the second and the third leaf are pushed into the root;
+ * - 1056: the root and the tail are both full;
+ * - 1057: the root grows a level, producing a two-level trie;
+ * - 1089: the first leaf is pushed into the root after it grew;
+ * - 1091 (0..1090): a two-level root with two top-level children;
+ * - 2146 (0..2145): a two-level root with three top-level children, so trimming the trie
+ *   down to 1057 elements has a stale top-level child to nullify.
+ *
+ * Sizes between the boundaries (40, 100, 1100, ...) only need to stay inside the shape
+ * named by their test, their exact values carry no meaning. The exception is an inserted
+ * collection whose size is a multiple of 32: it preserves the tail size on purpose.
+ *
+ * If [MAX_BUFFER_SIZE] changes, this check fails: re-pick every size from the rules above
+ * and verify with a coverage run (koverHtmlReport) that all branches of the immutableList
+ * implementation are still exercised.
+ */
 internal fun checkTrieShapeAssumptions() {
     check(MAX_BUFFER_SIZE == 32) {
         """
-        The sizes in this class are hand-picked trie shape boundaries for the buffer size of 32.
+        The sizes in these tests are hand-picked trie shape boundaries for the buffer size of 32.
         If MAX_BUFFER_SIZE changes, revisit each size manually
         and verify that all branches of the code under test are still covered.
         """.trimIndent()

--- a/core/commonTest/src/implementations/list/TrieIteratorTest.kt
+++ b/core/commonTest/src/implementations/list/TrieIteratorTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 JetBrains s.r.o.
+ * Copyright 2016-2026 JetBrains s.r.o.
  * Use of this source code is governed by the Apache 2.0 License that can be found in the LICENSE.txt file.
  */
 
@@ -44,6 +44,30 @@ class TrieIteratorTest {
 
         @Suppress("UNCHECKED_CAST")
         return leaves.single() as Array<Any?>
+    }
+
+    @Test
+    fun previousAtLeftEdgeTest() {
+        for (height in 1..4) {
+            val maxCount = MAX_BUFFER_SIZE.toDouble().pow(height - 1).toInt()
+            val leafCount = maxCount / 32 + 1
+            val root = makeRoot(height, leafCount)
+            val size = leafCount * MAX_BUFFER_SIZE
+
+            val iterator = TrieIterator<Int>(root, index = 0, size = size, height = height)
+
+            assertFailsWith<NoSuchElementException> { iterator.previous() }
+
+            for (i in 0..<size) {
+                assertEquals(i, iterator.next())
+            }
+            assertFalse(iterator.hasNext())
+            for (i in size - 1 downTo 0) {
+                assertEquals(i, iterator.previous())
+            }
+            assertFalse(iterator.hasPrevious())
+            assertFailsWith<NoSuchElementException> { iterator.previous() }
+        }
     }
 
     @Test

--- a/core/commonTest/src/implementations/list/TrieIteratorTest.kt
+++ b/core/commonTest/src/implementations/list/TrieIteratorTest.kt
@@ -50,7 +50,7 @@ class TrieIteratorTest {
     fun previousAtLeftEdgeTest() {
         for (height in 1..4) {
             val maxCount = MAX_BUFFER_SIZE.toDouble().pow(height - 1).toInt()
-            val leafCount = maxCount / 32 + 1
+            val leafCount = maxCount / MAX_BUFFER_SIZE + 1
             val root = makeRoot(height, leafCount)
             val size = leafCount * MAX_BUFFER_SIZE
 


### PR DESCRIPTION
Deterministic tests for the persistent list paths that were exercised only by randomized stress runs or not at all, with sizes at the trie shape boundaries: tail fill, leaf push into the root, height growth.

Coverage of `kotlinx.collections.immutable.implementations.immutableList` by the deterministic suites (stress tests excluded):

|        | Class, %      | Method, %       | Branch, %       | Line, %         | Instruction, %    |
| ------ | ------------- | --------------- | --------------- | --------------- | ----------------- |
| Before | 92.3% (12/13) | 76.3% (103/135) | 49.7% (187/376) | 56.1% (469/836) | 51.1% (2311/4520) |
| After  | 100% (13/13)  | 100% (135/135)  | 92.8% (349/376) | 100% (836/836)  | 98.6% (4458/4520) |
