### PR TITLE
Restore commented-out invariant asserts

### DIFF
--- a/core/commonMain/src/implementations/immutableList/PersistentVector.kt
+++ b/core/commonMain/src/implementations/immutableList/PersistentVector.kt
@@ -29,7 +29,7 @@ internal class PersistentVector<E>(
 
     init {
         require(size > MAX_BUFFER_SIZE) { "Trie-based persistent vector should have at least ${MAX_BUFFER_SIZE + 1} elements, got $size" }
-        assert(size - rootSize(size) <= tail.size.coerceAtMost(MAX_BUFFER_SIZE))
+        assert { size - rootSize(size) <= tail.size.coerceAtMost(MAX_BUFFER_SIZE) }
     }
 
     private fun rootSize(): Int = rootSize(size)
@@ -176,7 +176,7 @@ internal class PersistentVector<E>(
 
     private fun removeFromTailAt(root: Array<Any?>, rootSize: Int, shift: Int, index: Int): PersistentList<E> {
         val tailSize = size - rootSize
-        assert(index < tailSize)
+        assert { index < tailSize }
 
         if (tailSize == 1) {
             return pullLastBufferFromRoot(root, rootSize, shift)

--- a/core/commonMain/src/implementations/immutableList/PersistentVectorBuilder.kt
+++ b/core/commonMain/src/implementations/immutableList/PersistentVectorBuilder.kt
@@ -384,7 +384,7 @@ internal class PersistentVectorBuilder<E>(
         val buffersSize = (size - unaffectedElementsCount + elements.size - 1) / MAX_BUFFER_SIZE
 
         if (buffersSize == 0) {
-            assert(index >= rootSize())
+            assert { index >= rootSize() }
 
             val startIndex = index and MAX_BUFFER_SIZE_MINUS_ONE
             val endIndex = (index + elements.size - 1) and MAX_BUFFER_SIZE_MINUS_ONE // inclusive
@@ -596,7 +596,7 @@ internal class PersistentVectorBuilder<E>(
     @IgnorableReturnValue
     private fun removeFromTailAt(root: Array<Any?>?, rootSize: Int, shift: Int, index: Int): Any? {
         val tailSize = size - rootSize
-        assert(index < tailSize)
+        assert { index < tailSize }
 
         val removedElement: Any?
         if (tailSize == 1) {
@@ -742,7 +742,7 @@ internal class PersistentVectorBuilder<E>(
 
         // if no elements from the root match the predicate, check the tail
         if (bufferSize == MAX_BUFFER_SIZE) {
-            assert(!leafIterator.hasNext())
+            assert { !leafIterator.hasNext() }
             val newTailSize = removeAllFromTail(predicate, tailSize, bufferRef)
             if (newTailSize == 0) {
                 // all elements of the tail was removed, pull the last leaf from the root to make it the tail
@@ -856,7 +856,7 @@ internal class PersistentVectorBuilder<E>(
         val newTailSize = removeAll(predicate, tail, tailSize, bufferRef)
 
         if (newTailSize == tailSize) {
-            assert(bufferRef.value === tail)
+            assert { bufferRef.value === tail }
             return tailSize
         }
 

--- a/core/commonMain/src/implementations/immutableList/SmallPersistentVector.kt
+++ b/core/commonMain/src/implementations/immutableList/SmallPersistentVector.kt
@@ -14,7 +14,7 @@ import kotlinx.collections.immutable.mutate
 internal class SmallPersistentVector<E>(private val buffer: Array<Any?>) : AbstractPersistentList<E>() {
 
     init {
-        assert(buffer.size <= MAX_BUFFER_SIZE)
+        assert { buffer.size <= MAX_BUFFER_SIZE }
     }
 
     override val size: Int

--- a/core/commonMain/src/implementations/immutableMap/PersistentHashMapBuilderContentIterators.kt
+++ b/core/commonMain/src/implementations/immutableMap/PersistentHashMapBuilderContentIterators.kt
@@ -123,14 +123,14 @@ internal open class PersistentHashMapBuilderBaseIterator<K, V, T>(
                 return
             }
 
-//            assert(node.keyAtIndex(keyIndex) == key)
+            assert { node.keyAtIndex(keyIndex) == key }
 
             path[pathIndex].reset(node.buffer, ENTRY_SIZE * node.entryCount(), keyIndex)
             pathLastIndex = pathIndex
             return
         }
 
-//        assert(node.hasNodeAt(keyPositionMask)) // key is in node
+        assert { node.hasNodeAt(keyPositionMask) } // key is in node
 
         val nodeIndex = node.nodeIndex(keyPositionMask)
         val targetNode = node.nodeAtIndex(nodeIndex)

--- a/core/commonMain/src/implementations/immutableMap/PersistentHashMapBuilderContentIterators.kt
+++ b/core/commonMain/src/implementations/immutableMap/PersistentHashMapBuilderContentIterators.kt
@@ -13,7 +13,7 @@ internal class TrieNodeMutableEntriesIterator<K, V>(
 ) : TrieNodeBaseIterator<K, V, MutableMap.MutableEntry<K, V>>() {
 
     override fun next(): MutableMap.MutableEntry<K, V> {
-        assert(hasNextKey())
+        assert { hasNextKey() }
         index += 2
         @Suppress("UNCHECKED_CAST")
         return MutableMapEntry(parentIterator, buffer[index - 2] as K, buffer[index - 1] as V)

--- a/core/commonMain/src/implementations/immutableMap/PersistentHashMapContentIterators.kt
+++ b/core/commonMain/src/implementations/immutableMap/PersistentHashMapContentIterators.kt
@@ -31,29 +31,29 @@ internal abstract class TrieNodeBaseIterator<out K, out V, out T> : Iterator<T> 
     }
 
     fun currentKey(): K {
-        assert(hasNextKey())
+        assert { hasNextKey() }
         @Suppress("UNCHECKED_CAST")
         return buffer[index] as K
     }
 
     fun moveToNextKey() {
-        assert(hasNextKey())
+        assert { hasNextKey() }
         index += 2
     }
 
     fun hasNextNode(): Boolean {
-        assert(index >= dataSize)
+        assert { index >= dataSize }
         return index < buffer.size
     }
 
     fun currentNode(): TrieNode<out K, out V> {
-        assert(hasNextNode())
+        assert { hasNextNode() }
         @Suppress("UNCHECKED_CAST")
         return buffer[index] as TrieNode<K, V>
     }
 
     fun moveToNextNode() {
-        assert(hasNextNode())
+        assert { hasNextNode() }
         index++
     }
 
@@ -64,7 +64,7 @@ internal abstract class TrieNodeBaseIterator<out K, out V, out T> : Iterator<T> 
 
 internal class TrieNodeKeysIterator<out K, out V> : TrieNodeBaseIterator<K, V, K>() {
     override fun next(): K {
-        assert(hasNextKey())
+        assert { hasNextKey() }
         index += 2
         @Suppress("UNCHECKED_CAST")
         return buffer[index - 2] as K
@@ -73,7 +73,7 @@ internal class TrieNodeKeysIterator<out K, out V> : TrieNodeBaseIterator<K, V, K
 
 internal class TrieNodeValuesIterator<out K, out V> : TrieNodeBaseIterator<K, V, V>() {
     override fun next(): V {
-        assert(hasNextKey())
+        assert { hasNextKey() }
         index += 2
         @Suppress("UNCHECKED_CAST")
         return buffer[index - 1] as V
@@ -82,7 +82,7 @@ internal class TrieNodeValuesIterator<out K, out V> : TrieNodeBaseIterator<K, V,
 
 internal class TrieNodeEntriesIterator<out K, out V> : TrieNodeBaseIterator<K, V, Map.Entry<K, V>>() {
     override fun next(): Map.Entry<K, V> {
-        assert(hasNextKey())
+        assert { hasNextKey() }
         index += 2
         @Suppress("UNCHECKED_CAST")
         return MapEntry(buffer[index - 2] as K, buffer[index - 1] as V)

--- a/core/commonMain/src/implementations/immutableMap/TrieNode.kt
+++ b/core/commonMain/src/implementations/immutableMap/TrieNode.kt
@@ -108,7 +108,7 @@ internal class TrieNode<K, V>(
     }
 
     /** Returns true if the node bit map has the bit specified by [positionMask] set, indicating there's a subtrie node in the buffer at that position. */
-    private fun hasNodeAt(positionMask: Int): Boolean {
+    internal fun hasNodeAt(positionMask: Int): Boolean {
         return nodeMap and positionMask != 0
     }
 
@@ -123,7 +123,7 @@ internal class TrieNode<K, V>(
     }
 
     /** Retrieves the buffer element at the given [keyIndex] as key of a data entry. */
-    private fun keyAtIndex(keyIndex: Int): K {
+    internal fun keyAtIndex(keyIndex: Int): K {
         @Suppress("UNCHECKED_CAST")
         return buffer[keyIndex] as K
     }
@@ -141,7 +141,7 @@ internal class TrieNode<K, V>(
     }
 
     private fun insertEntryAt(positionMask: Int, key: K, value: V): TrieNode<K, V> {
-//        assert(!hasEntryAt(positionMask))
+        assert { !hasEntryAt(positionMask) }
 
         val keyIndex = entryKeyIndex(positionMask)
         val newBuffer = buffer.insertEntryAtIndex(keyIndex, key, value)
@@ -149,7 +149,7 @@ internal class TrieNode<K, V>(
     }
 
     private fun mutableInsertEntryAt(positionMask: Int, key: K, value: V, owner: MutabilityOwnership): TrieNode<K, V> {
-//        assert(!hasEntryAt(positionMask))
+        assert { !hasEntryAt(positionMask) }
 
         val keyIndex = entryKeyIndex(positionMask)
         if (ownedBy === owner) {
@@ -162,7 +162,7 @@ internal class TrieNode<K, V>(
     }
 
     private fun updateValueAtIndex(keyIndex: Int, value: V): TrieNode<K, V> {
-//        assert(buffer[keyIndex + 1] !== value)
+        assert { buffer[keyIndex + 1] !== value }
 
         val newBuffer = buffer.copyOf()
         newBuffer[keyIndex + 1] = value
@@ -174,7 +174,7 @@ internal class TrieNode<K, V>(
         value: V,
         mutator: PersistentHashMapBuilder<K, V>
     ): TrieNode<K, V> {
-//        assert(buffer[keyIndex + 1] !== value)
+        assert { buffer[keyIndex + 1] !== value }
 
         // If the [mutator] is exclusive owner of this node, update value at specified index in-place.
         if (ownedBy === mutator.ownership) {
@@ -198,7 +198,7 @@ internal class TrieNode<K, V>(
     ): TrieNode<K, V> {
         if (newNode.hasSingleEntry) {
             if (buffer.size == 1) {
-//                assert(dataMap == 0 && nodeMap xor positionMask == 0)
+                assert { dataMap == 0 && nodeMap xor positionMask == 0 }
                 newNode.dataMap = nodeMap
                 return newNode
             }
@@ -219,7 +219,7 @@ internal class TrieNode<K, V>(
     }
 
     private fun removeNodeAtIndex(nodeIndex: Int, positionMask: Int): TrieNode<K, V>? {
-//        assert(hasNodeAt(positionMask))
+        assert { hasNodeAt(positionMask) }
         if (buffer.size == 1) return null
 
         val newBuffer = buffer.removeNodeAtIndex(nodeIndex)
@@ -231,7 +231,7 @@ internal class TrieNode<K, V>(
         positionMask: Int,
         owner: MutabilityOwnership
     ): TrieNode<K, V>? {
-//        assert(hasNodeAt(positionMask))
+        assert { hasNodeAt(positionMask) }
         if (buffer.size == 1) return null
 
         if (ownedBy === owner) {
@@ -275,8 +275,8 @@ internal class TrieNode<K, V>(
         newValue: V,
         shift: Int
     ): TrieNode<K, V> {
-//        assert(hasEntryAt(positionMask))
-//        assert(!hasNodeAt(positionMask))
+        assert { hasEntryAt(positionMask) }
+        assert { !hasNodeAt(positionMask) }
 
         val newBuffer = bufferMoveEntryToNode(keyIndex, positionMask, newKeyHash, newKey, newValue, shift, null)
         return TrieNode(dataMap xor positionMask, nodeMap or positionMask, newBuffer)
@@ -291,8 +291,8 @@ internal class TrieNode<K, V>(
         shift: Int,
         owner: MutabilityOwnership
     ): TrieNode<K, V> {
-//        assert(hasEntryAt(positionMask))
-//        assert(!hasNodeAt(positionMask))
+        assert { hasEntryAt(positionMask) }
+        assert { !hasNodeAt(positionMask) }
 
         if (ownedBy === owner) {
             buffer = bufferMoveEntryToNode(keyIndex, positionMask, newKeyHash, newKey, newValue, shift, owner)
@@ -316,7 +316,7 @@ internal class TrieNode<K, V>(
         owner: MutabilityOwnership?
     ): TrieNode<K, V> {
         if (shift > MAX_SHIFT) {
-//            assert(key1 != key2)
+            assert { key1 != key2 }
             // when two key hashes are entirely equal: the last level subtrie node stores them just as unordered list
             return TrieNode(0, 0, arrayOf(key1, value1, key2, value2), owner)
         }
@@ -338,7 +338,7 @@ internal class TrieNode<K, V>(
     }
 
     private fun removeEntryAtIndex(keyIndex: Int, positionMask: Int): TrieNode<K, V>? {
-//        assert(hasEntryAt(positionMask))
+        assert { hasEntryAt(positionMask) }
         if (buffer.size == ENTRY_SIZE) return null
         val newBuffer = buffer.removeEntryAtIndex(keyIndex)
         return TrieNode(dataMap xor positionMask, nodeMap, newBuffer)
@@ -349,7 +349,7 @@ internal class TrieNode<K, V>(
         positionMask: Int,
         mutator: PersistentHashMapBuilder<K, V>
     ): TrieNode<K, V>? {
-//        assert(hasEntryAt(positionMask))
+        assert { hasEntryAt(positionMask) }
         mutator.size--
         mutator.operationResult = valueAtKeyIndex(keyIndex)
         if (buffer.size == ENTRY_SIZE) return null
@@ -960,7 +960,6 @@ internal class TrieNode<K, V>(
         var nodePositions = nodeMap
         while (nodePositions != 0) {
             val mask = nodePositions.takeLowestOneBit()
-//            assert(hasNodeAt(mask))
 
             val hashSegment = mask.countTrailingZeroBits()
 

--- a/core/commonMain/src/implementations/immutableMap/TrieNode.kt
+++ b/core/commonMain/src/implementations/immutableMap/TrieNode.kt
@@ -474,10 +474,10 @@ internal class TrieNode<K, V>(
         intersectionCounter: DeltaCounter,
         owner: MutabilityOwnership
     ): TrieNode<K, V> {
-        assert(nodeMap == 0)
-        assert(dataMap == 0)
-        assert(otherNode.nodeMap == 0)
-        assert(otherNode.dataMap == 0)
+        assert { nodeMap == 0 }
+        assert { dataMap == 0 }
+        assert { otherNode.nodeMap == 0 }
+        assert { otherNode.dataMap == 0 }
         val tempBuffer = this.buffer.copyOf(newSize = this.buffer.size + otherNode.buffer.size)
         var i = this.buffer.size
         for (j in 0..<otherNode.buffer.size step ENTRY_SIZE) {

--- a/core/commonMain/src/implementations/immutableSet/PersistentHashSetIterator.kt
+++ b/core/commonMain/src/implementations/immutableSet/PersistentHashSetIterator.kt
@@ -74,7 +74,7 @@ internal open class PersistentHashSetIterator<E>(node: TrieNode<E>) : Iterator<E
     }
 
     protected fun currentElement(): E {
-        assert(hasNext())
+        assert { hasNext() }
         return path[pathLastIndex].currentElement()
     }
 }
@@ -93,7 +93,7 @@ internal class TrieNodeIterator<out E> {
     }
 
     fun moveToNextCell() {
-        assert(hasNextCell())
+        assert { hasNextCell() }
         index++
     }
 
@@ -102,13 +102,13 @@ internal class TrieNodeIterator<out E> {
     }
 
     fun currentElement(): E {
-        assert(hasNextElement())
+        assert { hasNextElement() }
         @Suppress("UNCHECKED_CAST")
         return buffer[index] as E
     }
 
     fun nextElement(): E {
-        assert(hasNextElement())
+        assert { hasNextElement() }
         @Suppress("UNCHECKED_CAST")
         return buffer[index++] as E
     }
@@ -118,7 +118,7 @@ internal class TrieNodeIterator<out E> {
     }
 
     fun currentNode(): TrieNode<out E> {
-        assert(hasNextNode())
+        assert { hasNextNode() }
         @Suppress("UNCHECKED_CAST")
         return buffer[index] as TrieNode<E>
     }

--- a/core/commonMain/src/implementations/immutableSet/PersistentHashSetMutableIterator.kt
+++ b/core/commonMain/src/implementations/immutableSet/PersistentHashSetMutableIterator.kt
@@ -55,7 +55,7 @@ internal class PersistentHashSetMutableIterator<E>(private val builder: Persiste
         if (cell is TrieNode<*>) {
             resetPath(hashCode, cell, element, pathIndex + 1)
         } else {
-//            assert(cell == element)
+            assert { cell == element }
             pathLastIndex = pathIndex
         }
     }

--- a/core/commonMain/src/implementations/immutableSet/PersistentHashSetMutableIterator.kt
+++ b/core/commonMain/src/implementations/immutableSet/PersistentHashSetMutableIterator.kt
@@ -40,7 +40,7 @@ internal class PersistentHashSetMutableIterator<E>(private val builder: Persiste
     private fun resetPath(hashCode: Int, node: TrieNode<*>, element: E, pathIndex: Int) {
         if (isCollision(node)) {
             val index = node.buffer.indexOf(element)
-            assert(index != -1)
+            assert { index != -1 }
             path[pathIndex].reset(node.buffer, index)
             pathLastIndex = pathIndex
             return

--- a/core/commonMain/src/implementations/immutableSet/TrieNode.kt
+++ b/core/commonMain/src/implementations/immutableSet/TrieNode.kt
@@ -98,7 +98,7 @@ internal class TrieNode<E>(
     }
 
     private fun addElementAt(positionMask: Int, element: E, owner: MutabilityOwnership?): TrieNode<E> {
-//        assert(hasNoCellAt(positionMask))
+        assert { hasNoCellAt(positionMask) }
 
         val index = indexOfCellAt(positionMask)
         val newBitmap = bitmap or positionMask
@@ -121,7 +121,6 @@ internal class TrieNode<E>(
         newNode: TrieNode<E>,
         owner: MutabilityOwnership?
     ): TrieNode<E> {
-//        assert(buffer[nodeIndex] !== newNode)
         val cell: Any?
 
         val newNodeBuffer = newNode.buffer
@@ -182,7 +181,7 @@ internal class TrieNode<E>(
         owner: MutabilityOwnership?
     ): TrieNode<E> {
         if (shift > MAX_SHIFT) {
-//            assert(element1 != element2)
+            assert { element1 != element2 }
             // when two element hashes are entirely equal: the last level subtrie node stores them just as unordered list
             return TrieNode<E>(0, arrayOf(element1, element2), owner)
         }
@@ -205,8 +204,7 @@ internal class TrieNode<E>(
 
 
     private fun removeCellAtIndex(cellIndex: Int, positionMask: Int, owner: MutabilityOwnership?): TrieNode<E> {
-//        assert(!hasNoCellAt(positionMask))
-//        assert(buffer.size > 1) can be false only for the root node
+        assert { !hasNoCellAt(positionMask) }
 
         val newBitmap = bitmap xor positionMask
         val newBuffer = buffer.removeCellAtIndex(cellIndex)

--- a/core/commonMain/src/implementations/immutableSet/TrieNode.kt
+++ b/core/commonMain/src/implementations/immutableSet/TrieNode.kt
@@ -56,12 +56,12 @@ private inline fun Array<Any?>.filterTo(
     var i = 0
     var j = 0
     while (i < size) {
-        assert(j <= i) // this is extremely important if newArray === this
+        assert { j <= i } // this is extremely important if newArray === this
         val e = this[i]
         if (predicate(e)) {
             newArray[newArrayOffset + j] = this[i]
             ++j
-            assert(newArrayOffset + j <= newArray.size)
+            assert { newArrayOffset + j <= newArray.size }
         }
         ++i
     }

--- a/core/commonMain/src/implementations/persistentOrderedMap/PersistentOrderedMap.kt
+++ b/core/commonMain/src/implementations/persistentOrderedMap/PersistentOrderedMap.kt
@@ -11,6 +11,7 @@ import kotlinx.collections.immutable.PersistentMap
 import kotlinx.collections.immutable.implementations.immutableMap.PersistentHashMap
 import kotlinx.collections.immutable.implementations.immutableMap.PersistentHashMapBuilder
 import kotlinx.collections.immutable.internal.EndOfChain
+import kotlinx.collections.immutable.internal.assert
 import kotlinx.collections.immutable.mutate
 
 internal class LinkedValue<V>(val value: V, val previous: Any?, val next: Any?) {
@@ -87,7 +88,7 @@ internal class PersistentOrderedMap<K, V>(
         @Suppress("UNCHECKED_CAST")
         val lastKey = lastKey as K
         val lastLinks = hashMap[lastKey]!!
-//        assert(!lastLink.hasNext)
+        assert { !lastLinks.hasNext }
         val newMap = hashMap
             .putting(lastKey, lastLinks.withNext(key))
             .putting(key, LinkedValue(value, previous = lastKey))
@@ -107,13 +108,13 @@ internal class PersistentOrderedMap<K, V>(
         var newMap = hashMap.removing(key)
         if (links.hasPrevious) {
             val previousLinks = newMap[links.previous]!!
-//            assert(previousLinks.next == key)
+            assert { previousLinks.next == key }
             @Suppress("UNCHECKED_CAST")
             newMap = newMap.putting(links.previous as K, previousLinks.withNext(links.next))
         }
         if (links.hasNext) {
             val nextLinks = newMap[links.next]!!
-//            assert(nextLinks.previous == key)
+            assert { nextLinks.previous == key }
             @Suppress("UNCHECKED_CAST")
             newMap = newMap.putting(links.next as K, nextLinks.withPrevious(links.previous))
         }

--- a/core/commonMain/src/implementations/persistentOrderedMap/PersistentOrderedMapBuilder.kt
+++ b/core/commonMain/src/implementations/persistentOrderedMap/PersistentOrderedMapBuilder.kt
@@ -96,7 +96,7 @@ internal class PersistentOrderedMapBuilder<K, V>(map: PersistentOrderedMap<K, V>
         builtMap = null
         if (links.hasPrevious) {
             val previousLinks = hashMapBuilder[links.previous]!!
-//            assert(previousLinks.next == key)
+            assert { previousLinks.next == key }
             @Suppress("UNCHECKED_CAST")
             hashMapBuilder[links.previous as K] = previousLinks.withNext(links.next)
         } else {
@@ -104,7 +104,7 @@ internal class PersistentOrderedMapBuilder<K, V>(map: PersistentOrderedMap<K, V>
         }
         if (links.hasNext) {
             val nextLinks = hashMapBuilder[links.next]!!
-//            assert(nextLinks.previous == key)
+            assert { nextLinks.previous == key }
             @Suppress("UNCHECKED_CAST")
             hashMapBuilder[links.next as K] = nextLinks.withPrevious(links.previous)
         } else {

--- a/core/commonMain/src/implementations/persistentOrderedMap/PersistentOrderedMapBuilder.kt
+++ b/core/commonMain/src/implementations/persistentOrderedMap/PersistentOrderedMapBuilder.kt
@@ -26,11 +26,11 @@ internal class PersistentOrderedMapBuilder<K, V>(map: PersistentOrderedMap<K, V>
 
     override fun build(): PersistentMap<K, V> {
         return builtMap?.also { map ->
-            assert(hashMapBuilder.builtMap != null)
-            assert(firstKey === map.firstKey)
-            assert(lastKey === map.lastKey)
+            assert { hashMapBuilder.builtMap != null }
+            assert { firstKey === map.firstKey }
+            assert { lastKey === map.lastKey }
         } ?: run {
-            assert(hashMapBuilder.builtMap == null)
+            assert { hashMapBuilder.builtMap == null }
             val newHashMap = hashMapBuilder.build()
             val newOrdered = PersistentOrderedMap(firstKey, lastKey, newHashMap)
             builtMap = newOrdered
@@ -77,7 +77,7 @@ internal class PersistentOrderedMapBuilder<K, V>(map: PersistentOrderedMap<K, V>
                 @Suppress("UNCHECKED_CAST")
                 val lastKey = lastKey as K
                 val lastLinks = hashMapBuilder[lastKey]!!
-                assert(!lastLinks.hasNext)
+                assert { !lastLinks.hasNext }
                 hashMapBuilder[lastKey] = lastLinks.withNext(key)
                 hashMapBuilder[key] = LinkedValue(value, previous = lastKey)
                 this.lastKey = key

--- a/core/commonMain/src/implementations/persistentOrderedSet/PersistentOrderedSet.kt
+++ b/core/commonMain/src/implementations/persistentOrderedSet/PersistentOrderedSet.kt
@@ -8,6 +8,7 @@ package kotlinx.collections.immutable.implementations.persistentOrderedSet
 import kotlinx.collections.immutable.PersistentSet
 import kotlinx.collections.immutable.implementations.immutableMap.PersistentHashMap
 import kotlinx.collections.immutable.internal.EndOfChain
+import kotlinx.collections.immutable.internal.assert
 import kotlinx.collections.immutable.mutate
 
 internal class Links(val previous: Any?, val next: Any?) {
@@ -49,7 +50,7 @@ internal class PersistentOrderedSet<E>(
         @Suppress("UNCHECKED_CAST")
         val lastElement = lastElement as E
         val lastLinks = hashMap[lastElement]!!
-//        assert(!lastLinks.hasNext)
+        assert { !lastLinks.hasNext }
 
         val newMap = hashMap
             .putting(lastElement, lastLinks.withNext(element))
@@ -76,13 +77,13 @@ internal class PersistentOrderedSet<E>(
         var newMap = hashMap.removing(element)
         if (links.hasPrevious) {
             val previousLinks = newMap[links.previous]!!
-//            assert(previousLinks.next == element)
+            assert { previousLinks.next == element }
             @Suppress("UNCHECKED_CAST")
             newMap = newMap.putting(links.previous as E, previousLinks.withNext(links.next))
         }
         if (links.hasNext) {
             val nextLinks = newMap[links.next]!!
-//            assert(nextLinks.previous == element)
+            assert { nextLinks.previous == element }
             @Suppress("UNCHECKED_CAST")
             newMap = newMap.putting(links.next as E, nextLinks.withPrevious(links.previous))
         }

--- a/core/commonMain/src/implementations/persistentOrderedSet/PersistentOrderedSetBuilder.kt
+++ b/core/commonMain/src/implementations/persistentOrderedSet/PersistentOrderedSetBuilder.kt
@@ -50,7 +50,7 @@ internal class PersistentOrderedSetBuilder<E>(set: PersistentOrderedSet<E>) :
         }
 
         val lastLinks = hashMapBuilder[lastElement]!!
-//        assert(!lastLinks.hasNext)
+        assert { !lastLinks.hasNext }
         @Suppress("UNCHECKED_CAST")
         hashMapBuilder[lastElement as E] = lastLinks.withNext(element)
         hashMapBuilder[element] = Links(previous = lastElement)
@@ -64,7 +64,7 @@ internal class PersistentOrderedSetBuilder<E>(set: PersistentOrderedSet<E>) :
         builtSet = null
         if (links.hasPrevious) {
             val previousLinks = hashMapBuilder[links.previous]!!
-//            assert(previousLinks.next == element)
+            assert { previousLinks.next == element }
             @Suppress("UNCHECKED_CAST")
             hashMapBuilder[links.previous as E] = previousLinks.withNext(links.next)
         } else {
@@ -72,7 +72,7 @@ internal class PersistentOrderedSetBuilder<E>(set: PersistentOrderedSet<E>) :
         }
         if (links.hasNext) {
             val nextLinks = hashMapBuilder[links.next]!!
-//            assert(nextLinks.previous == element)
+            assert { nextLinks.previous == element }
             @Suppress("UNCHECKED_CAST")
             hashMapBuilder[links.next as E] = nextLinks.withPrevious(links.previous)
         } else {

--- a/core/commonMain/src/implementations/persistentOrderedSet/PersistentOrderedSetBuilder.kt
+++ b/core/commonMain/src/implementations/persistentOrderedSet/PersistentOrderedSetBuilder.kt
@@ -21,11 +21,11 @@ internal class PersistentOrderedSetBuilder<E>(set: PersistentOrderedSet<E>) :
 
     override fun build(): PersistentSet<E> {
         return builtSet?.also { set ->
-            assert(hashMapBuilder.builtMap != null)
-            assert(firstElement === set.firstElement)
-            assert(lastElement === set.lastElement)
+            assert { hashMapBuilder.builtMap != null }
+            assert { firstElement === set.firstElement }
+            assert { lastElement === set.lastElement }
         } ?: run {
-            assert(hashMapBuilder.builtMap == null)
+            assert { hashMapBuilder.builtMap == null }
             val newMap = hashMapBuilder.build()
             val newSet = PersistentOrderedSet(firstElement, lastElement, newMap)
             builtSet = newSet

--- a/core/commonMain/src/internal/commonFunctions.kt
+++ b/core/commonMain/src/internal/commonFunctions.kt
@@ -5,4 +5,4 @@
 
 package kotlinx.collections.immutable.internal
 
-internal expect fun assert(condition: Boolean)
+internal expect fun assert(condition: () -> Boolean)

--- a/core/commonTest/src/ObjectWrapper.kt
+++ b/core/commonTest/src/ObjectWrapper.kt
@@ -20,7 +20,7 @@ class ObjectWrapper<K: Comparable<K>>(
         if (other !is ObjectWrapper<*>) {
             return false
         }
-        assert(obj != other.obj || hashCode == other.hashCode)  // if elements are equal hashCodes must be equal
+        assert { obj != other.obj || hashCode == other.hashCode }  // if elements are equal hashCodes must be equal
         return obj == other.obj
     }
 

--- a/core/commonTest/src/implementations/list/TrieIteratorTest.kt
+++ b/core/commonTest/src/implementations/list/TrieIteratorTest.kt
@@ -6,7 +6,6 @@
 package tests.implementations.list
 
 import kotlinx.collections.immutable.implementations.immutableList.*
-import kotlinx.collections.immutable.internal.assert
 import kotlin.math.pow
 import kotlin.random.*
 import kotlin.test.*

--- a/core/jsMain/src/internal/commonFunctions.kt
+++ b/core/jsMain/src/internal/commonFunctions.kt
@@ -5,8 +5,4 @@
 
 package kotlinx.collections.immutable.internal
 
-internal actual fun assert(condition: Boolean) {
-    if (!condition) {
-        throw AssertionError("Assertion failed")
-    }
-}
+internal actual inline fun assert(condition: () -> Boolean) {}

--- a/core/jvmMain/src/internal/commonFunctions.kt
+++ b/core/jvmMain/src/internal/commonFunctions.kt
@@ -5,4 +5,10 @@
 
 package kotlinx.collections.immutable.internal
 
-internal actual fun assert(condition: Boolean) = kotlin.assert(condition)
+private class Assertions
+
+internal val ASSERTIONS_ENABLED = Assertions::class.java.desiredAssertionStatus()
+
+internal actual inline fun assert(condition: () -> Boolean) {
+    if (ASSERTIONS_ENABLED && !condition()) throw AssertionError("Assertion failed")
+}

--- a/core/jvmMain/src/internal/commonFunctions.kt
+++ b/core/jvmMain/src/internal/commonFunctions.kt
@@ -10,5 +10,9 @@ private class Assertions
 internal val ASSERTIONS_ENABLED = Assertions::class.java.desiredAssertionStatus()
 
 internal actual inline fun assert(condition: () -> Boolean) {
-    if (ASSERTIONS_ENABLED && !condition()) throw AssertionError("Assertion failed")
+    if (ASSERTIONS_ENABLED && !condition()) assertionFailed()
+}
+
+internal fun assertionFailed() {
+    throw AssertionError("Assertion failed")
 }

--- a/core/nativeMain/src/internal/commonFunctions.kt
+++ b/core/nativeMain/src/internal/commonFunctions.kt
@@ -6,4 +6,6 @@
 package kotlinx.collections.immutable.internal
 
 @OptIn(kotlin.experimental.ExperimentalNativeApi::class)
-internal actual fun assert(condition: Boolean) = kotlin.assert(condition)
+internal actual inline fun assert(condition: () -> Boolean) {
+    kotlin.assert(condition())
+}

--- a/core/wasmMain/src/internal/commonFunctions.kt
+++ b/core/wasmMain/src/internal/commonFunctions.kt
@@ -5,8 +5,4 @@
 
 package kotlinx.collections.immutable.internal
 
-internal actual fun assert(condition: Boolean) {
-    if (!condition) {
-        throw AssertionError("Assertion failed")
-    }
-}
+internal actual inline fun assert(condition: () -> Boolean) {}


### PR DESCRIPTION
This PR makes the internal assert zero-cost when disabled, following the kotlinx.coroutines approach: the condition is a lambda that is not evaluated unless assertions are enabled, and each platform provides an inline actual.

- JVM: checks run under `-ea`;
- Native: delegates to `kotlin.assert`;
- JS and Wasm: empty inline actual.

Benchmark runs with assertions disabled show identical allocation profiles and no time regression attributable to the change.
