### PR TITLE
Cover persistent map implementation gaps with tests

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -155,6 +155,10 @@ kotlin {
     }
 }
 
+extensions.getByType<SourceSetContainer>().configureEach {
+    java.setSrcDirs(listOf("$name/java"))
+}
+
 dependencies {
     dokkaHtmlPlugin("org.jetbrains.dokka:kotlin-playground-samples-plugin")
     dokka(project)

--- a/core/commonTest/src/contract/map/PersistentHashMapTest.kt
+++ b/core/commonTest/src/contract/map/PersistentHashMapTest.kt
@@ -10,6 +10,9 @@ import kotlinx.collections.immutable.persistentHashMapOf
 import tests.IntWrapper
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertSame
 import kotlin.test.assertTrue
 
 class PersistentHashMapTest {
@@ -72,5 +75,115 @@ class PersistentHashMapTest {
         val afterMutableRemoving = builder.build()
 
         assertEquals(afterImmutableRemoving, afterMutableRemoving)
+    }
+
+    @Test
+    fun `entries of a non-empty persistent hash map contain exactly the map contents`() {
+        val map = persistentHashMapOf("a" to 1, "b" to 2, "c" to 3)
+        val entries = map.entries
+        assertEquals(3, entries.size)
+        assertEquals(setOf("a" to 1, "b" to 2, "c" to 3), entries.map { it.key to it.value }.toSet())
+    }
+
+    @Test
+    fun `removing an absent key returns the same map instance`() {
+        val k1 = IntWrapper(1, 0)
+        val k2 = IntWrapper(2, 32)
+        val map = persistentHashMapOf(k1 to 1, k2 to 2)
+
+        assertSame(map, map.removing(IntWrapper(9, 0)))
+        assertSame(map, map.removing(IntWrapper(9, 64)))
+        assertSame(map, map.removing(IntWrapper(9, 1)))
+    }
+
+    @Test
+    fun `putting into a full hash collision node updates it correctly`() {
+        val a = IntWrapper(1, 0)
+        val b = IntWrapper(2, 0)
+        val sharedValue = "a"
+        val map = persistentHashMapOf(a to sharedValue, b to "b")
+
+        assertSame(map, map.putting(a, sharedValue))
+
+        val updated = map.putting(a, "a2")
+        assertEquals(2, updated.size)
+        assertEquals("a2", updated[a])
+        assertEquals("b", updated[b])
+        assertEquals(sharedValue, map[a])
+
+        val c = IntWrapper(3, 0)
+        val extended = map.putting(c, "c")
+        assertEquals(3, extended.size)
+        assertEquals("c", extended[c])
+        assertEquals(sharedValue, extended[a])
+
+        assertSame(map, map.removing(IntWrapper(9, 0)))
+    }
+
+    @Test
+    fun `removing by key and value removes only exactly matching root entries`() {
+        val k1 = IntWrapper(1, 0)
+        val k2 = IntWrapper(2, 1)
+        val map = persistentHashMapOf(k1 to 1, k2 to 2)
+
+        assertSame(map, map.removing(k1, 999))
+        assertSame(map, map.removing(IntWrapper(3, 2), 1))
+
+        val removed = map.removing(k1, 1)
+        assertEquals(1, removed.size)
+        assertNull(removed[k1])
+        assertEquals(2, removed[k2])
+        assertEquals(1, map[k1])
+
+        val emptied = persistentHashMapOf(k1 to 1).removing(k1, 1)
+        assertSame(PersistentHashMap.emptyOf(), emptied)
+    }
+
+    @Test
+    fun `removing by key and value under a full hash collision`() {
+        val a = IntWrapper(1, 0)
+        val b = IntWrapper(2, 0)
+        val c = IntWrapper(3, 0)
+        val map = persistentHashMapOf(a to "a", b to "b", c to "c")
+
+        assertSame(map, map.removing(a, "x"))
+        assertSame(map, map.removing(IntWrapper(4, 0), "a"))
+
+        val removed = map.removing(b, "b")
+        assertEquals(2, removed.size)
+        assertNull(removed[b])
+        assertEquals("a", removed[a])
+        assertEquals("c", removed[c])
+        assertEquals("b", map[b])
+    }
+
+    @Test
+    fun `builder removes by key and value under a full hash collision`() {
+        val a = IntWrapper(1, 0)
+        val b = IntWrapper(2, 0)
+        val c = IntWrapper(3, 0)
+        val map = persistentHashMapOf(a to "a", b to "b", c to "c") as PersistentHashMap<IntWrapper, String>
+        val builder = map.builder()
+
+        assertFalse(builder.remove(a, "x"))
+        assertFalse(builder.remove(IntWrapper(4, 0), "a"))
+        assertNull(builder.remove(IntWrapper(4, 0)))
+        assertEquals(3, builder.size)
+
+        assertTrue(builder.remove(b, "b"))
+        assertEquals(2, builder.size)
+        assertNull(builder[b])
+        assertEquals("a", builder[a])
+        assertEquals("c", builder[c])
+        assertEquals(mapOf(a to "a", c to "c"), builder.build())
+    }
+
+    @Test
+    fun `cleared persistent hash map is the empty map`() {
+        val map = persistentHashMapOf("a" to 1, "b" to 2)
+        val cleared = map.cleared()
+        assertTrue(cleared.isEmpty())
+        assertSame(PersistentHashMap.emptyOf(), cleared)
+        assertEquals(2, map.size)
     }
 }

--- a/core/commonTest/src/contract/map/PersistentMapEntryIteratorTest.kt
+++ b/core/commonTest/src/contract/map/PersistentMapEntryIteratorTest.kt
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2016-2026 JetBrains s.r.o.
+ * Use of this source code is governed by the Apache 2.0 License that can be found in the LICENSE.txt file.
+ */
+
+package tests.contract.map
+
+import kotlinx.collections.immutable.persistentHashMapOf
+import tests.IntWrapper
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+
+class PersistentMapEntryIteratorTest {
+
+    @Test
+    fun `setValue on a builder entry in the middle of iteration updates the builder and keeps iterating`() {
+        val k1 = IntWrapper(1, 1)
+        val k2 = IntWrapper(2, 2)
+        val k3 = IntWrapper(3, 3)
+        val k4 = IntWrapper(4, 4)
+        val builder = persistentHashMapOf(k1 to 1, k2 to 2, k3 to 3, k4 to 4).builder()
+        val iterator = builder.entries.iterator()
+
+        val first = iterator.next()
+        val firstOldValue = first.value
+        assertEquals(firstOldValue, first.setValue(firstOldValue + 100))
+        assertEquals(firstOldValue + 100, first.value)
+        assertEquals(firstOldValue + 100, builder[first.key])
+
+        val seen = mutableListOf(first.key to first.value)
+        while (iterator.hasNext()) {
+            val entry = iterator.next()
+            seen.add(entry.key to entry.value)
+        }
+        assertEquals(4, seen.size)
+        val expected = mutableMapOf(k1 to 1, k2 to 2, k3 to 3, k4 to 4)
+        expected[first.key] = firstOldValue + 100
+        assertEquals(expected, seen.toMap())
+        assertEquals<Map<IntWrapper, Int>>(expected, builder.build())
+    }
+
+    @Test
+    fun `setValue on the last builder entry works when iteration is finished`() {
+        val k1 = IntWrapper(1, 1)
+        val k2 = IntWrapper(2, 2)
+        val builder = persistentHashMapOf(k1 to 1, k2 to 2).builder()
+        val iterator = builder.entries.iterator()
+
+        var last = iterator.next()
+        while (iterator.hasNext()) {
+            last = iterator.next()
+        }
+
+        val oldValue = last.value
+        assertEquals(oldValue, last.setValue(50))
+        assertFalse(iterator.hasNext())
+        assertEquals(50, builder[last.key])
+
+        val expected = mutableMapOf(k1 to 1, k2 to 2)
+        expected[last.key] = 50
+        assertEquals<Map<IntWrapper, Int>>(expected, builder.build())
+    }
+
+    @Test
+    fun `setValue on an entry whose key was removed from the builder directly does not modify the builder`() {
+        val k1 = IntWrapper(1, 1)
+        val k2 = IntWrapper(2, 2)
+        val k3 = IntWrapper(3, 3)
+        val builder = persistentHashMapOf(k1 to 1, k2 to 2, k3 to 3).builder()
+        val iterator = builder.entries.iterator()
+
+        val entry = iterator.next()
+        val oldValue = entry.value
+        assertEquals(oldValue, builder.remove(entry.key))
+        assertEquals(2, builder.size)
+
+        assertEquals(oldValue, entry.setValue(100))
+        assertEquals(100, entry.value)
+        assertFalse(builder.containsKey(entry.key))
+        assertEquals(2, builder.size)
+    }
+
+    @Test
+    fun `setValue during iteration over colliding keys repositions the iterator inside the collision node`() {
+        val k1 = IntWrapper(1, 0)
+        val k2 = IntWrapper(2, 0)
+        val k3 = IntWrapper(3, 0)
+        val builder = persistentHashMapOf(k1 to "a", k2 to "b", k3 to "c").builder()
+        val iterator = builder.entries.iterator()
+
+        val first = iterator.next()
+        val firstOldValue = first.value
+        assertEquals(firstOldValue, first.setValue("$firstOldValue!"))
+        assertEquals("$firstOldValue!", builder[first.key])
+
+        val seen = mutableListOf(first.key to first.value)
+        while (iterator.hasNext()) {
+            val entry = iterator.next()
+            seen.add(entry.key to entry.value)
+        }
+        assertEquals(3, seen.size)
+        val expected = mutableMapOf(k1 to "a", k2 to "b", k3 to "c")
+        expected[first.key] = "$firstOldValue!"
+        assertEquals(expected, seen.toMap())
+        assertEquals<Map<IntWrapper, String>>(expected, builder.build())
+    }
+}

--- a/core/commonTest/src/implementations/map/HashMapTrieNodeTest.kt
+++ b/core/commonTest/src/implementations/map/HashMapTrieNodeTest.kt
@@ -363,6 +363,89 @@ class HashMapTrieNodeTest {
         }
     }
 
