### PR TITLE
Reformat core module sources to the official Kotlin style

### DIFF
--- a/core/commonMain/src/adapters/ReadOnlyCollectionAdapters.kt
+++ b/core/commonMain/src/adapters/ReadOnlyCollectionAdapters.kt
@@ -13,7 +13,8 @@ import kotlinx.collections.immutable.*
  Use with caution: wrapping mutable collection as immutable is a contract violation of the latter.
  */
 
-public open class ImmutableCollectionAdapter<E>(private val impl: Collection<E>) : ImmutableCollection<E>, Collection<E> by impl {
+public open class ImmutableCollectionAdapter<E>(private val impl: Collection<E>) :
+    ImmutableCollection<E>, Collection<E> by impl {
     override fun equals(other: Any?): Boolean = impl.equals(other)
     override fun hashCode(): Int = impl.hashCode()
     override fun toString(): String = impl.toString()
@@ -22,7 +23,8 @@ public open class ImmutableCollectionAdapter<E>(private val impl: Collection<E>)
 
 public class ImmutableListAdapter<E>(private val impl: List<E>) : ImmutableList<E>, List<E> by impl {
 
-    override fun subList(fromIndex: Int, toIndex: Int): ImmutableList<E> = ImmutableListAdapter(impl.subList(fromIndex, toIndex))
+    override fun subList(fromIndex: Int, toIndex: Int): ImmutableList<E> =
+        ImmutableListAdapter(impl.subList(fromIndex, toIndex))
 
     override fun equals(other: Any?): Boolean = impl.equals(other)
     override fun hashCode(): Int = impl.hashCode()

--- a/core/commonMain/src/extensions.kt
+++ b/core/commonMain/src/extensions.kt
@@ -26,7 +26,8 @@ import kotlinx.collections.immutable.implementations.persistentOrderedSet.Persis
  *
  * The mutable set passed to the [mutator] closure has the same contents as this persistent set.
  */
-public inline fun <T> PersistentSet<T>.mutate(mutator: (MutableSet<T>) -> Unit): PersistentSet<T> = builder().apply(mutator).build()
+public inline fun <T> PersistentSet<T>.mutate(mutator: (MutableSet<T>) -> Unit): PersistentSet<T> =
+    builder().apply(mutator).build()
 
 /**
  * Returns a new persistent list with the provided modifications applied,
@@ -34,7 +35,8 @@ public inline fun <T> PersistentSet<T>.mutate(mutator: (MutableSet<T>) -> Unit):
  *
  * The mutable list passed to the [mutator] closure has the same contents as this persistent list.
  */
-public inline fun <T> PersistentList<T>.mutate(mutator: (MutableList<T>) -> Unit): PersistentList<T> = builder().apply(mutator).build()
+public inline fun <T> PersistentList<T>.mutate(mutator: (MutableList<T>) -> Unit): PersistentList<T> =
+    builder().apply(mutator).build()
 
 /**
  * Returns a new persistent map with the provided modifications applied,
@@ -44,7 +46,7 @@ public inline fun <T> PersistentList<T>.mutate(mutator: (MutableList<T>) -> Unit
  */
 @Suppress("UNCHECKED_CAST")
 public inline fun <K, V> PersistentMap<out K, V>.mutate(mutator: (MutableMap<K, V>) -> Unit): PersistentMap<K, V> =
-        (this as PersistentMap<K, V>).builder().apply(mutator).build()
+    (this as PersistentMap<K, V>).builder().apply(mutator).build()
 
 
 /**
@@ -64,22 +66,22 @@ public inline operator fun <E> PersistentCollection<E>.minus(element: E): Persis
  * Returns a new persistent collection with elements of the specified [elements] collection added,
  * or this instance if no modifications were made in the result of this operation.
  */
-public operator fun <E> PersistentCollection<E>.plus(elements: Iterable<E>): PersistentCollection<E>
-        = if (elements is Collection) addingAll(elements) else builder().also { it.addAll(elements) }.build()
+public operator fun <E> PersistentCollection<E>.plus(elements: Iterable<E>): PersistentCollection<E> =
+    if (elements is Collection) addingAll(elements) else builder().also { it.addAll(elements) }.build()
 
 /**
  * Returns a new persistent collection with elements of the specified [elements] array added,
  * or this instance if no modifications were made in the result of this operation.
  */
-public operator fun <E> PersistentCollection<E>.plus(elements: Array<out E>): PersistentCollection<E>
-        = builder().also { it.addAll(elements) }.build()
+public operator fun <E> PersistentCollection<E>.plus(elements: Array<out E>): PersistentCollection<E> =
+    builder().also { it.addAll(elements) }.build()
 
 /**
  * Returns a new persistent collection with elements of the specified [elements] sequence added,
  * or this instance if no modifications were made in the result of this operation.
  */
-public operator fun <E> PersistentCollection<E>.plus(elements: Sequence<E>): PersistentCollection<E>
-        = builder().also { it.addAll(elements) }.build()
+public operator fun <E> PersistentCollection<E>.plus(elements: Sequence<E>): PersistentCollection<E> =
+    builder().also { it.addAll(elements) }.build()
 
 
 /**
@@ -87,24 +89,24 @@ public operator fun <E> PersistentCollection<E>.plus(elements: Sequence<E>): Per
  * except the elements contained in the specified [elements] collection,
  * or this instance if there are no elements to remove.
  */
-public operator fun <E> PersistentCollection<E>.minus(elements: Iterable<E>): PersistentCollection<E>
-        = if (elements is Collection) removingAll(elements) else builder().also { it.removeAll(elements) }.build()
+public operator fun <E> PersistentCollection<E>.minus(elements: Iterable<E>): PersistentCollection<E> =
+    if (elements is Collection) removingAll(elements) else builder().also { it.removeAll(elements) }.build()
 
 /**
  * Returns a new persistent collection containing all elements of this collection
  * except the elements contained in the specified [elements] array,
  * or this instance if there are no elements to remove.
  */
-public operator fun <E> PersistentCollection<E>.minus(elements: Array<out E>): PersistentCollection<E>
-        = builder().also { it.removeAll(elements) }.build()
+public operator fun <E> PersistentCollection<E>.minus(elements: Array<out E>): PersistentCollection<E> =
+    builder().also { it.removeAll(elements) }.build()
 
 /**
  * Returns a new persistent collection containing all elements of this collection
  * except the elements contained in the specified [elements] sequence,
  * or this instance if there are no elements to remove.
  */
-public operator fun <E> PersistentCollection<E>.minus(elements: Sequence<E>): PersistentCollection<E>
-        =  builder().also { it.removeAll(elements) }.build()
+public operator fun <E> PersistentCollection<E>.minus(elements: Sequence<E>): PersistentCollection<E> =
+    builder().also { it.removeAll(elements) }.build()
 
 
 /**
@@ -125,8 +127,8 @@ public inline operator fun <E> PersistentList<E>.minus(element: E): PersistentLi
  *
  * The elements are appended in the order they appear in the specified collection.
  */
-public operator fun <E> PersistentList<E>.plus(elements: Iterable<E>): PersistentList<E>
-        = if (elements is Collection) addingAll(elements) else mutate { it.addAll(elements) }
+public operator fun <E> PersistentList<E>.plus(elements: Iterable<E>): PersistentList<E> =
+    if (elements is Collection) addingAll(elements) else mutate { it.addAll(elements) }
 
 /**
  * Returns a new persistent list with elements of the specified [elements] array appended,
@@ -134,8 +136,8 @@ public operator fun <E> PersistentList<E>.plus(elements: Iterable<E>): Persisten
  *
  * The elements are appended in the order they appear in the specified array.
  */
-public operator fun <E> PersistentList<E>.plus(elements: Array<out E>): PersistentList<E>
-        = mutate { it.addAll(elements) }
+public operator fun <E> PersistentList<E>.plus(elements: Array<out E>): PersistentList<E> =
+    mutate { it.addAll(elements) }
 
 /**
  * Returns a new persistent list with elements of the specified [elements] sequence appended,
@@ -143,8 +145,8 @@ public operator fun <E> PersistentList<E>.plus(elements: Array<out E>): Persiste
  *
  * The elements are appended in the order they appear in the specified sequence.
  */
-public operator fun <E> PersistentList<E>.plus(elements: Sequence<E>): PersistentList<E>
-        = mutate { it.addAll(elements) }
+public operator fun <E> PersistentList<E>.plus(elements: Sequence<E>): PersistentList<E> =
+    mutate { it.addAll(elements) }
 
 
 /**
@@ -152,24 +154,24 @@ public operator fun <E> PersistentList<E>.plus(elements: Sequence<E>): Persisten
  * except the elements contained in the specified [elements] collection,
  * or this instance if there are no elements to remove.
  */
-public operator fun <E> PersistentList<E>.minus(elements: Iterable<E>): PersistentList<E>
-        = if (elements is Collection) removingAll(elements) else mutate { it.removeAll(elements) }
+public operator fun <E> PersistentList<E>.minus(elements: Iterable<E>): PersistentList<E> =
+    if (elements is Collection) removingAll(elements) else mutate { it.removeAll(elements) }
 
 /**
  * Returns a new persistent list containing all elements of this list
  * except the elements contained in the specified [elements] array,
  * or this instance if there are no elements to remove.
  */
-public operator fun <E> PersistentList<E>.minus(elements: Array<out E>): PersistentList<E>
-        = mutate { it.removeAll(elements) }
+public operator fun <E> PersistentList<E>.minus(elements: Array<out E>): PersistentList<E> =
+    mutate { it.removeAll(elements) }
 
 /**
  * Returns a new persistent list containing all elements of this list
  * except the elements contained in the specified [elements] sequence,
  * or this instance if there are no elements to remove.
  */
-public operator fun <E> PersistentList<E>.minus(elements: Sequence<E>): PersistentList<E>
-        = mutate { it.removeAll(elements) }
+public operator fun <E> PersistentList<E>.minus(elements: Sequence<E>): PersistentList<E> =
+    mutate { it.removeAll(elements) }
 
 
 /**
@@ -189,22 +191,20 @@ public inline operator fun <E> PersistentSet<E>.minus(element: E): PersistentSet
  * Returns a new persistent set with elements of the specified [elements] collection added,
  * or this instance if it already contains every element of the specified collection.
  */
-public operator fun <E> PersistentSet<E>.plus(elements: Iterable<E>): PersistentSet<E>
-        = if (elements is Collection) addingAll(elements) else mutate { it.addAll(elements) }
+public operator fun <E> PersistentSet<E>.plus(elements: Iterable<E>): PersistentSet<E> =
+    if (elements is Collection) addingAll(elements) else mutate { it.addAll(elements) }
 
 /**
  * Returns a new persistent set with elements of the specified [elements] array added,
  * or this instance if it already contains every element of the specified array.
  */
-public operator fun <E> PersistentSet<E>.plus(elements: Array<out E>): PersistentSet<E>
-        = mutate { it.addAll(elements) }
+public operator fun <E> PersistentSet<E>.plus(elements: Array<out E>): PersistentSet<E> = mutate { it.addAll(elements) }
 
 /**
  * Returns a new persistent set with elements of the specified [elements] sequence added,
  * or this instance if it already contains every element of the specified sequence.
  */
-public operator fun <E> PersistentSet<E>.plus(elements: Sequence<E>): PersistentSet<E>
-        = mutate { it.addAll(elements) }
+public operator fun <E> PersistentSet<E>.plus(elements: Sequence<E>): PersistentSet<E> = mutate { it.addAll(elements) }
 
 
 /**
@@ -212,39 +212,39 @@ public operator fun <E> PersistentSet<E>.plus(elements: Sequence<E>): Persistent
  * except the elements contained in the specified [elements] collection,
  * or this instance if there are no elements to remove.
  */
-public operator fun <E> PersistentSet<E>.minus(elements: Iterable<E>): PersistentSet<E>
-        = if (elements is Collection) removingAll(elements) else mutate { it.removeAll(elements) }
+public operator fun <E> PersistentSet<E>.minus(elements: Iterable<E>): PersistentSet<E> =
+    if (elements is Collection) removingAll(elements) else mutate { it.removeAll(elements) }
 
 /**
  * Returns a new persistent set containing all elements of this set
  * except the elements contained in the specified [elements] array,
  * or this instance if there are no elements to remove.
  */
-public operator fun <E> PersistentSet<E>.minus(elements: Array<out E>): PersistentSet<E>
-        = mutate { it.removeAll(elements) }
+public operator fun <E> PersistentSet<E>.minus(elements: Array<out E>): PersistentSet<E> =
+    mutate { it.removeAll(elements) }
 
 /**
  * Returns a new persistent set containing all elements of this set
  * except the elements contained in the specified [elements] sequence,
  * or this instance if there are no elements to remove.
  */
-public operator fun <E> PersistentSet<E>.minus(elements: Sequence<E>): PersistentSet<E>
-        = mutate { it.removeAll(elements) }
+public operator fun <E> PersistentSet<E>.minus(elements: Sequence<E>): PersistentSet<E> =
+    mutate { it.removeAll(elements) }
 
 /**
  * Returns a new persistent set with elements in this set that are also
  * contained in the specified [elements] collection,
  * or this instance if no modifications were made in the result of this operation.
  */
-public infix fun <E> PersistentSet<E>.intersect(elements: Iterable<E>): PersistentSet<E>
-        = if (elements is Collection) retainingAll(elements) else mutate { it.retainAll(elements) }
+public infix fun <E> PersistentSet<E>.intersect(elements: Iterable<E>): PersistentSet<E> =
+    if (elements is Collection) retainingAll(elements) else mutate { it.retainAll(elements) }
 
 /**
  * Returns a new persistent set with elements in this collection that are also
  * contained in the specified [elements] collection.
  */
-public infix fun <E> PersistentCollection<E>.intersect(elements: Iterable<E>): PersistentSet<E>
-        = this.toPersistentSet().intersect(elements)
+public infix fun <E> PersistentCollection<E>.intersect(elements: Iterable<E>): PersistentSet<E> =
+    this.toPersistentSet().intersect(elements)
 
 /**
  * Returns a new persistent map with an entry from the specified key-value [pair] added,
@@ -254,26 +254,29 @@ public infix fun <E> PersistentCollection<E>.intersect(elements: Iterable<E>): P
  * the old value is replaced by the value from the specified [pair].
  */
 @Suppress("UNCHECKED_CAST")
-public inline operator fun <K, V> PersistentMap<out K, V>.plus(pair: Pair<K, V>): PersistentMap<K, V>
-        = (this as PersistentMap<K, V>).putting(pair.first, pair.second)
+public inline operator fun <K, V> PersistentMap<out K, V>.plus(pair: Pair<K, V>): PersistentMap<K, V> =
+    (this as PersistentMap<K, V>).putting(pair.first, pair.second)
 
 /**
  * Returns a new persistent map with entries from the specified key-value pairs added,
  * or this instance if no modifications were made in the result of this operation.
  */
-public inline operator fun <K, V> PersistentMap<out K, V>.plus(pairs: Iterable<Pair<K, V>>): PersistentMap<K, V> = puttingAll(pairs)
+public inline operator fun <K, V> PersistentMap<out K, V>.plus(pairs: Iterable<Pair<K, V>>): PersistentMap<K, V> =
+    puttingAll(pairs)
 
 /**
  * Returns a new persistent map with entries from the specified key-value pairs added,
  * or this instance if no modifications were made in the result of this operation.
  */
-public inline operator fun <K, V> PersistentMap<out K, V>.plus(pairs: Array<out Pair<K, V>>): PersistentMap<K, V> = puttingAll(pairs)
+public inline operator fun <K, V> PersistentMap<out K, V>.plus(pairs: Array<out Pair<K, V>>): PersistentMap<K, V> =
+    puttingAll(pairs)
 
 /**
  * Returns a new persistent map with entries from the specified key-value pairs added,
  * or this instance if no modifications were made in the result of this operation.
  */
-public inline operator fun <K, V> PersistentMap<out K, V>.plus(pairs: Sequence<Pair<K, V>>): PersistentMap<K, V> = puttingAll(pairs)
+public inline operator fun <K, V> PersistentMap<out K, V>.plus(pairs: Sequence<Pair<K, V>>): PersistentMap<K, V> =
+    puttingAll(pairs)
 
 /**
  * Returns a new persistent map with keys and values from the specified [map] associated,
@@ -282,7 +285,8 @@ public inline operator fun <K, V> PersistentMap<out K, V>.plus(pairs: Sequence<P
  * The effect of this call is equivalent to that of calling `put(k, v)` once for each
  * mapping from key `k` to value `v` in the specified map.
  */
-public inline operator fun <K, V> PersistentMap<out K, V>.plus(map: Map<out K, V>): PersistentMap<K, V> = puttingAll(map)
+public inline operator fun <K, V> PersistentMap<out K, V>.plus(map: Map<out K, V>): PersistentMap<K, V> =
+    puttingAll(map)
 
 
 /**
@@ -393,38 +397,39 @@ public fun <K, V> PersistentMap<out K, V>.putAll(pairs: Sequence<Pair<K, V>>): P
  * or this instance if it contains no mapping for the key.
  */
 @Suppress("UNCHECKED_CAST")
-public operator fun <K, V> PersistentMap<out K, V>.minus(key: K): PersistentMap<K, V>
-        = (this as PersistentMap<K, V>).removing(key)
+public operator fun <K, V> PersistentMap<out K, V>.minus(key: K): PersistentMap<K, V> =
+    (this as PersistentMap<K, V>).removing(key)
 
 /**
  * Returns a new persistent map containing all entries of this map
  * except those whose keys are contained in the specified [keys] collection,
  * or this instance if there are no entries to remove.
  */
-public operator fun <K, V> PersistentMap<out K, V>.minus(keys: Iterable<K>): PersistentMap<K, V>
-        = mutate { it.minusAssign(keys) }
+public operator fun <K, V> PersistentMap<out K, V>.minus(keys: Iterable<K>): PersistentMap<K, V> =
+    mutate { it.minusAssign(keys) }
 
 /**
  * Returns a new persistent map containing all entries of this map
  * except those whose keys are contained in the specified [keys] array,
  * or this instance if there are no entries to remove.
  */
-public operator fun <K, V> PersistentMap<out K, V>.minus(keys: Array<out K>): PersistentMap<K, V>
-        = mutate { it.minusAssign(keys) }
+public operator fun <K, V> PersistentMap<out K, V>.minus(keys: Array<out K>): PersistentMap<K, V> =
+    mutate { it.minusAssign(keys) }
 
 /**
  * Returns a new persistent map containing all entries of this map
  * except those whose keys are contained in the specified [keys] sequence,
  * or this instance if there are no entries to remove.
  */
-public operator fun <K, V> PersistentMap<out K, V>.minus(keys: Sequence<K>): PersistentMap<K, V>
-        = mutate { it.minusAssign(keys) }
+public operator fun <K, V> PersistentMap<out K, V>.minus(keys: Sequence<K>): PersistentMap<K, V> =
+    mutate { it.minusAssign(keys) }
 
 
 /**
  * Returns a new persistent list of the specified elements.
  */
-public fun <E> persistentListOf(vararg elements: E): PersistentList<E> = persistentVectorOf<E>().addingAll(elements.asList())
+public fun <E> persistentListOf(vararg elements: E): PersistentList<E> =
+    persistentVectorOf<E>().addingAll(elements.asList())
 
 /**
  * Returns an empty persistent list.
@@ -437,7 +442,8 @@ public fun <E> persistentListOf(): PersistentList<E> = persistentVectorOf()
  *
  * Elements of the returned set are iterated in the order they were specified.
  */
-public fun <E> persistentSetOf(vararg elements: E): PersistentSet<E> = PersistentOrderedSet.emptyOf<E>().addingAll(elements.asList())
+public fun <E> persistentSetOf(vararg elements: E): PersistentSet<E> =
+    PersistentOrderedSet.emptyOf<E>().addingAll(elements.asList())
 
 /**
  * Returns an empty persistent set.
@@ -450,7 +456,8 @@ public fun <E> persistentSetOf(): PersistentSet<E> = PersistentOrderedSet.emptyO
  *
  * Order of the elements in the returned set is unspecified.
  */
-public fun <E> persistentHashSetOf(vararg elements: E): PersistentSet<E> = PersistentHashSet.emptyOf<E>().addingAll(elements.asList())
+public fun <E> persistentHashSetOf(vararg elements: E): PersistentSet<E> =
+    PersistentHashSet.emptyOf<E>().addingAll(elements.asList())
 
 /**
  * Returns an empty persistent set.
@@ -466,7 +473,8 @@ public fun <E> persistentHashSetOf(): PersistentSet<E> = PersistentHashSet.empty
  *
  * Entries of the map are iterated in the order they were specified.
  */
-public fun <K, V> persistentMapOf(vararg pairs: Pair<K, V>): PersistentMap<K, V> = PersistentOrderedMap.emptyOf<K,V>().mutate { it += pairs }
+public fun <K, V> persistentMapOf(vararg pairs: Pair<K, V>): PersistentMap<K, V> =
+    PersistentOrderedMap.emptyOf<K, V>().mutate { it += pairs }
 
 /**
  * Returns an empty persistent map.
@@ -482,7 +490,8 @@ public fun <K, V> persistentMapOf(): PersistentMap<K, V> = PersistentOrderedMap.
  *
  * Order of the entries in the returned map is unspecified.
  */
-public fun <K, V> persistentHashMapOf(vararg pairs: Pair<K, V>): PersistentMap<K, V> = PersistentHashMap.emptyOf<K,V>().mutate { it += pairs }
+public fun <K, V> persistentHashMapOf(vararg pairs: Pair<K, V>): PersistentMap<K, V> =
+    PersistentHashMap.emptyOf<K, V>().mutate { it += pairs }
 
 /**
  * Returns an empty persistent map.
@@ -555,9 +564,7 @@ public fun <K, V> immutableHashMapOf(vararg pairs: Pair<K, V>): PersistentMap<K,
  *
  * If the receiver is already an immutable list, returns it as is.
  */
-public fun <T> Iterable<T>.toImmutableList(): ImmutableList<T> =
-        this as? ImmutableList
-        ?: this.toPersistentList()
+public fun <T> Iterable<T>.toImmutableList(): ImmutableList<T> = this as? ImmutableList ?: this.toPersistentList()
 
 /**
  * Returns an immutable list containing all elements of this array.
@@ -582,7 +589,7 @@ public fun CharSequence.toImmutableList(): ImmutableList<Char> = toPersistentLis
  * If the receiver is a persistent list builder, calls `build` on it and returns the result.
  */
 public fun <T> Iterable<T>.toPersistentList(): PersistentList<T> =
-        this as? PersistentList
+    this as? PersistentList
         ?: (this as? PersistentList.Builder)?.build()
         ?: persistentListOf<T>() + this
 
@@ -611,7 +618,7 @@ public fun CharSequence.toPersistentList(): PersistentList<Char> =
  * Elements of the returned set are iterated in the same order as in this iterable.
  */
 public fun <T> Iterable<T>.toImmutableSet(): ImmutableSet<T> =
-        this as? ImmutableSet<T>
+    this as? ImmutableSet<T>
         ?: (this as? PersistentSet.Builder)?.build()
         ?: persistentSetOf<T>() + this
 
@@ -646,7 +653,7 @@ public fun CharSequence.toImmutableSet(): PersistentSet<Char> = toPersistentSet(
  * Elements of the returned set are iterated in the same order as in this iterable.
  */
 public fun <T> Iterable<T>.toPersistentSet(): PersistentSet<T> =
-        this as? PersistentOrderedSet<T>
+    this as? PersistentOrderedSet<T>
         ?: (this as? PersistentOrderedSetBuilder)?.build()
         ?: PersistentOrderedSet.emptyOf<T>() + this
 
@@ -670,7 +677,7 @@ public fun <T> Sequence<T>.toPersistentSet(): PersistentSet<T> = persistentSetOf
  * Elements of the returned set are iterated in the same order as in this char sequence.
  */
 public fun CharSequence.toPersistentSet(): PersistentSet<Char> =
-        persistentSetOf<Char>().mutate { this.toCollection(it) }
+    persistentSetOf<Char>().mutate { this.toCollection(it) }
 
 
 /**
@@ -681,8 +688,8 @@ public fun CharSequence.toPersistentSet(): PersistentSet<Char> =
  *
  * Order of the elements in the returned set is unspecified.
  */
-public fun <T> Iterable<T>.toPersistentHashSet(): PersistentSet<T>
-    = this as? PersistentHashSet
+public fun <T> Iterable<T>.toPersistentHashSet(): PersistentSet<T> =
+    this as? PersistentHashSet
         ?: (this as? PersistentHashSetBuilder<T>)?.build()
         ?: PersistentHashSet.emptyOf<T>() + this
 
@@ -706,7 +713,7 @@ public fun <T> Sequence<T>.toPersistentHashSet(): PersistentSet<T> = persistentH
  * Order of the elements in the returned set is unspecified.
  */
 public fun CharSequence.toPersistentHashSet(): PersistentSet<Char> =
-        persistentHashSetOf<Char>().mutate { this.toCollection(it) }
+    persistentHashSetOf<Char>().mutate { this.toCollection(it) }
 
 
 /**
@@ -716,8 +723,8 @@ public fun CharSequence.toPersistentHashSet(): PersistentSet<Char> =
  *
  * Entries of the returned map are iterated in the same order as in this map.
  */
-public fun <K, V> Map<K, V>.toImmutableMap(): ImmutableMap<K, V>
-    = this as? ImmutableMap
+public fun <K, V> Map<K, V>.toImmutableMap(): ImmutableMap<K, V> =
+    this as? ImmutableMap
         ?: (this as? PersistentMap.Builder)?.build()
         ?: persistentMapOf<K, V>().puttingAll(this)
 
@@ -729,8 +736,8 @@ public fun <K, V> Map<K, V>.toImmutableMap(): ImmutableMap<K, V>
  *
  * Entries of the returned map are iterated in the same order as in this map.
  */
-public fun <K, V> Map<K, V>.toPersistentMap(): PersistentMap<K, V>
-    = this as? PersistentOrderedMap<K, V>
+public fun <K, V> Map<K, V>.toPersistentMap(): PersistentMap<K, V> =
+    this as? PersistentOrderedMap<K, V>
         ?: (this as? PersistentOrderedMapBuilder<K, V>)?.build()
         ?: PersistentOrderedMap.emptyOf<K, V>().puttingAll(this)
 
@@ -742,7 +749,7 @@ public fun <K, V> Map<K, V>.toPersistentMap(): PersistentMap<K, V>
  *
  * Order of the entries in the returned map is unspecified.
  */
-public fun <K, V> Map<K, V>.toPersistentHashMap(): PersistentMap<K, V>
-        = this as? PersistentHashMap
+public fun <K, V> Map<K, V>.toPersistentHashMap(): PersistentMap<K, V> =
+    this as? PersistentHashMap
         ?: (this as? PersistentHashMapBuilder<K, V>)?.build()
         ?: PersistentHashMap.emptyOf<K, V>().puttingAll(this)

--- a/core/commonMain/src/implementations/immutableList/AbstractListIterator.kt
+++ b/core/commonMain/src/implementations/immutableList/AbstractListIterator.kt
@@ -34,7 +34,7 @@ internal abstract class AbstractListIterator<out E>(var index: Int, var size: In
 }
 
 
-internal class SingleElementListIterator<E>(private val element: E, index: Int): AbstractListIterator<E>(index, 1) {
+internal class SingleElementListIterator<E>(private val element: E, index: Int) : AbstractListIterator<E>(index, 1) {
     override fun next(): E {
         checkHasNext()
         index++

--- a/core/commonMain/src/implementations/immutableList/BufferIterator.kt
+++ b/core/commonMain/src/implementations/immutableList/BufferIterator.kt
@@ -6,9 +6,9 @@
 package kotlinx.collections.immutable.implementations.immutableList
 
 internal class BufferIterator<out T>(
-        private val buffer: Array<T>,
-        index: Int,
-        size: Int
+    private val buffer: Array<T>,
+    index: Int,
+    size: Int
 ) : AbstractListIterator<T>(index, size) {
     override fun next(): T {
         if (!hasNext()) {

--- a/core/commonMain/src/implementations/immutableList/PersistentVector.kt
+++ b/core/commonMain/src/implementations/immutableList/PersistentVector.kt
@@ -20,10 +20,12 @@ import kotlinx.collections.immutable.internal.assert
  * @param rootShift specifies the height of the trie structure, so that `rootShift = (height - 1) * LOG_MAX_BUFFER_SIZE`;
  *        elements in the [root] array are indexed with bits of the index starting from `rootShift` and until `rootShift + LOG_MAX_BUFFER_SIZE`.
  */
-internal class PersistentVector<E>(private val root: Array<Any?>,
-                                   private val tail: Array<Any?>,
-                                   override val size: Int,
-                                   private val rootShift: Int) : AbstractPersistentList<E>() {
+internal class PersistentVector<E>(
+    private val root: Array<Any?>,
+    private val tail: Array<Any?>,
+    override val size: Int,
+    private val rootShift: Int
+) : AbstractPersistentList<E>() {
 
     init {
         require(size > MAX_BUFFER_SIZE) { "Trie-based persistent vector should have at least ${MAX_BUFFER_SIZE + 1} elements, got $size" }
@@ -77,7 +79,8 @@ internal class PersistentVector<E>(private val root: Array<Any?>,
             // don't delve into the leaf level
         } else {
             @Suppress("UNCHECKED_CAST")
-            newRootNode[bufferIndex] = pushTail(newRootNode[bufferIndex] as Array<Any?>?, shift - LOG_MAX_BUFFER_SIZE, tail)
+            newRootNode[bufferIndex] =
+                pushTail(newRootNode[bufferIndex] as Array<Any?>?, shift - LOG_MAX_BUFFER_SIZE, tail)
         }
         return newRootNode
     }
@@ -123,7 +126,13 @@ internal class PersistentVector<E>(private val root: Array<Any?>,
      *
      * [elementCarry] contains the last element of this trie that was popped out by the insertion operation.
      */
-    private fun insertIntoRoot(root: Array<Any?>, shift: Int, index: Int, element: Any?, elementCarry: ObjectRef): Array<Any?> {
+    private fun insertIntoRoot(
+        root: Array<Any?>,
+        shift: Int,
+        index: Int,
+        element: Any?,
+        elementCarry: ObjectRef
+    ): Array<Any?> {
         val bufferIndex = indexSegment(index, shift)
 
         if (shift == 0) {
@@ -138,7 +147,8 @@ internal class PersistentVector<E>(private val root: Array<Any?>,
         val lowerLevelShift = shift - LOG_MAX_BUFFER_SIZE
 
         @Suppress("UNCHECKED_CAST")
-        newRoot[bufferIndex] = insertIntoRoot(root[bufferIndex] as Array<Any?>, lowerLevelShift, index, element, elementCarry)
+        newRoot[bufferIndex] =
+            insertIntoRoot(root[bufferIndex] as Array<Any?>, lowerLevelShift, index, element, elementCarry)
 
         for (i in bufferIndex + 1 until MAX_BUFFER_SIZE) {
             if (newRoot[i] == null) break
@@ -195,6 +205,7 @@ internal class PersistentVector<E>(private val root: Array<Any?>,
         }
         val tailCarry = ObjectRef(null)
         val newRoot = pullLastBuffer(root, shift, rootSize - 1, tailCarry)!!
+
         @Suppress("UNCHECKED_CAST")
         val newTail = tailCarry.value as Array<Any?>
 
@@ -333,8 +344,8 @@ internal class PersistentVector<E>(private val root: Array<Any?>,
             newRoot[bufferIndex] = e
         } else {
             @Suppress("UNCHECKED_CAST")
-            newRoot[bufferIndex] = setInRoot(newRoot[bufferIndex] as Array<Any?>,
-                    shift - LOG_MAX_BUFFER_SIZE, index, e)
+            newRoot[bufferIndex] =
+                setInRoot(newRoot[bufferIndex] as Array<Any?>, shift - LOG_MAX_BUFFER_SIZE, index, e)
         }
         return newRoot
     }

--- a/core/commonMain/src/implementations/immutableList/PersistentVectorBuilder.kt
+++ b/core/commonMain/src/implementations/immutableList/PersistentVectorBuilder.kt
@@ -11,16 +11,18 @@ import kotlinx.collections.immutable.internal.ListImplementation.checkPositionIn
 import kotlinx.collections.immutable.internal.MutabilityOwnership
 import kotlinx.collections.immutable.internal.assert
 
-internal class PersistentVectorBuilder<E>(vector: PersistentList<E>,
-                                          vectorRoot: Array<Any?>?,
-                                          vectorTail: Array<Any?>,
-                                          internal var rootShift: Int) : AbstractMutableList<E>(), PersistentList.Builder<E> {
+internal class PersistentVectorBuilder<E>(
+    vector: PersistentList<E>,
+    vectorRoot: Array<Any?>?,
+    vectorTail: Array<Any?>,
+    internal var rootShift: Int
+) : AbstractMutableList<E>(), PersistentList.Builder<E> {
 
     private var builtVector: PersistentList<E>? = vector
     private var ownership = MutabilityOwnership()
 
     internal var root = vectorRoot
-        private set (value) {
+        private set(value) {
             if (value !== field) {
                 builtVector = null
                 field = value
@@ -28,7 +30,7 @@ internal class PersistentVectorBuilder<E>(vector: PersistentList<E>,
         }
 
     internal var tail = vectorTail
-        private set (value) {
+        private set(value) {
             if (value !== field) {
                 builtVector = null
                 field = value
@@ -141,11 +143,13 @@ internal class PersistentVectorBuilder<E>(vector: PersistentList<E>,
             this.rootShift += LOG_MAX_BUFFER_SIZE
             this.size += 1
         }
+
         root == null -> {
             this.root = filledTail
             this.tail = newTail
             this.size += 1
         }
+
         else -> {
             this.root = pushTail(root, filledTail, rootShift)
             this.tail = newTail
@@ -221,13 +225,18 @@ internal class PersistentVectorBuilder<E>(vector: PersistentList<E>,
      *
      * Returns root of the resulting trie.
      */
-    private fun pushBuffersIncreasingHeightIfNeeded(root: Array<Any?>?, rootSize: Int, buffers: Array<Array<Any?>>): Array<Any?> {
+    private fun pushBuffersIncreasingHeightIfNeeded(
+        root: Array<Any?>?,
+        rootSize: Int,
+        buffers: Array<Array<Any?>>
+    ): Array<Any?> {
         val buffersIterator = buffers.iterator()
 
         var mutableRoot = when {
             rootSize shr LOG_MAX_BUFFER_SIZE < 1 shl rootShift ->
                 // if the root trie is not filled entirely, fill it
                 pushBuffers(root, rootSize, rootShift, buffersIterator)
+
             else ->
                 // root is filled entirely, make it mutable
                 makeMutable(root)
@@ -253,7 +262,12 @@ internal class PersistentVectorBuilder<E>(vector: PersistentList<E>,
      * Returns the resulting root.
      */
     @IgnorableReturnValue
-    private fun pushBuffers(root: Array<Any?>?, rootSize: Int, shift: Int, buffersIterator: Iterator<Array<Any?>>): Array<Any?> {
+    private fun pushBuffers(
+        root: Array<Any?>?,
+        rootSize: Int,
+        shift: Int,
+        buffersIterator: Iterator<Array<Any?>>
+    ): Array<Any?> {
         check(buffersIterator.hasNext())
         check(shift >= 0)
 
@@ -266,12 +280,12 @@ internal class PersistentVectorBuilder<E>(vector: PersistentList<E>,
 
         @Suppress("UNCHECKED_CAST")
         mutableRoot[index] =
-                pushBuffers(mutableRoot[index] as Array<Any?>?, rootSize, shift - LOG_MAX_BUFFER_SIZE, buffersIterator)
+            pushBuffers(mutableRoot[index] as Array<Any?>?, rootSize, shift - LOG_MAX_BUFFER_SIZE, buffersIterator)
 
         while (++index < MAX_BUFFER_SIZE && buffersIterator.hasNext()) {
             @Suppress("UNCHECKED_CAST")
             mutableRoot[index] =
-                    pushBuffers(mutableRoot[index] as Array<Any?>?, 0, shift - LOG_MAX_BUFFER_SIZE, buffersIterator)
+                pushBuffers(mutableRoot[index] as Array<Any?>?, 0, shift - LOG_MAX_BUFFER_SIZE, buffersIterator)
         }
         return mutableRoot
     }
@@ -321,7 +335,13 @@ internal class PersistentVectorBuilder<E>(vector: PersistentList<E>,
      *
      * [elementCarry] contains the last element of this trie that was popped out by the insertion operation.
      */
-    private fun insertIntoRoot(root: Array<Any?>, shift: Int, index: Int, element: Any?, elementCarry: ObjectRef): Array<Any?> {
+    private fun insertIntoRoot(
+        root: Array<Any?>,
+        shift: Int,
+        index: Int,
+        element: Any?,
+        elementCarry: ObjectRef
+    ): Array<Any?> {
         val bufferIndex = indexSegment(index, shift)
 
         if (shift == 0) {
@@ -336,13 +356,13 @@ internal class PersistentVectorBuilder<E>(vector: PersistentList<E>,
 
         @Suppress("UNCHECKED_CAST")
         mutableRoot[bufferIndex] =
-                insertIntoRoot(mutableRoot[bufferIndex] as Array<Any?>, lowerLevelShift, index, element, elementCarry)
+            insertIntoRoot(mutableRoot[bufferIndex] as Array<Any?>, lowerLevelShift, index, element, elementCarry)
 
         for (i in bufferIndex + 1 until MAX_BUFFER_SIZE) {
             if (mutableRoot[i] == null) break
             @Suppress("UNCHECKED_CAST")
             mutableRoot[i] =
-                    insertIntoRoot(mutableRoot[i] as Array<Any?>, lowerLevelShift, 0, elementCarry.value, elementCarry)
+                insertIntoRoot(mutableRoot[i] as Array<Any?>, lowerLevelShift, 0, elementCarry.value, elementCarry)
         }
 
         return mutableRoot
@@ -390,12 +410,14 @@ internal class PersistentVectorBuilder<E>(vector: PersistentList<E>,
                 newTail = mutableBuffer()
                 splitToBuffers(elements, index, tail, tailSize, buffers, buffersSize, newTail)
             }
+
             newTailSize > tailSize -> {
                 val rightShift = newTailSize - tailSize
                 newTail = makeMutableShiftingRight(tail, rightShift)
 
                 insertIntoRoot(elements, index, rightShift, buffers, buffersSize, newTail)
             }
+
             else -> {
                 newTail = tail.copyInto(mutableBuffer(), 0, tailSize - newTailSize, tailSize)
 
@@ -423,12 +445,12 @@ internal class PersistentVectorBuilder<E>(vector: PersistentList<E>,
      * Elements that do not fit [nullBuffers] buffers are copied to the [nextBuffer].
      */
     private fun insertIntoRoot(
-            elements: Collection<E>,
-            index: Int,
-            rightShift: Int,
-            buffers: Array<Array<Any?>?>,
-            nullBuffers: Int,
-            nextBuffer: Array<Any?>
+        elements: Collection<E>,
+        index: Int,
+        rightShift: Int,
+        buffers: Array<Array<Any?>?>,
+        nullBuffers: Int,
+        nextBuffer: Array<Any?>
     ) {
         checkNotNull(root)
 
@@ -452,11 +474,11 @@ internal class PersistentVectorBuilder<E>(vector: PersistentList<E>,
      * Returns leaf at the [startLeafIndex].
      */
     private fun shiftLeafBuffers(
-            startLeafIndex: Int,
-            rightShift: Int,
-            buffers: Array<Array<Any?>?>,
-            nullBuffers: Int,
-            nextBuffer: Array<Any?>
+        startLeafIndex: Int,
+        rightShift: Int,
+        buffers: Array<Array<Any?>?>,
+        nullBuffers: Int,
+        nextBuffer: Array<Any?>
     ): Array<Any?> {
         checkNotNull(root)
 
@@ -483,13 +505,13 @@ internal class PersistentVectorBuilder<E>(vector: PersistentList<E>,
      * Elements that do not fit [nullBuffers] buffers are copied to the [nextBuffer].
      */
     private fun splitToBuffers(
-            elements: Collection<E>,
-            index: Int,
-            startBuffer: Array<Any?>,
-            startBufferSize: Int,
-            buffers: Array<Array<Any?>?>,
-            nullBuffers: Int,
-            nextBuffer: Array<Any?>
+        elements: Collection<E>,
+        index: Int,
+        startBuffer: Array<Any?>,
+        startBufferSize: Int,
+        buffers: Array<Array<Any?>?>,
+        nullBuffers: Int,
+        nextBuffer: Array<Any?>
     ) {
         check(nullBuffers >= 1)
 
@@ -515,7 +537,12 @@ internal class PersistentVectorBuilder<E>(vector: PersistentList<E>,
                 buffers[--newNullBuffers] = newNextBuffer
             }
             firstBuffer.copyInto(nextBuffer, 0, startBufferSize - toCopyToLast, startBufferSize)
-            firstBuffer.copyInto(newNextBuffer, endBufferEndIndex + 1, startBufferStartIndex, startBufferSize - toCopyToLast)
+            firstBuffer.copyInto(
+                newNextBuffer,
+                endBufferEndIndex + 1,
+                startBufferStartIndex,
+                startBufferSize - toCopyToLast
+            )
         }
 
         val elementsIterator = elements.iterator()
@@ -619,7 +646,7 @@ internal class PersistentVectorBuilder<E>(vector: PersistentList<E>,
         }
         @Suppress("UNCHECKED_CAST")
         mutableRoot[bufferIndex] =
-                removeFromRootAt(mutableRoot[bufferIndex] as Array<Any?>, lowerLevelShift, index, tailCarry)
+            removeFromRootAt(mutableRoot[bufferIndex] as Array<Any?>, lowerLevelShift, index, tailCarry)
 
         return mutableRoot
     }
@@ -732,18 +759,24 @@ internal class PersistentVectorBuilder<E>(vector: PersistentList<E>,
 
         while (leafIterator.hasNext()) {
             val leaf = leafIterator.next()
-            bufferSize = recyclableRemoveAll(predicate, leaf, MAX_BUFFER_SIZE, bufferSize, bufferRef, recyclableBuffers, buffers)
+            bufferSize =
+                recyclableRemoveAll(predicate, leaf, MAX_BUFFER_SIZE, bufferSize, bufferRef, recyclableBuffers, buffers)
         }
 
         // handle the tail
-        val newTailSize = recyclableRemoveAll(predicate, tail, tailSize, bufferSize, bufferRef, recyclableBuffers, buffers)
+        val newTailSize =
+            recyclableRemoveAll(predicate, tail, tailSize, bufferSize, bufferRef, recyclableBuffers, buffers)
 
         @Suppress("UNCHECKED_CAST")
         val newTail = bufferRef.value as Array<Any?>
         newTail.fill(null, newTailSize, MAX_BUFFER_SIZE)
 
         // build the root
-        val newRoot = if (buffers.isEmpty()) root!! else pushBuffers(root, unaffectedElementsCount, rootShift, buffers.iterator())
+        val newRoot = if (buffers.isEmpty()) {
+            root!!
+        } else {
+            pushBuffers(root, unaffectedElementsCount, rootShift, buffers.iterator())
+        }
         val newRootSize = unaffectedElementsCount + (buffers.size shl LOG_MAX_BUFFER_SIZE)
 
         root = retainFirst(newRoot, newRootSize)
@@ -791,6 +824,7 @@ internal class PersistentVectorBuilder<E>(vector: PersistentList<E>,
         }
 
         val lastIndex = indexSegment(index, shift)
+
         @Suppress("UNCHECKED_CAST")
         val newChild = nullifyAfter(root[lastIndex] as Array<Any?>, index, shift - LOG_MAX_BUFFER_SIZE)
 
@@ -846,10 +880,10 @@ internal class PersistentVectorBuilder<E>(vector: PersistentList<E>,
      * Returns the filled size of the buffer stored in the [bufferRef].
      */
     private fun removeAll(
-            predicate: (E) -> Boolean,
-            buffer: Array<Any?>,
-            bufferSize: Int,
-            bufferRef: ObjectRef
+        predicate: (E) -> Boolean,
+        buffer: Array<Any?>,
+        bufferSize: Int,
+        bufferRef: ObjectRef
     ): Int {
         var newBuffer = buffer
         var newBufferSize = bufferSize
@@ -888,13 +922,13 @@ internal class PersistentVectorBuilder<E>(vector: PersistentList<E>,
      * Returns the filled size of the buffer stored in the [bufferRef].
      */
     private fun recyclableRemoveAll(
-            predicate: (E) -> Boolean,
-            buffer: Array<Any?>,
-            bufferSize: Int,
-            toBufferSize: Int,
-            bufferRef: ObjectRef,
-            recyclableBuffers: MutableList<Array<Any?>>,
-            buffers: MutableList<Array<Any?>>
+        predicate: (E) -> Boolean,
+        buffer: Array<Any?>,
+        bufferSize: Int,
+        toBufferSize: Int,
+        bufferRef: ObjectRef,
+        recyclableBuffers: MutableList<Array<Any?>>,
+        buffers: MutableList<Array<Any?>>
     ): Int {
         if (isMutable(buffer)) {
             recyclableBuffers.add(buffer)
@@ -940,7 +974,9 @@ internal class PersistentVectorBuilder<E>(vector: PersistentList<E>,
             val mutableTail = makeMutable(tail)
 
             // Creating new tail implies structural change.
-            if (mutableTail !== tail) { modCount++ }
+            if (mutableTail !== tail) {
+                modCount++
+            }
 
             val tailIndex = index and MAX_BUFFER_SIZE_MINUS_ONE
             val oldElement = mutableTail[tailIndex]
@@ -965,7 +1001,9 @@ internal class PersistentVectorBuilder<E>(vector: PersistentList<E>,
             // Actually, while descending to this leaf several nodes could be recreated.
             // However, this builder is exclusive owner of this leaf iff it is exclusive owner of all leaf's ancestors.
             // Hence, checking recreation of this leaf is enough to determine if a structural change occurred.
-            if (mutableRoot !== root) { modCount++ }
+            if (mutableRoot !== root) {
+                modCount++
+            }
 
             oldElementCarry.value = mutableRoot[bufferIndex]
             mutableRoot[bufferIndex] = e
@@ -973,7 +1011,7 @@ internal class PersistentVectorBuilder<E>(vector: PersistentList<E>,
         }
         @Suppress("UNCHECKED_CAST")
         mutableRoot[bufferIndex] =
-                setInRoot(mutableRoot[bufferIndex] as Array<Any?>, shift - LOG_MAX_BUFFER_SIZE, index, e, oldElementCarry)
+            setInRoot(mutableRoot[bufferIndex] as Array<Any?>, shift - LOG_MAX_BUFFER_SIZE, index, e, oldElementCarry)
         return mutableRoot
     }
 

--- a/core/commonMain/src/implementations/immutableList/PersistentVectorIterator.kt
+++ b/core/commonMain/src/implementations/immutableList/PersistentVectorIterator.kt
@@ -5,11 +5,13 @@
 
 package kotlinx.collections.immutable.implementations.immutableList
 
-internal class PersistentVectorIterator<out T>(root: Array<Any?>,
-                                               private val tail: Array<T>,
-                                               index: Int,
-                                               size: Int,
-                                               trieHeight: Int) : AbstractListIterator<T>(index, size) {
+internal class PersistentVectorIterator<out T>(
+    root: Array<Any?>,
+    private val tail: Array<T>,
+    index: Int,
+    size: Int,
+    trieHeight: Int
+) : AbstractListIterator<T>(index, size) {
     private val trieIterator: TrieIterator<T>
 
     init {

--- a/core/commonMain/src/implementations/immutableList/PersistentVectorMutableIterator.kt
+++ b/core/commonMain/src/implementations/immutableList/PersistentVectorMutableIterator.kt
@@ -13,8 +13,8 @@ package kotlinx.collections.immutable.implementations.immutableList
  * whereas tail elements are iterated directly from this class.
  */
 internal class PersistentVectorMutableIterator<T>(
-        private val builder: PersistentVectorBuilder<T>,
-        index: Int
+    private val builder: PersistentVectorBuilder<T>,
+    index: Int
 ) : MutableListIterator<T>, AbstractListIterator<T>(index, builder.size) {
 
     /**
@@ -22,11 +22,13 @@ internal class PersistentVectorMutableIterator<T>(
      * Used to check if the [PersistentVectorBuilder] was modified outside this iterator.
      */
     private var expectedModCount = builder.getModCount()
+
     /**
      * Iterates over leaves of the builder.root trie.
      * This property is equal to null if builder.root is null.
      */
     private var trieIterator: TrieIterator<T>? = null
+
     /**
      * Index of the element this iterator returned from last invocation of next() or previous().
      * Used to remove or set new value at this index.

--- a/core/commonMain/src/implementations/immutableList/TrieIterator.kt
+++ b/core/commonMain/src/implementations/immutableList/TrieIterator.kt
@@ -5,10 +5,12 @@
 
 package kotlinx.collections.immutable.implementations.immutableList
 
-internal class TrieIterator<out E>(root: Array<Any?>,
-                                   index: Int,
-                                   size: Int,
-                                   private var height: Int) : AbstractListIterator<E>(index, size) {
+internal class TrieIterator<out E>(
+    root: Array<Any?>,
+    index: Int,
+    size: Int,
+    private var height: Int
+) : AbstractListIterator<E>(index, size) {
     private var path: Array<Any?> = arrayOfNulls<Any?>(height)
     private var isInRightEdge = index == size
 

--- a/core/commonMain/src/implementations/immutableList/Utils.kt
+++ b/core/commonMain/src/implementations/immutableList/Utils.kt
@@ -33,10 +33,10 @@ internal fun presizedBufferWith(element: Any?): Array<Any?> {
  * For each upper level `shift` increments by [LOG_MAX_BUFFER_SIZE].
  */
 internal fun indexSegment(index: Int, shift: Int): Int =
-        (index shr shift) and MAX_BUFFER_SIZE_MINUS_ONE
+    (index shr shift) and MAX_BUFFER_SIZE_MINUS_ONE
 
 /**
  * Returns the size of trie part of a persistent vector of the specified [vectorSize].
  */
 internal fun rootSize(vectorSize: Int) =
-        (vectorSize - 1) and MAX_BUFFER_SIZE_MINUS_ONE.inv()
+    (vectorSize - 1) and MAX_BUFFER_SIZE_MINUS_ONE.inv()

--- a/core/commonMain/src/implementations/immutableMap/PersistentHashMap.kt
+++ b/core/commonMain/src/implementations/immutableMap/PersistentHashMap.kt
@@ -12,8 +12,10 @@ import kotlinx.collections.immutable.implementations.persistentOrderedMap.Persis
 import kotlinx.collections.immutable.implementations.persistentOrderedMap.PersistentOrderedMapBuilder
 import kotlinx.collections.immutable.mutate
 
-internal class PersistentHashMap<K, V>(internal val node: TrieNode<K, V>,
-                                       override val size: Int): AbstractMap<K, V>(), PersistentMap<K, V> {
+internal class PersistentHashMap<K, V>(
+    internal val node: TrieNode<K, V>,
+    override val size: Int
+) : AbstractMap<K, V>(), PersistentMap<K, V> {
 
     override val keys: ImmutableSet<K>
         get() {
@@ -57,7 +59,8 @@ internal class PersistentHashMap<K, V>(internal val node: TrieNode<K, V>,
         return PersistentHashMap(newNodeResult.node, size + newNodeResult.sizeDelta)
     }
 
-    override fun putting(key: K, value: @UnsafeVariance V): PersistentHashMap<K, V> = @Suppress("DEPRECATION") put(key, value)
+    override fun putting(key: K, value: @UnsafeVariance V): PersistentHashMap<K, V> =
+        @Suppress("DEPRECATION") put(key, value)
 
     @Deprecated(
         "Use removing() instead. For more details, read the documentation for this function.",
@@ -65,8 +68,12 @@ internal class PersistentHashMap<K, V>(internal val node: TrieNode<K, V>,
     )
     override fun remove(key: K): PersistentHashMap<K, V> {
         val newNode = node.remove(key.hashCode(), key, 0)
-        if (node === newNode) { return this }
-        if (newNode == null) { return emptyOf() }
+        if (node === newNode) {
+            return this
+        }
+        if (newNode == null) {
+            return emptyOf()
+        }
         return PersistentHashMap(newNode, size - 1)
     }
 
@@ -78,8 +85,8 @@ internal class PersistentHashMap<K, V>(internal val node: TrieNode<K, V>,
     )
     override fun remove(key: K, value: @UnsafeVariance V): PersistentHashMap<K, V> {
         val newNode = node.remove(key.hashCode(), key, value, 0)
-        if (node === newNode) { return this }
-        if (newNode == null) { return emptyOf() }
+        if (node === newNode) return this
+        if (newNode == null) return emptyOf()
         return PersistentHashMap(newNode, size - 1)
     }
 
@@ -110,22 +117,10 @@ internal class PersistentHashMap<K, V>(internal val node: TrieNode<K, V>,
         if (size != other.size) return false
 
         return when (other) {
-            is PersistentOrderedMap<*, *> -> {
-                node.equalsWith(other.hashMap.node) { a, b ->
-                    a == b.value
-                }
-            }
-            is PersistentOrderedMapBuilder<*, *> -> {
-                node.equalsWith(other.hashMapBuilder.node) { a, b ->
-                    a == b.value
-                }
-            }
-            is PersistentHashMap<*, *> -> {
-                node.equalsWith(other.node) { a, b -> a == b }
-            }
-            is PersistentHashMapBuilder<*, *> -> {
-                node.equalsWith(other.node) { a, b -> a == b }
-            }
+            is PersistentOrderedMap<*, *> -> node.equalsWith(other.hashMap.node) { a, b -> a == b.value }
+            is PersistentOrderedMapBuilder<*, *> -> node.equalsWith(other.hashMapBuilder.node) { a, b -> a == b.value }
+            is PersistentHashMap<*, *> -> node.equalsWith(other.node) { a, b -> a == b }
+            is PersistentHashMapBuilder<*, *> -> node.equalsWith(other.node) { a, b -> a == b }
             else -> super.equals(other)
         }
     }
@@ -138,6 +133,7 @@ internal class PersistentHashMap<K, V>(internal val node: TrieNode<K, V>,
 
     internal companion object {
         private val EMPTY = PersistentHashMap(TrieNode.EMPTY, 0)
+
         @Suppress("UNCHECKED_CAST")
         internal fun <K, V> emptyOf(): PersistentHashMap<K, V> = EMPTY as PersistentHashMap<K, V>
     }

--- a/core/commonMain/src/implementations/immutableMap/PersistentHashMapBuilder.kt
+++ b/core/commonMain/src/implementations/immutableMap/PersistentHashMapBuilder.kt
@@ -11,9 +11,10 @@ import kotlinx.collections.immutable.implementations.persistentOrderedMap.Persis
 import kotlinx.collections.immutable.internal.DeltaCounter
 import kotlinx.collections.immutable.internal.MutabilityOwnership
 
-internal class PersistentHashMapBuilder<K, V>(map: PersistentHashMap<K, V>) : PersistentMap.Builder<K, V>, AbstractMutableMap<K, V>() {
+internal class PersistentHashMapBuilder<K, V>(map: PersistentHashMap<K, V>) :
+    PersistentMap.Builder<K, V>, AbstractMutableMap<K, V>() {
     internal var builtMap: PersistentHashMap<K, V>? = map
-        private set 
+        private set
     internal var ownership = MutabilityOwnership()
         private set
     internal var node = map.node
@@ -79,7 +80,7 @@ internal class PersistentHashMapBuilder<K, V>(map: PersistentHashMap<K, V>) : Pe
             val oldSize = this.size
             node = node.mutablePutAll(map.node as TrieNode<K, V>, 0, intersectionCounter, this)
             val newSize = oldSize + map.size - intersectionCounter.count
-            if(oldSize != newSize) this.size = newSize
+            if (oldSize != newSize) this.size = newSize
         }
         else super.putAll(from)
     }
@@ -110,22 +111,10 @@ internal class PersistentHashMapBuilder<K, V>(map: PersistentHashMap<K, V>) : Pe
         if (size != other.size) return false
 
         return when (other) {
-            is PersistentHashMap<*, *> -> {
-                node.equalsWith(other.node) { a, b -> a == b }
-            }
-            is PersistentHashMapBuilder<*, *> -> {
-                node.equalsWith(other.node) { a, b -> a == b }
-            }
-            is PersistentOrderedMap<*, *> -> {
-                node.equalsWith(other.hashMap.node) { a, b ->
-                    a == b.value
-                }
-            }
-            is PersistentOrderedMapBuilder<*, *> -> {
-                node.equalsWith(other.hashMapBuilder.node) { a, b ->
-                    a == b.value
-                }
-            }
+            is PersistentHashMap<*, *> -> node.equalsWith(other.node) { a, b -> a == b }
+            is PersistentHashMapBuilder<*, *> -> node.equalsWith(other.node) { a, b -> a == b }
+            is PersistentOrderedMap<*, *> -> node.equalsWith(other.hashMap.node) { a, b -> a == b.value }
+            is PersistentOrderedMapBuilder<*, *> -> node.equalsWith(other.hashMapBuilder.node) { a, b -> a == b.value }
             else -> super.equals(other)
         }
     }

--- a/core/commonMain/src/implementations/immutableMap/PersistentHashMapBuilderContentIterators.kt
+++ b/core/commonMain/src/implementations/immutableMap/PersistentHashMapBuilderContentIterators.kt
@@ -9,7 +9,7 @@ import kotlinx.collections.immutable.internal.assert
 
 
 internal class TrieNodeMutableEntriesIterator<K, V>(
-        private val parentIterator: PersistentHashMapBuilderEntriesIterator<K, V>
+    private val parentIterator: PersistentHashMapBuilderEntriesIterator<K, V>
 ) : TrieNodeBaseIterator<K, V, MutableMap.MutableEntry<K, V>>() {
 
     override fun next(): MutableMap.MutableEntry<K, V> {
@@ -21,9 +21,9 @@ internal class TrieNodeMutableEntriesIterator<K, V>(
 }
 
 private class MutableMapEntry<K, V>(
-        private val parentIterator: PersistentHashMapBuilderEntriesIterator<K, V>,
-        key: K,
-        override var value: V
+    private val parentIterator: PersistentHashMapBuilderEntriesIterator<K, V>,
+    key: K,
+    override var value: V
 ) : MapEntry<K, V>(key, value), MutableMap.MutableEntry<K, V> {
 
     override fun setValue(newValue: V): V {
@@ -36,8 +36,8 @@ private class MutableMapEntry<K, V>(
 
 
 internal open class PersistentHashMapBuilderBaseIterator<K, V, T>(
-        private val builder: PersistentHashMapBuilder<K, V>,
-        path: Array<TrieNodeBaseIterator<K, V, T>>
+    private val builder: PersistentHashMapBuilder<K, V>,
+    path: Array<TrieNodeBaseIterator<K, V, T>>
 ) : MutableIterator<T>, PersistentHashMapBaseIterator<K, V, T>(builder.node, path) {
 
     private var lastIteratedKey: K? = null
@@ -57,7 +57,10 @@ internal open class PersistentHashMapBuilderBaseIterator<K, V, T>(
             val currentKey = currentKey()
 
             builder.remove(lastIteratedKey)
-            resetPath(currentKey.hashCode(), builder.node, currentKey, 0, lastIteratedKey.hashCode(), afterRemove = true)
+            resetPath(
+                currentKey.hashCode(), builder.node, currentKey,
+                0, lastIteratedKey.hashCode(), afterRemove = true
+            )
         } else {
             builder.remove(lastIteratedKey)
         }
@@ -72,7 +75,6 @@ internal open class PersistentHashMapBuilderBaseIterator<K, V, T>(
 
         if (hasNext()) {
             val currentKey = currentKey()
-
             builder[key] = newValue
             resetPath(currentKey.hashCode(), builder.node, currentKey, 0)
         } else {
@@ -82,10 +84,17 @@ internal open class PersistentHashMapBuilderBaseIterator<K, V, T>(
         expectedModCount = builder.modCount
     }
 
-    private fun resetPath(keyHash: Int, node: TrieNode<*, *>, key: K, pathIndex: Int, removedKeyHash: Int = 0, afterRemove: Boolean = false) {
+    private fun resetPath(
+        keyHash: Int,
+        node: TrieNode<*, *>,
+        key: K,
+        pathIndex: Int,
+        removedKeyHash: Int = 0,
+        afterRemove: Boolean = false
+    ) {
         val shift = pathIndex * LOG_MAX_BRANCHING_FACTOR
 
-        if (shift > MAX_SHIFT) {    // collision
+        if (shift > MAX_SHIFT) { // collision
             path[pathIndex].reset(node.buffer, node.buffer.size, 0)
             while (path[pathIndex].currentKey() != key) {
                 path[pathIndex].moveToNextKey()
@@ -141,11 +150,12 @@ internal open class PersistentHashMapBuilderBaseIterator<K, V, T>(
 }
 
 internal class PersistentHashMapBuilderEntriesIterator<K, V>(
-        builder: PersistentHashMapBuilder<K, V>
+    builder: PersistentHashMapBuilder<K, V>
 ) : MutableIterator<MutableMap.MutableEntry<K, V>> {
     private val base = PersistentHashMapBuilderBaseIterator<K, V, MutableMap.MutableEntry<K, V>>(
-            builder,
-            Array(TRIE_MAX_HEIGHT + 1) { TrieNodeMutableEntriesIterator(this) }
+        builder, Array(TRIE_MAX_HEIGHT + 1) {
+            TrieNodeMutableEntriesIterator(this)
+        }
     )
 
     override fun hasNext(): Boolean = base.hasNext()
@@ -155,8 +165,10 @@ internal class PersistentHashMapBuilderEntriesIterator<K, V>(
     fun setValue(key: K, newValue: V): Unit = base.setValue(key, newValue)
 }
 
-internal class PersistentHashMapBuilderKeysIterator<K, V>(builder: PersistentHashMapBuilder<K, V>)
-    : PersistentHashMapBuilderBaseIterator<K, V, K>(builder, Array(TRIE_MAX_HEIGHT + 1) { TrieNodeKeysIterator<K, V>() })
+internal class PersistentHashMapBuilderKeysIterator<K, V>(builder: PersistentHashMapBuilder<K, V>) :
+    PersistentHashMapBuilderBaseIterator<K, V, K>(builder, Array(TRIE_MAX_HEIGHT + 1) { TrieNodeKeysIterator<K, V>() })
 
-internal class PersistentHashMapBuilderValuesIterator<K, V>(builder: PersistentHashMapBuilder<K, V>)
-    : PersistentHashMapBuilderBaseIterator<K, V, V>(builder, Array(TRIE_MAX_HEIGHT + 1) { TrieNodeValuesIterator<K, V>() })
+internal class PersistentHashMapBuilderValuesIterator<K, V>(builder: PersistentHashMapBuilder<K, V>) :
+    PersistentHashMapBuilderBaseIterator<K, V, V>(
+        builder, Array(TRIE_MAX_HEIGHT + 1) { TrieNodeValuesIterator<K, V>() }
+    )

--- a/core/commonMain/src/implementations/immutableMap/PersistentHashMapBuilderContentViews.kt
+++ b/core/commonMain/src/implementations/immutableMap/PersistentHashMapBuilderContentViews.kt
@@ -12,16 +12,18 @@ internal abstract class AbstractMapBuilderEntries<E : Map.Entry<K, V>, K, V> : A
     final override fun contains(element: E): Boolean {
         return containsEntry(element)
     }
+
     abstract fun containsEntry(element: Map.Entry<K, V>): Boolean
 
     final override fun remove(element: E): Boolean {
         return removeEntry(element)
     }
+
     abstract fun removeEntry(element: Map.Entry<K, V>): Boolean
 }
 
-internal class PersistentHashMapBuilderEntries<K, V>(private val builder: PersistentHashMapBuilder<K, V>)
-    : AbstractMapBuilderEntries<MutableMap.MutableEntry<K, V>, K, V>() {
+internal class PersistentHashMapBuilderEntries<K, V>(private val builder: PersistentHashMapBuilder<K, V>) :
+    AbstractMapBuilderEntries<MutableMap.MutableEntry<K, V>, K, V>() {
     override fun add(element: MutableMap.MutableEntry<K, V>): Boolean {
         throw UnsupportedOperationException()
     }
@@ -46,7 +48,8 @@ internal class PersistentHashMapBuilderEntries<K, V>(private val builder: Persis
     }
 }
 
-internal class PersistentHashMapBuilderKeys<K, V>(private val builder: PersistentHashMapBuilder<K, V>) : MutableSet<K>, AbstractMutableSet<K>() {
+internal class PersistentHashMapBuilderKeys<K, V>(private val builder: PersistentHashMapBuilder<K, V>) :
+    MutableSet<K>, AbstractMutableSet<K>() {
     override fun add(element: K): Boolean {
         throw UnsupportedOperationException()
     }
@@ -75,7 +78,8 @@ internal class PersistentHashMapBuilderKeys<K, V>(private val builder: Persisten
     }
 }
 
-internal class PersistentHashMapBuilderValues<K, V>(private val builder: PersistentHashMapBuilder<K, V>) : MutableCollection<V>, AbstractMutableCollection<V>() {
+internal class PersistentHashMapBuilderValues<K, V>(private val builder: PersistentHashMapBuilder<K, V>) :
+    MutableCollection<V>, AbstractMutableCollection<V>() {
     override val size: Int
         get() = builder.size
 

--- a/core/commonMain/src/implementations/immutableMap/PersistentHashMapContentIterators.kt
+++ b/core/commonMain/src/implementations/immutableMap/PersistentHashMapContentIterators.kt
@@ -92,18 +92,19 @@ internal class TrieNodeEntriesIterator<out K, out V> : TrieNodeBaseIterator<K, V
 internal open class MapEntry<out K, out V>(override val key: K, override val value: V) : Map.Entry<K, V> {
     override fun hashCode(): Int = key.hashCode() xor value.hashCode()
     override fun equals(other: Any?): Boolean =
-            (other as? Map.Entry<*, *>)?.let { it.key == key && it.value == value } ?: false
+        (other as? Map.Entry<*, *>)?.let { it.key == key && it.value == value } ?: false
 
     override fun toString(): String = key.toString() + "=" + value.toString()
 }
 
 
 internal abstract class PersistentHashMapBaseIterator<K, V, T>(
-        node: TrieNode<K, V>,
-        protected val path: Array<TrieNodeBaseIterator<K, V, T>>
+    node: TrieNode<K, V>,
+    protected val path: Array<TrieNodeBaseIterator<K, V, T>>
 ) : Iterator<T> {
 
     protected var pathLastIndex = 0
+
     @JsName("_hasNext")
     private var hasNext = true
 
@@ -119,7 +120,7 @@ internal abstract class PersistentHashMapBaseIterator<K, V, T>(
         }
         if (path[pathIndex].hasNextNode()) {
             val node = path[pathIndex].currentNode()
-            if (pathIndex == TRIE_MAX_HEIGHT - 1) {     // collision
+            if (pathIndex == TRIE_MAX_HEIGHT - 1) { // collision
                 path[pathIndex + 1].reset(node.buffer, node.buffer.size)
             } else {
                 path[pathIndex + 1].reset(node.buffer, ENTRY_SIZE * node.entryCount())
@@ -133,7 +134,7 @@ internal abstract class PersistentHashMapBaseIterator<K, V, T>(
         if (path[pathLastIndex].hasNextKey()) {
             return
         }
-        for(i in pathLastIndex downTo 0) {
+        for (i in pathLastIndex downTo 0) {
             var result = moveToNextNodeWithData(i)
 
             if (result == -1 && path[i].hasNextNode()) {
@@ -174,11 +175,13 @@ internal abstract class PersistentHashMapBaseIterator<K, V, T>(
     }
 }
 
-internal class PersistentHashMapEntriesIterator<K, V>(node: TrieNode<K, V>)
-    : PersistentHashMapBaseIterator<K, V, Map.Entry<K, V>>(node, Array(TRIE_MAX_HEIGHT + 1) { TrieNodeEntriesIterator<K, V>() })
+internal class PersistentHashMapEntriesIterator<K, V>(node: TrieNode<K, V>) :
+    PersistentHashMapBaseIterator<K, V, Map.Entry<K, V>>(
+        node, Array(TRIE_MAX_HEIGHT + 1) { TrieNodeEntriesIterator<K, V>() }
+    )
 
-internal class PersistentHashMapKeysIterator<K, V>(node: TrieNode<K, V>)
-    : PersistentHashMapBaseIterator<K, V, K>(node, Array(TRIE_MAX_HEIGHT + 1) { TrieNodeKeysIterator<K, V>() })
+internal class PersistentHashMapKeysIterator<K, V>(node: TrieNode<K, V>) :
+    PersistentHashMapBaseIterator<K, V, K>(node, Array(TRIE_MAX_HEIGHT + 1) { TrieNodeKeysIterator<K, V>() })
 
-internal class PersistentHashMapValuesIterator<K, V>(node: TrieNode<K, V>)
-    : PersistentHashMapBaseIterator<K, V, V>(node, Array(TRIE_MAX_HEIGHT + 1) { TrieNodeValuesIterator<K, V>() })
+internal class PersistentHashMapValuesIterator<K, V>(node: TrieNode<K, V>) :
+    PersistentHashMapBaseIterator<K, V, V>(node, Array(TRIE_MAX_HEIGHT + 1) { TrieNodeValuesIterator<K, V>() })

--- a/core/commonMain/src/implementations/immutableMap/PersistentHashMapContentViews.kt
+++ b/core/commonMain/src/implementations/immutableMap/PersistentHashMapContentViews.kt
@@ -9,7 +9,8 @@ import kotlinx.collections.immutable.ImmutableCollection
 import kotlinx.collections.immutable.ImmutableSet
 import kotlinx.collections.immutable.internal.containsEntry
 
-internal class PersistentHashMapEntries<K, V>(private val map: PersistentHashMap<K, V>) : ImmutableSet<Map.Entry<K, V>>, AbstractSet<Map.Entry<K, V>>() {
+internal class PersistentHashMapEntries<K, V>(private val map: PersistentHashMap<K, V>) :
+    ImmutableSet<Map.Entry<K, V>>, AbstractSet<Map.Entry<K, V>>() {
     override val size: Int get() = map.size
 
     override fun contains(element: Map.Entry<K, V>): Boolean {
@@ -21,7 +22,8 @@ internal class PersistentHashMapEntries<K, V>(private val map: PersistentHashMap
     }
 }
 
-internal class PersistentHashMapKeys<K, V>(private val map: PersistentHashMap<K, V>) : ImmutableSet<K>, AbstractSet<K>() {
+internal class PersistentHashMapKeys<K, V>(private val map: PersistentHashMap<K, V>) :
+    ImmutableSet<K>, AbstractSet<K>() {
     override val size: Int
         get() = map.size
 
@@ -34,7 +36,8 @@ internal class PersistentHashMapKeys<K, V>(private val map: PersistentHashMap<K,
     }
 }
 
-internal class PersistentHashMapValues<K, V>(private val map: PersistentHashMap<K, V>) : ImmutableCollection<V>, AbstractCollection<V>() {
+internal class PersistentHashMapValues<K, V>(private val map: PersistentHashMap<K, V>) :
+    ImmutableCollection<V>, AbstractCollection<V>() {
     override val size: Int
         get() = map.size
 

--- a/core/commonMain/src/implementations/immutableMap/TrieNode.kt
+++ b/core/commonMain/src/implementations/immutableMap/TrieNode.kt
@@ -24,7 +24,7 @@ internal const val MAX_SHIFT = 30
  * For each lower level `shift` increments by [LOG_MAX_BRANCHING_FACTOR].
  */
 internal fun indexSegment(index: Int, shift: Int): Int =
-        (index shr shift) and MAX_BRANCHING_FACTOR_MINUS_ONE
+    (index shr shift) and MAX_BRANCHING_FACTOR_MINUS_ONE
 
 private fun <K, V> Array<Any?>.insertEntryAtIndex(keyIndex: Int, key: K, value: V): Array<Any?> {
     val newBuffer = arrayOfNulls<Any?>(this.size + ENTRY_SIZE)
@@ -36,7 +36,7 @@ private fun <K, V> Array<Any?>.insertEntryAtIndex(keyIndex: Int, key: K, value: 
 }
 
 private fun Array<Any?>.replaceEntryWithNode(keyIndex: Int, nodeIndex: Int, newNode: TrieNode<*, *>): Array<Any?> {
-    val newNodeIndex = nodeIndex - ENTRY_SIZE  // place where to insert new node in the new buffer
+    val newNodeIndex = nodeIndex - ENTRY_SIZE // place where to insert new node in the new buffer
     val newBuffer = arrayOfNulls<Any?>(this.size - ENTRY_SIZE + 1)
     this.copyInto(newBuffer, endIndex = keyIndex)
     this.copyInto(newBuffer, keyIndex, startIndex = keyIndex + ENTRY_SIZE, endIndex = nodeIndex)
@@ -48,7 +48,7 @@ private fun Array<Any?>.replaceEntryWithNode(keyIndex: Int, nodeIndex: Int, newN
 private fun <K, V> Array<Any?>.replaceNodeWithEntry(nodeIndex: Int, keyIndex: Int, key: K, value: V): Array<Any?> {
     val newBuffer = this.copyOf(this.size + 1)
     newBuffer.copyInto(newBuffer, nodeIndex + 2, nodeIndex + 1, this.size)
-    newBuffer.copyInto(newBuffer, keyIndex + 2, keyIndex , nodeIndex)
+    newBuffer.copyInto(newBuffer, keyIndex + 2, keyIndex, nodeIndex)
     newBuffer[keyIndex] = key
     newBuffer[keyIndex + 1] = value
     return newBuffer
@@ -69,18 +69,17 @@ private fun Array<Any?>.removeNodeAtIndex(nodeIndex: Int): Array<Any?> {
 }
 
 
-
 internal class TrieNode<K, V>(
-        private var dataMap: Int,
-        private var nodeMap: Int,
-        buffer: Array<Any?>,
-        private val ownedBy: MutabilityOwnership?
+    private var dataMap: Int,
+    private var nodeMap: Int,
+    buffer: Array<Any?>,
+    private val ownedBy: MutabilityOwnership?
 ) {
     constructor(dataMap: Int, nodeMap: Int, buffer: Array<Any?>) : this(dataMap, nodeMap, buffer, null)
 
     internal class ModificationResult<K, V>(var node: TrieNode<K, V>, val sizeDelta: Int) {
         inline fun replaceNode(operation: (TrieNode<K, V>) -> TrieNode<K, V>): ModificationResult<K, V> =
-                apply { node = operation(node) }
+            apply { node = operation(node) }
     }
 
     private fun asInsertResult() = ModificationResult(this, 1)
@@ -170,7 +169,11 @@ internal class TrieNode<K, V>(
         return TrieNode(dataMap, nodeMap, newBuffer)
     }
 
-    private fun mutableUpdateValueAtIndex(keyIndex: Int, value: V, mutator: PersistentHashMapBuilder<K, V>): TrieNode<K, V> {
+    private fun mutableUpdateValueAtIndex(
+        keyIndex: Int,
+        value: V,
+        mutator: PersistentHashMapBuilder<K, V>
+    ): TrieNode<K, V> {
 //        assert(buffer[keyIndex + 1] !== value)
 
         // If the [mutator] is exclusive owner of this node, update value at specified index in-place.
@@ -187,7 +190,12 @@ internal class TrieNode<K, V>(
     }
 
     /** The given [newNode] must not be a part of any persistent map instance. */
-    private fun updateNodeAtIndex(nodeIndex: Int, positionMask: Int, newNode: TrieNode<K, V>, owner: MutabilityOwnership? = null): TrieNode<K, V> {
+    private fun updateNodeAtIndex(
+        nodeIndex: Int,
+        positionMask: Int,
+        newNode: TrieNode<K, V>,
+        owner: MutabilityOwnership? = null
+    ): TrieNode<K, V> {
         if (newNode.hasSingleEntry) {
             if (buffer.size == 1) {
 //                assert(dataMap == 0 && nodeMap xor positionMask == 0)
@@ -218,7 +226,11 @@ internal class TrieNode<K, V>(
         return TrieNode(dataMap, nodeMap xor positionMask, newBuffer)
     }
 
-    private fun mutableRemoveNodeAtIndex(nodeIndex: Int, positionMask: Int, owner: MutabilityOwnership): TrieNode<K, V>? {
+    private fun mutableRemoveNodeAtIndex(
+        nodeIndex: Int,
+        positionMask: Int,
+        owner: MutabilityOwnership
+    ): TrieNode<K, V>? {
 //        assert(hasNodeAt(positionMask))
         if (buffer.size == 1) return null
 
@@ -232,13 +244,22 @@ internal class TrieNode<K, V>(
     }
 
 
-    private fun bufferMoveEntryToNode(keyIndex: Int, positionMask: Int, newKeyHash: Int,
-                                      newKey: K, newValue: V, shift: Int, owner: MutabilityOwnership?): Array<Any?> {
+    private fun bufferMoveEntryToNode(
+        keyIndex: Int,
+        positionMask: Int,
+        newKeyHash: Int,
+        newKey: K,
+        newValue: V,
+        shift: Int,
+        owner: MutabilityOwnership?
+    ): Array<Any?> {
         val storedKey = keyAtIndex(keyIndex)
         val storedKeyHash = storedKey.hashCode()
         val storedValue = valueAtKeyIndex(keyIndex)
-        val newNode = makeNode(storedKeyHash, storedKey, storedValue,
-                newKeyHash, newKey, newValue, shift + LOG_MAX_BRANCHING_FACTOR, owner)
+        val newNode = makeNode(
+            storedKeyHash, storedKey, storedValue,
+            newKeyHash, newKey, newValue, shift + LOG_MAX_BRANCHING_FACTOR, owner
+        )
 
         val nodeIndex = nodeIndex(positionMask) + 1 // place where to insert new node in the current buffer
 
@@ -246,8 +267,14 @@ internal class TrieNode<K, V>(
     }
 
 
-    private fun moveEntryToNode(keyIndex: Int, positionMask: Int, newKeyHash: Int,
-                                newKey: K, newValue: V, shift: Int): TrieNode<K, V> {
+    private fun moveEntryToNode(
+        keyIndex: Int,
+        positionMask: Int,
+        newKeyHash: Int,
+        newKey: K,
+        newValue: V,
+        shift: Int
+    ): TrieNode<K, V> {
 //        assert(hasEntryAt(positionMask))
 //        assert(!hasNodeAt(positionMask))
 
@@ -255,8 +282,15 @@ internal class TrieNode<K, V>(
         return TrieNode(dataMap xor positionMask, nodeMap or positionMask, newBuffer)
     }
 
-    private fun mutableMoveEntryToNode(keyIndex: Int, positionMask: Int, newKeyHash: Int,
-                                       newKey: K, newValue: V, shift: Int, owner: MutabilityOwnership): TrieNode<K, V> {
+    private fun mutableMoveEntryToNode(
+        keyIndex: Int,
+        positionMask: Int,
+        newKeyHash: Int,
+        newKey: K,
+        newValue: V,
+        shift: Int,
+        owner: MutabilityOwnership
+    ): TrieNode<K, V> {
 //        assert(hasEntryAt(positionMask))
 //        assert(!hasNodeAt(positionMask))
 
@@ -271,8 +305,16 @@ internal class TrieNode<K, V>(
     }
 
     /** Creates a new TrieNode for holding two given key value entries */
-    private fun makeNode(keyHash1: Int, key1: K, value1: V,
-                         keyHash2: Int, key2: K, value2: V, shift: Int, owner: MutabilityOwnership?): TrieNode<K, V> {
+    private fun makeNode(
+        keyHash1: Int,
+        key1: K,
+        value1: V,
+        keyHash2: Int,
+        key2: K,
+        value2: V,
+        shift: Int,
+        owner: MutabilityOwnership?
+    ): TrieNode<K, V> {
         if (shift > MAX_SHIFT) {
 //            assert(key1 != key2)
             // when two key hashes are entirely equal: the last level subtrie node stores them just as unordered list
@@ -302,7 +344,11 @@ internal class TrieNode<K, V>(
         return TrieNode(dataMap xor positionMask, nodeMap, newBuffer)
     }
 
-    private fun mutableRemoveEntryAtIndex(keyIndex: Int, positionMask: Int, mutator: PersistentHashMapBuilder<K, V>): TrieNode<K, V>? {
+    private fun mutableRemoveEntryAtIndex(
+        keyIndex: Int,
+        positionMask: Int,
+        mutator: PersistentHashMapBuilder<K, V>
+    ): TrieNode<K, V>? {
 //        assert(hasEntryAt(positionMask))
         mutator.size--
         mutator.operationResult = valueAtKeyIndex(keyIndex)
@@ -423,9 +469,11 @@ internal class TrieNode<K, V>(
         return this
     }
 
-    private fun mutableCollisionPutAll(otherNode: TrieNode<K, V>,
-                                       intersectionCounter: DeltaCounter,
-                                       owner: MutabilityOwnership): TrieNode<K, V> {
+    private fun mutableCollisionPutAll(
+        otherNode: TrieNode<K, V>,
+        intersectionCounter: DeltaCounter,
+        owner: MutabilityOwnership
+    ): TrieNode<K, V> {
         assert(nodeMap == 0)
         assert(dataMap == 0)
         assert(otherNode.nodeMap == 0)
@@ -464,8 +512,14 @@ internal class TrieNode<K, V>(
             when {
                 otherNode.hasNodeAt(positionMask) -> {
                     val otherTargetNode = otherNode.nodeAtIndex(otherNode.nodeIndex(positionMask))
-                    targetNode.mutablePutAll(otherTargetNode, shift + LOG_MAX_BRANCHING_FACTOR, intersectionCounter, mutator)
+                    targetNode.mutablePutAll(
+                        otherTargetNode,
+                        shift + LOG_MAX_BRANCHING_FACTOR,
+                        intersectionCounter,
+                        mutator
+                    )
                 }
+
                 otherNode.hasEntryAt(positionMask) -> {
                     val keyIndex = otherNode.entryKeyIndex(positionMask)
                     val key = otherNode.keyAtIndex(keyIndex)
@@ -475,6 +529,7 @@ internal class TrieNode<K, V>(
                         if (mutator.size == oldSize) intersectionCounter.count++
                     }
                 }
+
                 else -> targetNode
             }
         }
@@ -491,9 +546,13 @@ internal class TrieNode<K, V>(
                         otherTargetNode
                     } else {
                         val value = this.valueAtKeyIndex(keyIndex)
-                        otherTargetNode.mutablePut(key.hashCode(), key, value, shift + LOG_MAX_BRANCHING_FACTOR, mutator)
+                        otherTargetNode.mutablePut(
+                            key.hashCode(), key, value,
+                            shift + LOG_MAX_BRANCHING_FACTOR, mutator
+                        )
                     }
                 }
+
                 else -> otherTargetNode
             }
         }
@@ -522,7 +581,7 @@ internal class TrieNode<K, V>(
         if (nodeMap == 0) return buffer.size / ENTRY_SIZE
         val numValues = dataMap.countOneBits()
         var result = numValues
-        for(i in (numValues * ENTRY_SIZE) until buffer.size) {
+        for (i in (numValues * ENTRY_SIZE) until buffer.size) {
             result += nodeAtIndex(i).calculateSize()
         }
         return result
@@ -533,7 +592,7 @@ internal class TrieNode<K, V>(
         if (nodeMap != otherNode.nodeMap) return false
         if (dataMap != otherNode.dataMap) return false
         for (i in 0 until buffer.size) {
-            if(buffer[i] !== otherNode.buffer[i]) return false
+            if (buffer[i] !== otherNode.buffer[i]) return false
         }
         return true
     }
@@ -579,10 +638,12 @@ internal class TrieNode<K, V>(
         return null
     }
 
-    fun mutablePutAll(otherNode: TrieNode<K, V>,
-                      shift: Int,
-                      intersectionCounter: DeltaCounter,
-                      mutator: PersistentHashMapBuilder<K, V>): TrieNode<K, V> {
+    fun mutablePutAll(
+        otherNode: TrieNode<K, V>,
+        shift: Int,
+        intersectionCounter: DeltaCounter,
+        mutator: PersistentHashMapBuilder<K, V>
+    ): TrieNode<K, V> {
         if (this === otherNode) {
             intersectionCounter += calculateSize()
             return this
@@ -619,7 +680,8 @@ internal class TrieNode<K, V>(
         }
         newNodeMap.forEachOneBit { positionMask, index ->
             val newNodeIndex = mutableNode.buffer.size - 1 - index
-            mutableNode.buffer[newNodeIndex] = mutablePutAllFromOtherNodeCell(otherNode, positionMask, shift, intersectionCounter, mutator)
+            mutableNode.buffer[newNodeIndex] =
+                mutablePutAllFromOtherNodeCell(otherNode, positionMask, shift, intersectionCounter, mutator)
         }
         newDataMap.forEachOneBit { positionMask, index ->
             val newKeyIndex = index * ENTRY_SIZE
@@ -676,7 +738,13 @@ internal class TrieNode<K, V>(
         return insertEntryAt(keyPositionMask, key, value).asInsertResult()
     }
 
-    fun mutablePut(keyHash: Int, key: K, value: @UnsafeVariance V, shift: Int, mutator: PersistentHashMapBuilder<K, V>): TrieNode<K, V> {
+    fun mutablePut(
+        keyHash: Int,
+        key: K,
+        value: @UnsafeVariance V,
+        shift: Int,
+        mutator: PersistentHashMapBuilder<K, V>
+    ): TrieNode<K, V> {
         val keyPositionMask = 1 shl indexSegment(keyHash, shift)
 
         if (hasEntryAt(keyPositionMask)) { // key is directly in buffer
@@ -740,14 +808,12 @@ internal class TrieNode<K, V>(
         return this
     }
 
-    private fun replaceNode(targetNode: TrieNode<K, V>, newNode: TrieNode<K, V>?, nodeIndex: Int, positionMask: Int) = when {
-        newNode == null ->
-            removeNodeAtIndex(nodeIndex, positionMask)
-        targetNode !== newNode ->
-            updateNodeAtIndex(nodeIndex, positionMask, newNode)
-        else ->
-            this
-    }
+    private fun replaceNode(targetNode: TrieNode<K, V>, newNode: TrieNode<K, V>?, nodeIndex: Int, positionMask: Int) =
+        when {
+            newNode == null -> removeNodeAtIndex(nodeIndex, positionMask)
+            targetNode !== newNode -> updateNodeAtIndex(nodeIndex, positionMask, newNode)
+            else -> this
+        }
 
     fun mutableRemove(keyHash: Int, key: K, shift: Int, mutator: PersistentHashMapBuilder<K, V>): TrieNode<K, V>? {
         val keyPositionMask = 1 shl indexSegment(keyHash, shift)
@@ -819,7 +885,13 @@ internal class TrieNode<K, V>(
         return this
     }
 
-    fun mutableRemove(keyHash: Int, key: K, value: @UnsafeVariance V, shift: Int, mutator: PersistentHashMapBuilder<K, V>): TrieNode<K, V>? {
+    fun mutableRemove(
+        keyHash: Int,
+        key: K,
+        value: @UnsafeVariance V,
+        shift: Int,
+        mutator: PersistentHashMapBuilder<K, V>
+    ): TrieNode<K, V>? {
         val keyPositionMask = 1 shl indexSegment(keyHash, shift)
 
         if (hasEntryAt(keyPositionMask)) { // key is directly in buffer
@@ -879,9 +951,9 @@ internal class TrieNode<K, V>(
     }
 
     private fun accept(
-            visitor: (node: TrieNode<K, V>, shift: Int, hash: Int, dataMap: Int, nodeMap: Int) -> Unit,
-            hash: Int,
-            shift: Int
+        visitor: (node: TrieNode<K, V>, shift: Int, hash: Int, dataMap: Int, nodeMap: Int) -> Unit,
+        hash: Int,
+        shift: Int
     ) {
         visitor(this, shift, hash, dataMap, nodeMap)
 

--- a/core/commonMain/src/implementations/immutableSet/PersistentHashSet.kt
+++ b/core/commonMain/src/implementations/immutableSet/PersistentHashSet.kt
@@ -8,8 +8,10 @@ package kotlinx.collections.immutable.implementations.immutableSet
 import kotlinx.collections.immutable.PersistentSet
 import kotlinx.collections.immutable.mutate
 
-internal class PersistentHashSet<E>(internal val node: TrieNode<E>,
-                                    override val size: Int): AbstractSet<E>(), PersistentSet<E> {
+internal class PersistentHashSet<E>(
+    internal val node: TrieNode<E>,
+    override val size: Int
+) : AbstractSet<E>(), PersistentSet<E> {
     override fun contains(element: E): Boolean {
         return node.contains(element.hashCode(), element, 0)
     }
@@ -20,7 +22,7 @@ internal class PersistentHashSet<E>(internal val node: TrieNode<E>,
     )
     override fun add(element: E): PersistentSet<E> {
         val newNode = node.add(element.hashCode(), element, 0)
-        if (node === newNode) { return this }
+        if (node === newNode) return this
         return PersistentHashSet(newNode, size + 1)
     }
 
@@ -39,7 +41,7 @@ internal class PersistentHashSet<E>(internal val node: TrieNode<E>,
     )
     override fun remove(element: E): PersistentSet<E> {
         val newNode = node.remove(element.hashCode(), element, 0)
-        if (node === newNode) { return this }
+        if (node === newNode) return this
         return PersistentHashSet(newNode, size - 1)
     }
 

--- a/core/commonMain/src/implementations/immutableSet/PersistentHashSetBuilder.kt
+++ b/core/commonMain/src/implementations/immutableSet/PersistentHashSetBuilder.kt
@@ -9,12 +9,13 @@ import kotlinx.collections.immutable.PersistentSet
 import kotlinx.collections.immutable.internal.DeltaCounter
 import kotlinx.collections.immutable.internal.MutabilityOwnership
 
-internal class PersistentHashSetBuilder<E>(set: PersistentHashSet<E>) : AbstractMutableSet<E>(), PersistentSet.Builder<E> {
+internal class PersistentHashSetBuilder<E>(set: PersistentHashSet<E>) :
+    AbstractMutableSet<E>(), PersistentSet.Builder<E> {
     private var builtSet: PersistentHashSet<E>? = set
     internal var ownership = MutabilityOwnership()
         private set
     internal var node = set.node
-        private set (value) {
+        private set(value) {
             if (value !== field) {
                 builtSet = null
                 field = value

--- a/core/commonMain/src/implementations/immutableSet/PersistentHashSetIterator.kt
+++ b/core/commonMain/src/implementations/immutableSet/PersistentHashSetIterator.kt
@@ -11,6 +11,7 @@ import kotlin.js.JsName
 internal open class PersistentHashSetIterator<E>(node: TrieNode<E>) : Iterator<E> {
     protected val path = mutableListOf(TrieNodeIterator<E>())
     protected var pathLastIndex = 0
+
     @JsName("_hasNext")
     private var hasNext = true
 
@@ -40,7 +41,7 @@ internal open class PersistentHashSetIterator<E>(node: TrieNode<E>) : Iterator<E
         if (path[pathLastIndex].hasNextElement()) {
             return
         }
-        for(i in pathLastIndex downTo 0) {
+        for (i in pathLastIndex downTo 0) {
             var result = moveToNextNodeWithData(i)
 
             if (result == -1 && path[i].hasNextCell()) {

--- a/core/commonMain/src/implementations/immutableSet/PersistentHashSetMutableIterator.kt
+++ b/core/commonMain/src/implementations/immutableSet/PersistentHashSetMutableIterator.kt
@@ -7,8 +7,8 @@ package kotlinx.collections.immutable.implementations.immutableSet
 
 import kotlinx.collections.immutable.internal.assert
 
-internal class PersistentHashSetMutableIterator<E>(private val builder: PersistentHashSetBuilder<E>)
-    : PersistentHashSetIterator<E>(builder.node), MutableIterator<E> {
+internal class PersistentHashSetMutableIterator<E>(private val builder: PersistentHashSetBuilder<E>) :
+    PersistentHashSetIterator<E>(builder.node), MutableIterator<E> {
     private var lastIteratedElement: E? = null
     private var nextWasInvoked = false
     private var expectedModCount = builder.modCount

--- a/core/commonMain/src/implementations/immutableSet/TrieNode.kt
+++ b/core/commonMain/src/implementations/immutableSet/TrieNode.kt
@@ -23,7 +23,7 @@ internal const val MAX_SHIFT = 30
  * For each lower level `shift` increments by [LOG_MAX_BRANCHING_FACTOR].
  */
 internal fun indexSegment(index: Int, shift: Int): Int =
-        (index shr shift) and MAX_BRANCHING_FACTOR_MINUS_ONE
+    (index shr shift) and MAX_BRANCHING_FACTOR_MINUS_ONE
 
 
 private fun <E> Array<Any?>.addElementAtIndex(index: Int, element: E): Array<Any?> {
@@ -49,9 +49,10 @@ private fun Array<Any?>.removeCellAtIndex(cellIndex: Int): Array<Any?> {
  **/
 @IgnorableReturnValue
 private inline fun Array<Any?>.filterTo(
-        newArray: Array<Any?>,
-        newArrayOffset: Int = 0,
-        predicate: (Any?) -> Boolean = { it !== TrieNode.EMPTY }): Int {
+    newArray: Array<Any?>,
+    newArrayOffset: Int = 0,
+    predicate: (Any?) -> Boolean = { it !== TrieNode.EMPTY }
+): Int {
     var i = 0
     var j = 0
     while (i < size) {
@@ -68,9 +69,9 @@ private inline fun Array<Any?>.filterTo(
 }
 
 internal class TrieNode<E>(
-        var bitmap: Int,
-        var buffer: Array<Any?>,
-        var ownedBy: MutabilityOwnership?
+    var bitmap: Int,
+    var buffer: Array<Any?>,
+    var ownedBy: MutabilityOwnership?
 ) {
 
     constructor(bitmap: Int, buffer: Array<Any?>) : this(bitmap, buffer, null)
@@ -115,7 +116,11 @@ internal class TrieNode<E>(
     }
 
     /** The given [newNode] must not be a part of any persistent set instance. */
-    private fun canonicalizeNodeAtIndex(nodeIndex: Int, newNode: TrieNode<E>, owner: MutabilityOwnership?): TrieNode<E> {
+    private fun canonicalizeNodeAtIndex(
+        nodeIndex: Int,
+        newNode: TrieNode<E>,
+        owner: MutabilityOwnership?
+    ): TrieNode<E> {
 //        assert(buffer[nodeIndex] !== newNode)
         val cell: Any?
 
@@ -143,21 +148,39 @@ internal class TrieNode<E>(
         return TrieNode(bitmap, newBuffer, owner)
     }
 
-    private fun makeNodeAtIndex(elementIndex: Int, newElementHash: Int, newElement: E,
-                                shift: Int, owner: MutabilityOwnership?): TrieNode<E> {
+    private fun makeNodeAtIndex(
+        elementIndex: Int,
+        newElementHash: Int,
+        newElement: E,
+        shift: Int,
+        owner: MutabilityOwnership?
+    ): TrieNode<E> {
         val storedElement = elementAtIndex(elementIndex)
-        return makeNode(storedElement.hashCode(), storedElement,
-                newElementHash, newElement, shift + LOG_MAX_BRANCHING_FACTOR, owner)
+        return makeNode(
+            storedElement.hashCode(), storedElement,
+            newElementHash, newElement, shift + LOG_MAX_BRANCHING_FACTOR, owner
+        )
     }
 
-    private fun moveElementToNode(elementIndex: Int, newElementHash: Int, newElement: E,
-                                         shift: Int, owner: MutabilityOwnership?): TrieNode<E> {
+    private fun moveElementToNode(
+        elementIndex: Int,
+        newElementHash: Int,
+        newElement: E,
+        shift: Int,
+        owner: MutabilityOwnership?
+    ): TrieNode<E> {
         val node = makeNodeAtIndex(elementIndex, newElementHash, newElement, shift, owner)
         return setCellAtIndex(elementIndex, node, owner)
     }
 
-    private fun makeNode(elementHash1: Int, element1: E, elementHash2: Int, element2: E,
-                         shift: Int, owner: MutabilityOwnership?): TrieNode<E> {
+    private fun makeNode(
+        elementHash1: Int,
+        element1: E,
+        elementHash2: Int,
+        element2: E,
+        shift: Int,
+        owner: MutabilityOwnership?
+    ): TrieNode<E> {
         if (shift > MAX_SHIFT) {
 //            assert(element1 != element2)
             // when two element hashes are entirely equal: the last level subtrie node stores them just as unordered list
@@ -229,9 +252,11 @@ internal class TrieNode<E>(
         return this
     }
 
-    private fun mutableCollisionAddAll(otherNode: TrieNode<E>,
-                                       intersectionSizeRef: DeltaCounter,
-                                       owner: MutabilityOwnership): TrieNode<E> {
+    private fun mutableCollisionAddAll(
+        otherNode: TrieNode<E>,
+        intersectionSizeRef: DeltaCounter,
+        owner: MutabilityOwnership
+    ): TrieNode<E> {
         if (this === otherNode) {
             intersectionSizeRef += buffer.size
             return this
@@ -250,15 +275,18 @@ internal class TrieNode<E>(
         return setProperties(newBitmap = 0, newBuffer, owner)
     }
 
-    private fun mutableCollisionRetainAll(otherNode: TrieNode<E>, intersectionSizeRef: DeltaCounter,
-                                          owner: MutabilityOwnership): Any? {
+    private fun mutableCollisionRetainAll(
+        otherNode: TrieNode<E>,
+        intersectionSizeRef: DeltaCounter,
+        owner: MutabilityOwnership
+    ): Any? {
         if (this === otherNode) {
             intersectionSizeRef += buffer.size
             return this
         }
         val tempBuffer =
-                if (owner === ownedBy) buffer
-                else arrayOfNulls<Any?>(minOf(buffer.size, otherNode.buffer.size))
+            if (owner === ownedBy) buffer
+            else arrayOfNulls<Any?>(minOf(buffer.size, otherNode.buffer.size))
         val totalWritten = buffer.filterTo(tempBuffer) {
             @Suppress("UNCHECKED_CAST")
             otherNode.collisionContainsElement(it as E)
@@ -274,9 +302,11 @@ internal class TrieNode<E>(
         }
     }
 
-    private fun mutableCollisionRemoveAll(otherNode: TrieNode<E>,
-                                          intersectionSizeRef: DeltaCounter,
-                                          owner: MutabilityOwnership): Any? {
+    private fun mutableCollisionRemoveAll(
+        otherNode: TrieNode<E>,
+        intersectionSizeRef: DeltaCounter,
+        owner: MutabilityOwnership
+    ): Any? {
         if (this === otherNode) {
             intersectionSizeRef += buffer.size
             return EMPTY
@@ -336,10 +366,12 @@ internal class TrieNode<E>(
         return element == buffer[cellIndex]
     }
 
-    fun mutableAddAll(otherNode: TrieNode<E>,
-                      shift: Int,
-                      intersectionSizeRef: DeltaCounter,
-                      mutator: PersistentHashSetBuilder<*>): TrieNode<E> {
+    fun mutableAddAll(
+        otherNode: TrieNode<E>,
+        shift: Int,
+        intersectionSizeRef: DeltaCounter,
+        mutator: PersistentHashSetBuilder<*>
+    ): TrieNode<E> {
         if (this === otherNode) {
             intersectionSizeRef.count += this.calculateSize()
             return this
@@ -378,10 +410,8 @@ internal class TrieNode<E>(
                             thisCell as TrieNode<E>
                             otherNodeCell as TrieNode<E>
                             thisCell.mutableAddAll(
-                                    otherNodeCell,
-                                    shift + LOG_MAX_BRANCHING_FACTOR,
-                                    intersectionSizeRef,
-                                    mutator
+                                otherNodeCell, shift + LOG_MAX_BRANCHING_FACTOR,
+                                intersectionSizeRef, mutator
                             )
                         }
                         // one of them is a node -> add the other one to it
@@ -390,10 +420,8 @@ internal class TrieNode<E>(
                             otherNodeCell as E
                             val oldSize = mutator.size
                             thisCell.mutableAdd(
-                                    otherNodeCell.hashCode(),
-                                    otherNodeCell,
-                                    shift + LOG_MAX_BRANCHING_FACTOR,
-                                    mutator
+                                otherNodeCell.hashCode(), otherNodeCell,
+                                shift + LOG_MAX_BRANCHING_FACTOR, mutator
                             ).also {
                                 if (mutator.size == oldSize) intersectionSizeRef.count++
                             }
@@ -404,10 +432,8 @@ internal class TrieNode<E>(
                             thisCell as E
                             val oldSize = mutator.size
                             otherNodeCell.mutableAdd(
-                                    thisCell.hashCode(),
-                                    thisCell,
-                                    shift + LOG_MAX_BRANCHING_FACTOR,
-                                    mutator
+                                thisCell.hashCode(), thisCell,
+                                shift + LOG_MAX_BRANCHING_FACTOR, mutator
                             ).also {
                                 if (mutator.size == oldSize) intersectionSizeRef.count++
                             }
@@ -419,12 +445,9 @@ internal class TrieNode<E>(
                             thisCell as E
                             otherNodeCell as E
                             makeNode(
-                                    thisCell.hashCode(),
-                                    thisCell,
-                                    otherNodeCell.hashCode(),
-                                    otherNodeCell,
-                                    shift + LOG_MAX_BRANCHING_FACTOR,
-                                    mutator.ownership
+                                thisCell.hashCode(), thisCell,
+                                otherNodeCell.hashCode(), otherNodeCell,
+                                shift + LOG_MAX_BRANCHING_FACTOR, mutator.ownership
                             )
                         }
                     }
@@ -438,10 +461,12 @@ internal class TrieNode<E>(
         }
     }
 
-    fun mutableRetainAll(otherNode: TrieNode<E>,
-                         shift: Int,
-                         intersectionSizeRef: DeltaCounter,
-                         mutator: PersistentHashSetBuilder<*>): Any? {
+    fun mutableRetainAll(
+        otherNode: TrieNode<E>,
+        shift: Int,
+        intersectionSizeRef: DeltaCounter,
+        mutator: PersistentHashSetBuilder<*>
+    ): Any? {
         if (this === otherNode) {
             intersectionSizeRef += calculateSize();
             return this
@@ -455,8 +480,8 @@ internal class TrieNode<E>(
         // zero means no nodes intersect
         if (newBitMap == 0) return EMPTY
         val mutableNode =
-                if (ownedBy == mutator.ownership && newBitMap == bitmap) this
-                else TrieNode<E>(newBitMap, arrayOfNulls<Any?>(newBitMap.countOneBits()), mutator.ownership)
+            if (ownedBy == mutator.ownership && newBitMap == bitmap) this
+            else TrieNode<E>(newBitMap, arrayOfNulls<Any?>(newBitMap.countOneBits()), mutator.ownership)
         // we need to keep track of the real mask 'cos some of the children may intersect to nothing
         var realBitMap = 0
         // for each bit in intersection mask, try to intersect children
@@ -474,17 +499,19 @@ internal class TrieNode<E>(
                         thisCell as TrieNode<E>
                         otherNodeCell as TrieNode<E>
                         thisCell.mutableRetainAll(
-                                otherNodeCell,
-                                shift + LOG_MAX_BRANCHING_FACTOR,
-                                intersectionSizeRef,
-                                mutator
+                            otherNodeCell, shift + LOG_MAX_BRANCHING_FACTOR,
+                            intersectionSizeRef, mutator
                         )
                     }
                     // one of them is a node -> check containment
                     thisIsNode -> @Suppress("UNCHECKED_CAST") {
                         thisCell as TrieNode<E>
                         otherNodeCell as E
-                        if (thisCell.contains(otherNodeCell.hashCode(), otherNodeCell, shift + LOG_MAX_BRANCHING_FACTOR)) {
+                        if (thisCell.contains(
+                                otherNodeCell.hashCode(), otherNodeCell,
+                                shift + LOG_MAX_BRANCHING_FACTOR
+                            )
+                        ) {
                             intersectionSizeRef += 1
                             otherNodeCell
                         } else EMPTY
@@ -522,10 +549,12 @@ internal class TrieNode<E>(
                 }
             }
             // single values are kept only on root level
-            realSize == 1 && shift != 0 -> when (val single = mutableNode.buffer[mutableNode.indexOfCellAt(realBitMap)]) {
-                is TrieNode<*> -> TrieNode<E>(realBitMap, arrayOf(single), mutator.ownership)
-                else -> single
-            }
+            realSize == 1 && shift != 0 ->
+                when (val single = mutableNode.buffer[mutableNode.indexOfCellAt(realBitMap)]) {
+                    is TrieNode<*> -> TrieNode<E>(realBitMap, arrayOf(single), mutator.ownership)
+                    else -> single
+                }
+
             else -> {
                 // clean up all the EMPTYs in the resulting buffer
                 val realBuffer = arrayOfNulls<Any>(realSize)
@@ -535,9 +564,12 @@ internal class TrieNode<E>(
         }
     }
 
-    fun mutableRemoveAll(otherNode: TrieNode<E>, shift: Int,
-                         intersectionSizeRef: DeltaCounter,
-                         mutator: PersistentHashSetBuilder<*>): Any? {
+    fun mutableRemoveAll(
+        otherNode: TrieNode<E>,
+        shift: Int,
+        intersectionSizeRef: DeltaCounter,
+        mutator: PersistentHashSetBuilder<*>
+    ): Any? {
         if (this === otherNode) {
             intersectionSizeRef += calculateSize();
             return EMPTY
@@ -552,8 +584,8 @@ internal class TrieNode<E>(
         if (removalBitmap == 0) return this
         // node here is either us (if we are mutable) or a mutable copy
         val mutableNode =
-                if (ownedBy == mutator.ownership) this
-                else TrieNode<E>(bitmap, buffer.copyOf(), mutator.ownership)
+            if (ownedBy == mutator.ownership) this
+            else TrieNode<E>(bitmap, buffer.copyOf(), mutator.ownership)
         // keep track of the real mask
         var realBitMap = bitmap
         removalBitmap.forEachOneBit { positionMask, _ ->
@@ -570,10 +602,8 @@ internal class TrieNode<E>(
                         thisCell as TrieNode<E>
                         otherNodeCell as TrieNode<E>
                         thisCell.mutableRemoveAll(
-                                otherNodeCell,
-                                shift + LOG_MAX_BRANCHING_FACTOR,
-                                intersectionSizeRef,
-                                mutator
+                            otherNodeCell, shift + LOG_MAX_BRANCHING_FACTOR,
+                            intersectionSizeRef, mutator
                         )
                     }
                     // one of them is a node -> remove single element
@@ -582,10 +612,9 @@ internal class TrieNode<E>(
                         otherNodeCell as E
                         val oldSize = mutator.size
                         val removed = thisCell.mutableRemove(
-                                otherNodeCell.hashCode(),
-                                otherNodeCell,
-                                shift + LOG_MAX_BRANCHING_FACTOR,
-                                mutator)
+                            otherNodeCell.hashCode(), otherNodeCell,
+                            shift + LOG_MAX_BRANCHING_FACTOR, mutator
+                        )
                         // additional check needed for removal
                         if (oldSize != mutator.size) {
                             intersectionSizeRef += 1
@@ -623,16 +652,19 @@ internal class TrieNode<E>(
         return when {
             realBitMap == 0 -> EMPTY
             // single values are kept only on root level
-            realSize == 1 && shift != 0 -> when (val single = mutableNode.buffer[mutableNode.indexOfCellAt(realBitMap)]) {
-                is TrieNode<*> -> TrieNode<E>(realBitMap, arrayOf(single), mutator.ownership)
-                else -> single
-            }
+            realSize == 1 && shift != 0 ->
+                when (val single = mutableNode.buffer[mutableNode.indexOfCellAt(realBitMap)]) {
+                    is TrieNode<*> -> TrieNode<E>(realBitMap, arrayOf(single), mutator.ownership)
+                    else -> single
+                }
+
             realBitMap == bitmap -> {
                 when {
                     mutableNode.elementsIdentityEquals(this) -> this
                     else -> mutableNode
                 }
             }
+
             else -> {
                 // clean up all the EMPTYs in the resulting buffer
                 val realBuffer = arrayOfNulls<Any>(realSize)
@@ -670,7 +702,10 @@ internal class TrieNode<E>(
                 thisIsNode -> @Suppress("UNCHECKED_CAST") {
                     thisCell as TrieNode<E>
                     otherNodeCell as E
-                    thisCell.contains(otherNodeCell.hashCode(), otherNodeCell, shift + LOG_MAX_BRANCHING_FACTOR) || return false
+                    thisCell.contains(
+                        otherNodeCell.hashCode(), otherNodeCell,
+                        shift + LOG_MAX_BRANCHING_FACTOR
+                    ) || return false
                 }
                 // left is just E, right is node => not possible
                 otherIsNode -> return false
@@ -780,7 +815,7 @@ internal class TrieNode<E>(
         // element is directly in buffer
         if (element == buffer[cellIndex]) {
             mutator.size--
-            return removeCellAtIndex(cellIndex, cellPositionMask, mutator.ownership)   // check is empty
+            return removeCellAtIndex(cellIndex, cellPositionMask, mutator.ownership) // check is empty
         }
         return this
     }

--- a/core/commonMain/src/implementations/persistentOrderedMap/PersistentOrderedMap.kt
+++ b/core/commonMain/src/implementations/persistentOrderedMap/PersistentOrderedMap.kt
@@ -16,6 +16,7 @@ import kotlinx.collections.immutable.mutate
 internal class LinkedValue<V>(val value: V, val previous: Any?, val next: Any?) {
     /** Constructs LinkedValue for a new single entry */
     constructor(value: V) : this(value, EndOfChain, EndOfChain)
+
     /** Constructs LinkedValue for a new last entry */
     constructor(value: V, previous: Any?) : this(value, previous, EndOfChain)
 
@@ -28,9 +29,9 @@ internal class LinkedValue<V>(val value: V, val previous: Any?, val next: Any?) 
 }
 
 internal class PersistentOrderedMap<K, V>(
-        internal val firstKey: Any?,
-        internal val lastKey: Any?,
-        internal val hashMap: PersistentHashMap<K, LinkedValue<V>>
+    internal val firstKey: Any?,
+    internal val lastKey: Any?,
+    internal val hashMap: PersistentHashMap<K, LinkedValue<V>>
 ) : AbstractMap<K, V>(), PersistentMap<K, V> {
 
     override val size: Int get() = hashMap.size
@@ -88,12 +89,13 @@ internal class PersistentOrderedMap<K, V>(
         val lastLinks = hashMap[lastKey]!!
 //        assert(!lastLink.hasNext)
         val newMap = hashMap
-                .putting(lastKey, lastLinks.withNext(key))
-                .putting(key, LinkedValue(value, previous = lastKey))
+            .putting(lastKey, lastLinks.withNext(key))
+            .putting(key, LinkedValue(value, previous = lastKey))
         return PersistentOrderedMap(firstKey, key, newMap)
     }
 
-    override fun putting(key: K, value: @UnsafeVariance V): PersistentOrderedMap<K, V> = @Suppress("DEPRECATION") put(key, value)
+    override fun putting(key: K, value: @UnsafeVariance V): PersistentOrderedMap<K, V> =
+        @Suppress("DEPRECATION") put(key, value)
 
     @Deprecated(
         "Use removing() instead. For more details, read the documentation for this function.",
@@ -159,26 +161,11 @@ internal class PersistentOrderedMap<K, V>(
         if (size != other.size) return false
 
         return when (other) {
-            is PersistentOrderedMap<*, *> -> {
-                hashMap.node.equalsWith(other.hashMap.node) { a, b ->
-                    a.value == b.value
-                }
-            }
-            is PersistentOrderedMapBuilder<*, *> -> {
-                hashMap.node.equalsWith(other.hashMapBuilder.node) { a, b ->
-                    a.value == b.value
-                }
-            }
-            is PersistentHashMap<*, *> -> {
-                hashMap.node.equalsWith(other.node) { a, b ->
-                    a.value == b
-                }
-            }
-            is PersistentHashMapBuilder<*, *> -> {
-                hashMap.node.equalsWith(other.node) { a, b ->
-                    a.value == b
-                }
-            }
+            is PersistentOrderedMap<*, *> -> hashMap.node.equalsWith(other.hashMap.node) { a, b -> a.value == b.value }
+            is PersistentOrderedMapBuilder<*, *> ->
+                hashMap.node.equalsWith(other.hashMapBuilder.node) { a, b -> a.value == b.value }
+            is PersistentHashMap<*, *> -> hashMap.node.equalsWith(other.node) { a, b -> a.value == b }
+            is PersistentHashMapBuilder<*, *> -> hashMap.node.equalsWith(other.node) { a, b -> a.value == b }
             else -> super.equals(other)
         }
     }
@@ -191,6 +178,7 @@ internal class PersistentOrderedMap<K, V>(
 
     internal companion object {
         private val EMPTY = PersistentOrderedMap<Nothing, Nothing>(EndOfChain, EndOfChain, PersistentHashMap.emptyOf())
+
         @Suppress("UNCHECKED_CAST")
         internal fun <K, V> emptyOf(): PersistentOrderedMap<K, V> = EMPTY as PersistentOrderedMap<K, V>
     }

--- a/core/commonMain/src/implementations/persistentOrderedMap/PersistentOrderedMapBuilder.kt
+++ b/core/commonMain/src/implementations/persistentOrderedMap/PersistentOrderedMapBuilder.kt
@@ -11,7 +11,8 @@ import kotlinx.collections.immutable.implementations.immutableMap.PersistentHash
 import kotlinx.collections.immutable.internal.EndOfChain
 import kotlinx.collections.immutable.internal.assert
 
-internal class PersistentOrderedMapBuilder<K, V>(map: PersistentOrderedMap<K, V>) : AbstractMutableMap<K, V>(), PersistentMap.Builder<K, V> {
+internal class PersistentOrderedMapBuilder<K, V>(map: PersistentOrderedMap<K, V>) :
+    AbstractMutableMap<K, V>(), PersistentMap.Builder<K, V> {
     private var builtMap: PersistentOrderedMap<K, V>? = map
 
     internal var firstKey = map.firstKey
@@ -139,26 +140,12 @@ internal class PersistentOrderedMapBuilder<K, V>(map: PersistentOrderedMap<K, V>
         if (size != other.size) return false
 
         return when (other) {
-            is PersistentOrderedMap<*, *> -> {
-                hashMapBuilder.node.equalsWith(other.hashMap.node) { a, b ->
-                    a.value == b.value
-                }
-            }
-            is PersistentOrderedMapBuilder<*, *> -> {
-                hashMapBuilder.node.equalsWith(other.hashMapBuilder.node) { a, b ->
-                    a.value == b.value
-                }
-            }
-            is PersistentHashMap<*, *> -> {
-                hashMapBuilder.node.equalsWith(other.node) { a, b ->
-                    a.value == b
-                }
-            }
-            is PersistentHashMapBuilder<*, *> -> {
-                hashMapBuilder.node.equalsWith(other.node) { a, b ->
-                    a.value == b
-                }
-            }
+            is PersistentOrderedMap<*, *> ->
+                hashMapBuilder.node.equalsWith(other.hashMap.node) { a, b -> a.value == b.value }
+            is PersistentOrderedMapBuilder<*, *> ->
+                hashMapBuilder.node.equalsWith(other.hashMapBuilder.node) { a, b -> a.value == b.value }
+            is PersistentHashMap<*, *> -> hashMapBuilder.node.equalsWith(other.node) { a, b -> a.value == b }
+            is PersistentHashMapBuilder<*, *> -> hashMapBuilder.node.equalsWith(other.node) { a, b -> a.value == b }
             else -> super.equals(other)
         }
     }

--- a/core/commonMain/src/implementations/persistentOrderedMap/PersistentOrderedMapBuilderContentIterators.kt
+++ b/core/commonMain/src/implementations/persistentOrderedMap/PersistentOrderedMapBuilderContentIterators.kt
@@ -9,8 +9,8 @@ import kotlinx.collections.immutable.implementations.immutableMap.MapEntry
 import kotlinx.collections.immutable.internal.EndOfChain
 
 internal open class PersistentOrderedMapBuilderLinksIterator<K, V>(
-        private var nextKey: Any?,
-        internal val builder: PersistentOrderedMapBuilder<K, V>
+    private var nextKey: Any?,
+    internal val builder: PersistentOrderedMapBuilder<K, V>
 ) : MutableIterator<LinkedValue<V>> {
 
     internal var lastIteratedKey: Any? = EndOfChain
@@ -62,7 +62,8 @@ internal open class PersistentOrderedMapBuilderLinksIterator<K, V>(
     }
 }
 
-internal class PersistentOrderedMapBuilderEntriesIterator<K, V>(map: PersistentOrderedMapBuilder<K, V>): MutableIterator<MutableMap.MutableEntry<K, V>> {
+internal class PersistentOrderedMapBuilderEntriesIterator<K, V>(map: PersistentOrderedMapBuilder<K, V>) :
+    MutableIterator<MutableMap.MutableEntry<K, V>> {
     private val internal = PersistentOrderedMapBuilderLinksIterator(map.firstKey, map)
 
     override fun hasNext(): Boolean {
@@ -80,9 +81,11 @@ internal class PersistentOrderedMapBuilderEntriesIterator<K, V>(map: PersistentO
     }
 }
 
-private class MutableMapEntry<K, V>(private val builder: PersistentOrderedMapBuilder<K, V>,
-                                    key: K,
-                                    private var links: LinkedValue<V>) : MapEntry<K, V>(key, links.value), MutableMap.MutableEntry<K, V> {
+private class MutableMapEntry<K, V>(
+    private val builder: PersistentOrderedMapBuilder<K, V>,
+    key: K,
+    private var links: LinkedValue<V>
+) : MapEntry<K, V>(key, links.value), MutableMap.MutableEntry<K, V> {
     private val expectedModCount = builder.hashMapBuilder.modCount
 
     override val value: V
@@ -100,7 +103,8 @@ private class MutableMapEntry<K, V>(private val builder: PersistentOrderedMapBui
     }
 }
 
-internal class PersistentOrderedMapBuilderKeysIterator<out K, out V>(map: PersistentOrderedMapBuilder<K, V>): MutableIterator<K> {
+internal class PersistentOrderedMapBuilderKeysIterator<out K, out V>(map: PersistentOrderedMapBuilder<K, V>) :
+    MutableIterator<K> {
     private val internal = PersistentOrderedMapBuilderLinksIterator(map.firstKey, map)
 
     override fun hasNext(): Boolean {
@@ -118,7 +122,8 @@ internal class PersistentOrderedMapBuilderKeysIterator<out K, out V>(map: Persis
     }
 }
 
-internal class PersistentOrderedMapBuilderValuesIterator<out K, out V>(map: PersistentOrderedMapBuilder<K, V>): MutableIterator<V> {
+internal class PersistentOrderedMapBuilderValuesIterator<out K, out V>(map: PersistentOrderedMapBuilder<K, V>) :
+    MutableIterator<V> {
     private val internal = PersistentOrderedMapBuilderLinksIterator(map.firstKey, map)
 
     override fun hasNext(): Boolean {

--- a/core/commonMain/src/implementations/persistentOrderedMap/PersistentOrderedMapBuilderContentViews.kt
+++ b/core/commonMain/src/implementations/persistentOrderedMap/PersistentOrderedMapBuilderContentViews.kt
@@ -8,8 +8,8 @@ package kotlinx.collections.immutable.implementations.persistentOrderedMap
 import kotlinx.collections.immutable.implementations.immutableMap.AbstractMapBuilderEntries
 import kotlinx.collections.immutable.internal.containsEntry
 
-internal class PersistentOrderedMapBuilderEntries<K, V>(private val builder: PersistentOrderedMapBuilder<K, V>)
-    : AbstractMapBuilderEntries<MutableMap.MutableEntry<K, V>, K, V>() {
+internal class PersistentOrderedMapBuilderEntries<K, V>(private val builder: PersistentOrderedMapBuilder<K, V>) :
+    AbstractMapBuilderEntries<MutableMap.MutableEntry<K, V>, K, V>() {
     override fun add(element: MutableMap.MutableEntry<K, V>): Boolean {
         throw UnsupportedOperationException()
     }
@@ -34,7 +34,8 @@ internal class PersistentOrderedMapBuilderEntries<K, V>(private val builder: Per
     }
 }
 
-internal class PersistentOrderedMapBuilderKeys<K, V>(private val builder: PersistentOrderedMapBuilder<K, V>) : MutableSet<K>, AbstractMutableSet<K>() {
+internal class PersistentOrderedMapBuilderKeys<K, V>(private val builder: PersistentOrderedMapBuilder<K, V>) :
+    MutableSet<K>, AbstractMutableSet<K>() {
     override fun add(element: K): Boolean {
         throw UnsupportedOperationException()
     }
@@ -63,7 +64,8 @@ internal class PersistentOrderedMapBuilderKeys<K, V>(private val builder: Persis
     }
 }
 
-internal class PersistentOrderedMapBuilderValues<K, V>(private val builder: PersistentOrderedMapBuilder<K, V>) : MutableCollection<V>, AbstractMutableCollection<V>() {
+internal class PersistentOrderedMapBuilderValues<K, V>(private val builder: PersistentOrderedMapBuilder<K, V>) :
+    MutableCollection<V>, AbstractMutableCollection<V>() {
     override val size: Int
         get() = builder.size
 

--- a/core/commonMain/src/implementations/persistentOrderedMap/PersistentOrderedMapContentIterators.kt
+++ b/core/commonMain/src/implementations/persistentOrderedMap/PersistentOrderedMapContentIterators.kt
@@ -8,8 +8,8 @@ package kotlinx.collections.immutable.implementations.persistentOrderedMap
 import kotlinx.collections.immutable.implementations.immutableMap.MapEntry
 
 internal open class PersistentOrderedMapLinksIterator<K, V>(
-        internal var nextKey: Any?,
-        private val hashMap: Map<K, LinkedValue<V>>
+    internal var nextKey: Any?,
+    private val hashMap: Map<K, LinkedValue<V>>
 ) : Iterator<LinkedValue<V>> {
     internal var index = 0
 
@@ -33,7 +33,8 @@ internal open class PersistentOrderedMapLinksIterator<K, V>(
 
 }
 
-internal class PersistentOrderedMapEntriesIterator<out K, out V>(map: PersistentOrderedMap<K, V>) : Iterator<Map.Entry<K, V>> {
+internal class PersistentOrderedMapEntriesIterator<out K, out V>(map: PersistentOrderedMap<K, V>) :
+    Iterator<Map.Entry<K, V>> {
     private val internal = PersistentOrderedMapLinksIterator(map.firstKey, map.hashMap)
 
     override fun hasNext(): Boolean {

--- a/core/commonMain/src/implementations/persistentOrderedMap/PersistentOrderedMapContentViews.kt
+++ b/core/commonMain/src/implementations/persistentOrderedMap/PersistentOrderedMapContentViews.kt
@@ -9,7 +9,8 @@ import kotlinx.collections.immutable.ImmutableCollection
 import kotlinx.collections.immutable.ImmutableSet
 import kotlinx.collections.immutable.internal.containsEntry
 
-internal class PersistentOrderedMapEntries<K, V>(private val map: PersistentOrderedMap<K, V>) : ImmutableSet<Map.Entry<K, V>>, AbstractSet<Map.Entry<K, V>>() {
+internal class PersistentOrderedMapEntries<K, V>(private val map: PersistentOrderedMap<K, V>) :
+    ImmutableSet<Map.Entry<K, V>>, AbstractSet<Map.Entry<K, V>>() {
     override val size: Int get() = map.size
 
     override fun contains(element: Map.Entry<K, V>): Boolean {
@@ -21,7 +22,8 @@ internal class PersistentOrderedMapEntries<K, V>(private val map: PersistentOrde
     }
 }
 
-internal class PersistentOrderedMapKeys<K, V>(private val map: PersistentOrderedMap<K, V>) : ImmutableSet<K>, AbstractSet<K>() {
+internal class PersistentOrderedMapKeys<K, V>(private val map: PersistentOrderedMap<K, V>) :
+    ImmutableSet<K>, AbstractSet<K>() {
     override val size: Int
         get() = map.size
 
@@ -34,7 +36,8 @@ internal class PersistentOrderedMapKeys<K, V>(private val map: PersistentOrdered
     }
 }
 
-internal class PersistentOrderedMapValues<K, V>(private val map: PersistentOrderedMap<K, V>) : ImmutableCollection<V>, AbstractCollection<V>() {
+internal class PersistentOrderedMapValues<K, V>(private val map: PersistentOrderedMap<K, V>) :
+    ImmutableCollection<V>, AbstractCollection<V>() {
     override val size: Int
         get() = map.size
 

--- a/core/commonMain/src/implementations/persistentOrderedSet/PersistentOrderedSet.kt
+++ b/core/commonMain/src/implementations/persistentOrderedSet/PersistentOrderedSet.kt
@@ -13,6 +13,7 @@ import kotlinx.collections.immutable.mutate
 internal class Links(val previous: Any?, val next: Any?) {
     /** Constructs Links for a new single element */
     constructor() : this(EndOfChain, EndOfChain)
+
     /** Constructs Links for a new last element */
     constructor(previous: Any?) : this(previous, EndOfChain)
 
@@ -24,9 +25,9 @@ internal class Links(val previous: Any?, val next: Any?) {
 }
 
 internal class PersistentOrderedSet<E>(
-        internal val firstElement: Any?,
-        internal val lastElement: Any?,
-        internal val hashMap: PersistentHashMap<E, Links>
+    internal val firstElement: Any?,
+    internal val lastElement: Any?,
+    internal val hashMap: PersistentHashMap<E, Links>
 ) : AbstractSet<E>(), PersistentSet<E> {
 
     override val size: Int get() = hashMap.size
@@ -51,8 +52,8 @@ internal class PersistentOrderedSet<E>(
 //        assert(!lastLinks.hasNext)
 
         val newMap = hashMap
-                .putting(lastElement, lastLinks.withNext(element))
-                .putting(element, Links(previous = lastElement))
+            .putting(lastElement, lastLinks.withNext(element))
+            .putting(element, Links(previous = lastElement))
         return PersistentOrderedSet(firstElement, element, newMap)
     }
 
@@ -138,12 +139,8 @@ internal class PersistentOrderedSet<E>(
         if (size != other.size) return false
 
         return when (other) {
-            is PersistentOrderedSet<*> -> {
-                hashMap.node.equalsWith(other.hashMap.node) { _, _ -> true }
-            }
-            is PersistentOrderedSetBuilder<*> -> {
-                hashMap.node.equalsWith(other.hashMapBuilder.node) { _, _ -> true }
-            }
+            is PersistentOrderedSet<*> -> hashMap.node.equalsWith(other.hashMap.node) { _, _ -> true }
+            is PersistentOrderedSetBuilder<*> -> hashMap.node.equalsWith(other.hashMapBuilder.node) { _, _ -> true }
             else -> super.equals(other)
         }
     }

--- a/core/commonMain/src/implementations/persistentOrderedSet/PersistentOrderedSetBuilder.kt
+++ b/core/commonMain/src/implementations/persistentOrderedSet/PersistentOrderedSetBuilder.kt
@@ -9,7 +9,8 @@ import kotlinx.collections.immutable.PersistentSet
 import kotlinx.collections.immutable.internal.EndOfChain
 import kotlinx.collections.immutable.internal.assert
 
-internal class PersistentOrderedSetBuilder<E>(set: PersistentOrderedSet<E>) : AbstractMutableSet<E>(), PersistentSet.Builder<E> {
+internal class PersistentOrderedSetBuilder<E>(set: PersistentOrderedSet<E>) :
+    AbstractMutableSet<E>(), PersistentSet.Builder<E> {
     private var builtSet: PersistentOrderedSet<E>? = set
     internal var firstElement = set.firstElement
     private var lastElement = set.lastElement
@@ -100,12 +101,9 @@ internal class PersistentOrderedSetBuilder<E>(set: PersistentOrderedSet<E>) : Ab
         if (size != other.size) return false
 
         return when (other) {
-            is PersistentOrderedSet<*> -> {
-                hashMapBuilder.node.equalsWith(other.hashMap.node) { _, _ -> true }
-            }
-            is PersistentOrderedSetBuilder<*> -> {
+            is PersistentOrderedSet<*> -> hashMapBuilder.node.equalsWith(other.hashMap.node) { _, _ -> true }
+            is PersistentOrderedSetBuilder<*> ->
                 hashMapBuilder.node.equalsWith(other.hashMapBuilder.node) { _, _ -> true }
-            }
             else -> super.equals(other)
         }
     }

--- a/core/commonMain/src/implementations/persistentOrderedSet/PersistentOrderedSetIterator.kt
+++ b/core/commonMain/src/implementations/persistentOrderedSet/PersistentOrderedSetIterator.kt
@@ -5,8 +5,10 @@
 
 package kotlinx.collections.immutable.implementations.persistentOrderedSet
 
-internal open class PersistentOrderedSetIterator<E>(private var nextElement: Any?,
-                                                    internal val map: Map<E, Links>) : Iterator<E> {
+internal open class PersistentOrderedSetIterator<E>(
+    private var nextElement: Any?,
+    internal val map: Map<E, Links>
+) : Iterator<E> {
     internal var index = 0
 
     override fun hasNext(): Boolean {

--- a/core/commonMain/src/implementations/persistentOrderedSet/PersistentOrderedSetMutableIterator.kt
+++ b/core/commonMain/src/implementations/persistentOrderedSet/PersistentOrderedSetMutableIterator.kt
@@ -5,8 +5,8 @@
 
 package kotlinx.collections.immutable.implementations.persistentOrderedSet
 
-internal class PersistentOrderedSetMutableIterator<E>(private val builder: PersistentOrderedSetBuilder<E>)
-    : PersistentOrderedSetIterator<E>(builder.firstElement, builder.hashMapBuilder), MutableIterator<E> {
+internal class PersistentOrderedSetMutableIterator<E>(private val builder: PersistentOrderedSetBuilder<E>) :
+    PersistentOrderedSetIterator<E>(builder.firstElement, builder.hashMapBuilder), MutableIterator<E> {
 
     private var lastIteratedElement: E? = null
     private var nextWasInvoked = false

--- a/core/commonMain/src/internal/MutableCounter.kt
+++ b/core/commonMain/src/internal/MutableCounter.kt
@@ -6,5 +6,7 @@
 package kotlinx.collections.immutable.internal
 
 internal data class DeltaCounter(var count: Int = 0) {
-    operator fun plusAssign(that: Int) { count += that }
+    operator fun plusAssign(that: Int) {
+        count += that
+    }
 }


### PR DESCRIPTION
No code changes: whitespace, line wrapping, and redundant braces only. Small idiom cleanups are split into #288.