### PR TITLE
KT-78078: remove watchosArm32

### DIFF
--- a/core/api/kotlinx-collections-immutable.klib.api
+++ b/core/api/kotlinx-collections-immutable.klib.api
@@ -1,5 +1,5 @@
 // Klib ABI Dump
-// Targets: [androidNativeArm32, androidNativeArm64, androidNativeX64, androidNativeX86, iosArm64, iosSimulatorArm64, iosX64, js, linuxArm64, linuxX64, macosArm64, macosX64, mingwX64, tvosArm64, tvosSimulatorArm64, tvosX64, wasmJs, wasmWasi, watchosArm32, watchosArm64, watchosDeviceArm64, watchosSimulatorArm64, watchosX64]
+// Targets: [androidNativeArm32, androidNativeArm64, androidNativeX64, androidNativeX86, iosArm64, iosSimulatorArm64, iosX64, js, linuxArm64, linuxX64, macosArm64, macosX64, mingwX64, tvosArm64, tvosSimulatorArm64, tvosX64, wasmJs, wasmWasi, watchosArm64, watchosDeviceArm64, watchosSimulatorArm64, watchosX64]
 // Rendering settings:
 // - Signature version: 2
 // - Show manifest properties: true

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -38,7 +38,6 @@ kotlin {
     linuxArm64()
     watchosSimulatorArm64()
     watchosX64()
-    watchosArm32()
     watchosArm64()
     tvosSimulatorArm64()
     tvosX64()


### PR DESCRIPTION
Similar to what we did in other kotlinx-libraries, let's remove the watchosArm32 target only from the kc/dev branch.