+    private val innerKey = IntWrapper(1, 0)
+    private val topKey = IntWrapper(2, 1)
+
+    private fun singleEntryChild() = TrieNode<IntWrapper, Int>(1 shl 0, 0, arrayOf(innerKey, 100))
+
+    @Test
+    fun `removing the only entry of a sub-node drops the whole node`() {
+        val root = TrieNode<IntWrapper, Int>(1 shl 1, 1 shl 0, arrayOf(topKey, 200, singleEntryChild()))
+        val map = PersistentHashMap(root, 2)
+        assertEquals(100, map[innerKey])
+        assertEquals(200, map[topKey])
+
+        val removed = map.removing(innerKey)
+        assertEquals(1, removed.size)
+        assertNull(removed[innerKey])
+        assertEquals(200, removed[topKey])
+        removed.node.accept { node: TrieNode<IntWrapper, Int>, shift: Int, hash: Int, dataMap: Int, nodeMap: Int ->
+            assertEquals(0, shift)
+            assertEquals(0, hash)
+            assertEquals(0b10, dataMap)
+            assertEquals(0b0, nodeMap)
+            assertTrue(arrayOf<Any?>(topKey, 200) contentEquals node.buffer)
+        }
+
+        val chainRoot = TrieNode<IntWrapper, Int>(0, 1 shl 0, arrayOf(singleEntryChild()))
+        val emptied = PersistentHashMap(chainRoot, 1).removing(innerKey)
+        assertSame(PersistentHashMap.emptyOf(), emptied)
+    }
+
+    @Test
+    fun `builder removing the only entry of a sub-node drops the whole node`() {
+        val builder1 = PersistentHashMap(
+            node = TrieNode<IntWrapper, Int>(
+                1 shl 1,
+                1 shl 0,
+                arrayOf(topKey, 200, singleEntryChild())
+            ),
+            size = 2
+        ).builder()
+        assertEquals(100, builder1.remove(innerKey))
+        assertEquals(1, builder1.size)
+        assertNull(builder1[innerKey])
+        assertEquals(200, builder1[topKey])
+        builder1.node.accept { node: TrieNode<IntWrapper, Int>, shift: Int, hash: Int, dataMap: Int, nodeMap: Int ->
+            assertEquals(0, shift)
+            assertEquals(0, hash)
+            assertEquals(0b10, dataMap)
+            assertEquals(0b0, nodeMap)
+            assertTrue(arrayOf<Any?>(topKey, 200) contentEquals node.buffer)
+        }
+
+        val builder2 = PersistentHashMap(
+            node = TrieNode<IntWrapper, Int>(
+                1 shl 1,
+                1 shl 0,
+                arrayOf(topKey, 200, singleEntryChild())
+            ),
+            size = 2
+        ).builder()
+        builder2[topKey] = 999
+        assertEquals(100, builder2.remove(innerKey))
+        assertEquals(1, builder2.size)
+        assertNull(builder2[innerKey])
+        assertEquals(999, builder2[topKey])
+        assertEquals(mapOf(topKey to 999), builder2.build())
+        builder2.node.accept { node: TrieNode<IntWrapper, Int>, shift: Int, hash: Int, dataMap: Int, nodeMap: Int ->
+            assertEquals(0, shift)
+            assertEquals(0, hash)
+            assertEquals(0b10, dataMap)
+            assertEquals(0b0, nodeMap)
+            assertTrue(arrayOf<Any?>(topKey, 999) contentEquals node.buffer)
+        }
+
+        val builder3 = PersistentHashMap(
+            node = TrieNode<IntWrapper, Int>(0, 1 shl 0, arrayOf(singleEntryChild())),
+            size = 1
+        ).builder()
+        assertEquals(100, builder3.remove(innerKey))
+        assertSame<TrieNode<*, *>>(TrieNode.EMPTY, builder3.node)
+        assertTrue(builder3.isEmpty())
+        assertEquals(0, builder3.build().size)
+    }
+
     // TODO: Investigate performance impact of converting single-entry collision root node to compact node. See the following commented test:
 /*
     // Nodes drawn using square braces are collision nodes.

--- a/core/commonTest/src/implementations/map/MapContentIteratorsTest.kt
+++ b/core/commonTest/src/implementations/map/MapContentIteratorsTest.kt
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2016-2026 JetBrains s.r.o.
+ * Use of this source code is governed by the Apache 2.0 License that can be found in the LICENSE.txt file.
+ */
+
+package tests.implementations.map
+
+import kotlinx.collections.immutable.implementations.immutableMap.PersistentHashMap
+import kotlinx.collections.immutable.implementations.immutableMap.TrieNode
+import kotlinx.collections.immutable.implementations.immutableMap.TrieNodeKeysIterator
+import kotlinx.collections.immutable.implementations.persistentOrderedMap.PersistentOrderedMap
+import kotlinx.collections.immutable.implementations.persistentOrderedMap.PersistentOrderedMapBuilder
+import kotlinx.collections.immutable.implementations.persistentOrderedMap.PersistentOrderedMapBuilderLinksIterator
+import kotlinx.collections.immutable.implementations.persistentOrderedMap.PersistentOrderedMapLinksIterator
+import kotlinx.collections.immutable.persistentMapOf
+import tests.IntWrapper
+import kotlin.test.*
+
+class MapContentIteratorsTest {
+
+    @Test
+    fun `trie node keys iterator yields the key of each data entry`() {
+        val iterator = TrieNodeKeysIterator<String, Int>()
+        iterator.reset(arrayOf("a", 1, "b", 2), 4)
+        val keys = mutableListOf<String>()
+        while (iterator.hasNext()) {
+            keys.add(iterator.next())
+        }
+        assertEquals(listOf("a", "b"), keys)
+    }
+
+    @Test
+    fun `hash map iterator skips a single non-canonical empty child node`() {
+        val key = IntWrapper(1, 0)
+        val realChild = TrieNode<IntWrapper, Int>(1 shl 0, 0, arrayOf(key, 42))
+        val root = TrieNode<IntWrapper, Int>(0, 0b11, arrayOf(TrieNode.EMPTY, realChild))
+        val map = PersistentHashMap(root, 1)
+
+        assertEquals(42, map[key])
+        assertEquals(listOf(key to 42), map.entries.map { it.key to it.value })
+    }
+
+    @Test
+    fun `entries and links iterator of a non-empty ordered map iterate in insertion order`() {
+        val map = persistentMapOf("a" to 1, "b" to 2, "c" to 3) as PersistentOrderedMap<String, Int>
+
+        assertEquals(listOf("a" to 1, "b" to 2, "c" to 3), map.entries.map { it.key to it.value })
+
+        val links = PersistentOrderedMapLinksIterator(map.firstKey, map.hashMap)
+        assertEquals(0, links.index)
+        val values = mutableListOf<Int>()
+        while (links.hasNext()) {
+            values.add(links.next().value)
+        }
+        assertEquals(listOf(1, 2, 3), values)
+        assertEquals(3, links.index)
+        assertFailsWith<NoSuchElementException> { links.next() }
+    }
+
+    @Test
+    fun `ordered map builder links iterator iterates in order and detects concurrent modification`() {
+        val builder =
+            persistentMapOf("a" to 1, "b" to 2, "c" to 3).builder() as PersistentOrderedMapBuilder<String, Int>
+
+        val links = PersistentOrderedMapBuilderLinksIterator(builder.firstKey, builder)
+        assertEquals(0, links.index)
+        val values = mutableListOf<Int>()
+        while (links.hasNext()) {
+            values.add(links.next().value)
+        }
+        assertEquals(listOf(1, 2, 3), values)
+        assertEquals(3, links.index)
+        assertFailsWith<NoSuchElementException> { links.next() }
+
+        val freshLinks = PersistentOrderedMapBuilderLinksIterator(builder.firstKey, builder)
+        builder["d"] = 4
+        assertFailsWith<ConcurrentModificationException> { freshLinks.next() }
+    }
+}

--- a/core/jvmTest/java/tests/contract/map/PersistentMapJavaAccessorsTest.java
+++ b/core/jvmTest/java/tests/contract/map/PersistentMapJavaAccessorsTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2016-2026 JetBrains s.r.o.
+ * Use of this source code is governed by the Apache 2.0 License that can be found in the LICENSE.txt file.
+ */
+
+package tests.contract.map;
+
+import kotlinx.collections.immutable.ExtensionsKt;
+import kotlinx.collections.immutable.ImmutableSet;
+import kotlinx.collections.immutable.PersistentMap;
+import org.junit.Test;
+
+import java.util.AbstractMap.SimpleEntry;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class PersistentMapJavaAccessorsTest {
+    @Test
+    public void entriesOfHashAndOrderedMapsAreImmutableSetsInJava() {
+        PersistentMap<String, Integer> hashMap =
+                ExtensionsKt.<String, Integer>persistentHashMapOf().putting("a", 1).putting("b", 2);
+        ImmutableSet<Map.Entry<String, Integer>> hashEntries = hashMap.getEntries();
+        assertEquals(2, hashEntries.size());
+        assertTrue(hashEntries.contains(new SimpleEntry<>("a", 1)));
+        assertTrue(hashEntries.contains(new SimpleEntry<>("b", 2)));
+
+        PersistentMap<String, Integer> orderedMap =
+                ExtensionsKt.<String, Integer>persistentMapOf().putting("b", 2).putting("a", 1);
+        ImmutableSet<Map.Entry<String, Integer>> orderedEntries = orderedMap.getEntries();
+        assertEquals(2, orderedEntries.size());
+        assertTrue(orderedEntries.contains(new SimpleEntry<>("b", 2)));
+        assertTrue(orderedEntries.contains(new SimpleEntry<>("a", 1)));
+    }
+}


### PR DESCRIPTION
Tests for the persistent map paths the existing suites left uncovered: collision-node updates, removal that drops an emptied sub-node, setValue through a builder entry during iteration, the content iterators, and the Java-visible entries bridge.

Coverage of `kotlinx.collections.immutable.implementations.immutableMap`:

|        | Class, %     | Method, %       | Branch, %       | Line, %         | Instruction, %    |
| ------ | ------------ | --------------- | --------------- | --------------- | ----------------- |
| Before | 100% (29/29) | 91.8% (178/194) | 76.2% (340/446) | 88.4% (655/741) | 87.8% (3916/4461) |
| After  | 100% (29/29) | 100% (194/194)  | 89% (397/446)   | 100% (741/741)  | 98.4% (4390/4461) |

Coverage of `kotlinx.collections.immutable.implementations.persistentOrderedMap`:

|        | Class, %     | Method, %       | Branch, %       | Line, %         | Instruction, %    |
| ------ | ------------ | --------------- | --------------- | --------------- | ----------------- |
| Before | 100% (19/19) | 97.5% (117/120) | 94.3% (100/106) | 98.9% (270/273) | 98.7% (1432/1451) |
| After  | 100% (19/19) | 100% (120/120)  | 94.3% (100/106) | 100% (273/273)  | 99.5% (1444/1451) |
