### PR TITLE
Clean up small idioms and typos in core sources

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# Reformat core module sources to the official Kotlin style
+fb1ce236d600795bc2952b4953a1576547007169

--- a/core/commonMain/src/adapters/ReadOnlyCollectionAdapters.kt
+++ b/core/commonMain/src/adapters/ReadOnlyCollectionAdapters.kt
@@ -15,7 +15,7 @@ import kotlinx.collections.immutable.*
 
 public open class ImmutableCollectionAdapter<E>(private val impl: Collection<E>) :
     ImmutableCollection<E>, Collection<E> by impl {
-    override fun equals(other: Any?): Boolean = impl.equals(other)
+    override fun equals(other: Any?): Boolean = impl == other
     override fun hashCode(): Int = impl.hashCode()
     override fun toString(): String = impl.toString()
 }
@@ -26,7 +26,7 @@ public class ImmutableListAdapter<E>(private val impl: List<E>) : ImmutableList<
     override fun subList(fromIndex: Int, toIndex: Int): ImmutableList<E> =
         ImmutableListAdapter(impl.subList(fromIndex, toIndex))
 
-    override fun equals(other: Any?): Boolean = impl.equals(other)
+    override fun equals(other: Any?): Boolean = impl == other
     override fun hashCode(): Int = impl.hashCode()
     override fun toString(): String = impl.toString()
 }
@@ -41,7 +41,7 @@ public class ImmutableMapAdapter<K, out V>(private val impl: Map<K, V>) : Immuta
     override val values: ImmutableCollection<V> = ImmutableCollectionAdapter(impl.values)
     override val entries: ImmutableSet<Map.Entry<K, V>> = ImmutableSetAdapter(impl.entries)
 
-    override fun equals(other: Any?): Boolean = impl.equals(other)
+    override fun equals(other: Any?): Boolean = impl == other
     override fun hashCode(): Int = impl.hashCode()
     override fun toString(): String = impl.toString()
 }

--- a/core/commonMain/src/extensions.kt
+++ b/core/commonMain/src/extensions.kt
@@ -591,7 +591,7 @@ public fun CharSequence.toImmutableList(): ImmutableList<Char> = toPersistentLis
 public fun <T> Iterable<T>.toPersistentList(): PersistentList<T> =
     this as? PersistentList
         ?: (this as? PersistentList.Builder)?.build()
-        ?: persistentListOf<T>() + this
+        ?: (persistentListOf<T>() + this)
 
 /**
  * Returns a persistent list containing all elements of this array.
@@ -620,7 +620,7 @@ public fun CharSequence.toPersistentList(): PersistentList<Char> =
 public fun <T> Iterable<T>.toImmutableSet(): ImmutableSet<T> =
     this as? ImmutableSet<T>
         ?: (this as? PersistentSet.Builder)?.build()
-        ?: persistentSetOf<T>() + this
+        ?: (persistentSetOf<T>() + this)
 
 /**
  * Returns an immutable set of all elements of this array.
@@ -655,7 +655,7 @@ public fun CharSequence.toImmutableSet(): PersistentSet<Char> = toPersistentSet(
 public fun <T> Iterable<T>.toPersistentSet(): PersistentSet<T> =
     this as? PersistentOrderedSet<T>
         ?: (this as? PersistentOrderedSetBuilder)?.build()
-        ?: PersistentOrderedSet.emptyOf<T>() + this
+        ?: (PersistentOrderedSet.emptyOf<T>() + this)
 
 /**
  * Returns a persistent set of all elements of this array.
@@ -691,7 +691,7 @@ public fun CharSequence.toPersistentSet(): PersistentSet<Char> =
 public fun <T> Iterable<T>.toPersistentHashSet(): PersistentSet<T> =
     this as? PersistentHashSet
         ?: (this as? PersistentHashSetBuilder<T>)?.build()
-        ?: PersistentHashSet.emptyOf<T>() + this
+        ?: (PersistentHashSet.emptyOf<T>() + this)
 
 /**
  * Returns a persistent set of all elements of this array.

--- a/core/commonMain/src/implementations/immutableList/PersistentVector.kt
+++ b/core/commonMain/src/implementations/immutableList/PersistentVector.kt
@@ -150,7 +150,7 @@ internal class PersistentVector<E>(
         newRoot[bufferIndex] =
             insertIntoRoot(root[bufferIndex] as Array<Any?>, lowerLevelShift, index, element, elementCarry)
 
-        for (i in bufferIndex + 1 until MAX_BUFFER_SIZE) {
+        for (i in bufferIndex + 1..<MAX_BUFFER_SIZE) {
             if (newRoot[i] == null) break
 
             @Suppress("UNCHECKED_CAST")

--- a/core/commonMain/src/implementations/immutableList/PersistentVectorBuilder.kt
+++ b/core/commonMain/src/implementations/immutableList/PersistentVectorBuilder.kt
@@ -195,7 +195,7 @@ internal class PersistentVectorBuilder<E>(
             // fill remained space of tail
             buffers[0] = copyToBuffer(makeMutable(tail), tailSize, elementsIterator)
             // fill other buffers
-            for (index in 1 until buffersSize) {
+            for (index in 1..<buffersSize) {
                 buffers[index] = copyToBuffer(mutableBuffer(), 0, elementsIterator)
             }
 
@@ -358,7 +358,7 @@ internal class PersistentVectorBuilder<E>(
         mutableRoot[bufferIndex] =
             insertIntoRoot(mutableRoot[bufferIndex] as Array<Any?>, lowerLevelShift, index, element, elementCarry)
 
-        for (i in bufferIndex + 1 until MAX_BUFFER_SIZE) {
+        for (i in bufferIndex + 1..<MAX_BUFFER_SIZE) {
             if (mutableRoot[i] == null) break
             @Suppress("UNCHECKED_CAST")
             mutableRoot[i] =
@@ -548,7 +548,7 @@ internal class PersistentVectorBuilder<E>(
         val elementsIterator = elements.iterator()
 
         copyToBuffer(firstBuffer, startBufferStartIndex, elementsIterator)
-        for (i in 1 until newNullBuffers) {
+        for (i in 1..<newNullBuffers) {
             buffers[i] = copyToBuffer(mutableBuffer(), 0, elementsIterator)
         }
         copyToBuffer(newNextBuffer, 0, elementsIterator)
@@ -847,7 +847,7 @@ internal class PersistentVectorBuilder<E>(
      * Copies elements of the [tail] buffer of size [tailSize] that do not match the given [predicate] to a new buffer.
      *
      * If the [tail] is mutable, it is reused to store non-matching elements.
-     * If non of the elements match the [predicate], no buffers are created and elements are not copied.
+     * If none of the elements match the [predicate], no buffers are created and elements are not copied.
      * [bufferRef] stores the newly created buffer, or the [tail] if a new buffer was not created.
      *
      * Returns the filled size of the buffer stored in the [bufferRef].
@@ -874,7 +874,7 @@ internal class PersistentVectorBuilder<E>(
      * Copies elements of the given [buffer] of size [bufferSize] that do not match the given [predicate] to a new buffer.
      *
      * If the [buffer] is mutable, it is reused to store non-matching elements.
-     * If non of the elements match the [predicate], no buffers are created and elements are not copied.
+     * If none of the elements match the [predicate], no buffers are created and elements are not copied.
      * [bufferRef] stores the newly created buffer, or the [buffer] if a new buffer was not created.
      *
      * Returns the filled size of the buffer stored in the [bufferRef].
@@ -890,7 +890,7 @@ internal class PersistentVectorBuilder<E>(
 
         var anyRemoved = false
 
-        for (index in 0 until bufferSize) {
+        for (index in 0..<bufferSize) {
             @Suppress("UNCHECKED_CAST")
             val element = buffer[index] as E
 
@@ -940,7 +940,7 @@ internal class PersistentVectorBuilder<E>(
         var newToBuffer = toBuffer
         var newToBufferSize = toBufferSize
 
-        for (index in 0 until bufferSize) {
+        for (index in 0..<bufferSize) {
             @Suppress("UNCHECKED_CAST")
             val element = buffer[index] as E
 

--- a/core/commonMain/src/implementations/immutableList/SmallPersistentVector.kt
+++ b/core/commonMain/src/implementations/immutableList/SmallPersistentVector.kt
@@ -64,7 +64,7 @@ internal class SmallPersistentVector<E>(private val buffer: Array<Any?>) : Abstr
         var newSize = size
         var removeMask = 0
 
-        for (index in 0 until size) {
+        for (index in 0..<size) {
             @Suppress("UNCHECKED_CAST")
             val element = buffer[index] as E
 
@@ -80,7 +80,7 @@ internal class SmallPersistentVector<E>(private val buffer: Array<Any?>) : Abstr
             else -> {
                 val newBuffer = buffer.copyOf(newSize)
                 var newIndex = removeMask.countTrailingZeroBits()
-                for (index in newIndex + 1 until size) {
+                for (index in newIndex + 1..<size) {
                     if ((removeMask ushr index) and 1 == 0) {
                         newBuffer[newIndex++] = buffer[index]
                     }

--- a/core/commonMain/src/implementations/immutableMap/PersistentHashMapBuilderContentIterators.kt
+++ b/core/commonMain/src/implementations/immutableMap/PersistentHashMapBuilderContentIterators.kt
@@ -166,9 +166,9 @@ internal class PersistentHashMapBuilderEntriesIterator<K, V>(
 }
 
 internal class PersistentHashMapBuilderKeysIterator<K, V>(builder: PersistentHashMapBuilder<K, V>) :
-    PersistentHashMapBuilderBaseIterator<K, V, K>(builder, Array(TRIE_MAX_HEIGHT + 1) { TrieNodeKeysIterator<K, V>() })
+    PersistentHashMapBuilderBaseIterator<K, V, K>(builder, Array(TRIE_MAX_HEIGHT + 1) { TrieNodeKeysIterator() })
 
 internal class PersistentHashMapBuilderValuesIterator<K, V>(builder: PersistentHashMapBuilder<K, V>) :
     PersistentHashMapBuilderBaseIterator<K, V, V>(
-        builder, Array(TRIE_MAX_HEIGHT + 1) { TrieNodeValuesIterator<K, V>() }
+        builder, Array(TRIE_MAX_HEIGHT + 1) { TrieNodeValuesIterator() }
     )

--- a/core/commonMain/src/implementations/immutableMap/PersistentHashMapContentIterators.kt
+++ b/core/commonMain/src/implementations/immutableMap/PersistentHashMapContentIterators.kt
@@ -94,7 +94,7 @@ internal open class MapEntry<out K, out V>(override val key: K, override val val
     override fun equals(other: Any?): Boolean =
         (other as? Map.Entry<*, *>)?.let { it.key == key && it.value == value } ?: false
 
-    override fun toString(): String = key.toString() + "=" + value.toString()
+    override fun toString(): String = "$key=$value"
 }
 
 
@@ -177,11 +177,11 @@ internal abstract class PersistentHashMapBaseIterator<K, V, T>(
 
 internal class PersistentHashMapEntriesIterator<K, V>(node: TrieNode<K, V>) :
     PersistentHashMapBaseIterator<K, V, Map.Entry<K, V>>(
-        node, Array(TRIE_MAX_HEIGHT + 1) { TrieNodeEntriesIterator<K, V>() }
+        node, Array(TRIE_MAX_HEIGHT + 1) { TrieNodeEntriesIterator() }
     )
 
 internal class PersistentHashMapKeysIterator<K, V>(node: TrieNode<K, V>) :
-    PersistentHashMapBaseIterator<K, V, K>(node, Array(TRIE_MAX_HEIGHT + 1) { TrieNodeKeysIterator<K, V>() })
+    PersistentHashMapBaseIterator<K, V, K>(node, Array(TRIE_MAX_HEIGHT + 1) { TrieNodeKeysIterator() })
 
 internal class PersistentHashMapValuesIterator<K, V>(node: TrieNode<K, V>) :
-    PersistentHashMapBaseIterator<K, V, V>(node, Array(TRIE_MAX_HEIGHT + 1) { TrieNodeValuesIterator<K, V>() })
+    PersistentHashMapBaseIterator<K, V, V>(node, Array(TRIE_MAX_HEIGHT + 1) { TrieNodeValuesIterator() })

--- a/core/commonMain/src/implementations/immutableMap/TrieNode.kt
+++ b/core/commonMain/src/implementations/immutableMap/TrieNode.kt
@@ -383,7 +383,7 @@ internal class TrieNode<K, V>(
     }
 
     private fun collisionKeyIndex(key: Any?): Int {
-        for (i in 0 until buffer.size step ENTRY_SIZE) {
+        for (i in 0..<buffer.size step ENTRY_SIZE) {
             if (key == keyAtIndex(i)) return i
         }
         return -1
@@ -480,7 +480,7 @@ internal class TrieNode<K, V>(
         assert(otherNode.dataMap == 0)
         val tempBuffer = this.buffer.copyOf(newSize = this.buffer.size + otherNode.buffer.size)
         var i = this.buffer.size
-        for (j in 0 until otherNode.buffer.size step ENTRY_SIZE) {
+        for (j in 0..<otherNode.buffer.size step ENTRY_SIZE) {
             @Suppress("UNCHECKED_CAST")
             if (!this.collisionContainsKey(otherNode.buffer[j] as K)) {
                 tempBuffer[i] = otherNode.buffer[j]
@@ -581,7 +581,7 @@ internal class TrieNode<K, V>(
         if (nodeMap == 0) return buffer.size / ENTRY_SIZE
         val numValues = dataMap.countOneBits()
         var result = numValues
-        for (i in (numValues * ENTRY_SIZE) until buffer.size) {
+        for (i in (numValues * ENTRY_SIZE)..<buffer.size) {
             result += nodeAtIndex(i).calculateSize()
         }
         return result
@@ -591,7 +591,7 @@ internal class TrieNode<K, V>(
         if (this === otherNode) return true
         if (nodeMap != otherNode.nodeMap) return false
         if (dataMap != otherNode.dataMap) return false
-        for (i in 0 until buffer.size) {
+        for (i in buffer.indices) {
             if (buffer[i] !== otherNode.buffer[i]) return false
         }
         return true
@@ -923,7 +923,7 @@ internal class TrieNode<K, V>(
         if (dataMap != that.dataMap || nodeMap != that.nodeMap) return false
         if (dataMap == 0 && nodeMap == 0) { // collision node
             if (buffer.size != that.buffer.size) return false
-            return (0 until buffer.size step ENTRY_SIZE).all { i ->
+            return (buffer.indices step ENTRY_SIZE).all { i ->
                 val thatKey = that.keyAtIndex(i)
                 val thatValue = that.valueAtKeyIndex(i)
                 val keyIndex = collisionKeyIndex(thatKey)
@@ -935,11 +935,11 @@ internal class TrieNode<K, V>(
         }
 
         val valueSize = dataMap.countOneBits() * ENTRY_SIZE
-        for (i in 0 until valueSize step ENTRY_SIZE) {
+        for (i in 0..<valueSize step ENTRY_SIZE) {
             if (keyAtIndex(i) != that.keyAtIndex(i)) return false
             if (!equalityComparator(valueAtKeyIndex(i), that.valueAtKeyIndex(i))) return false
         }
-        for (i in valueSize until buffer.size) {
+        for (i in valueSize..<buffer.size) {
             if (!nodeAtIndex(i).equalsWith(that.nodeAtIndex(i), equalityComparator)) return false
         }
         return true

--- a/core/commonMain/src/implementations/immutableSet/PersistentHashSet.kt
+++ b/core/commonMain/src/implementations/immutableSet/PersistentHashSet.kt
@@ -67,7 +67,7 @@ internal class PersistentHashSet<E>(
         replaceWith = ReplaceWith("retainingAll(elements)")
     )
     override fun retainAll(elements: Collection<E>): PersistentSet<E> {
-        if (elements.isEmpty()) return PersistentHashSet.emptyOf<E>()
+        if (elements.isEmpty()) return emptyOf()
         return mutate { it.retainAll(elements) }
     }
 
@@ -86,7 +86,7 @@ internal class PersistentHashSet<E>(
         replaceWith = ReplaceWith("cleared()")
     )
     override fun clear(): PersistentSet<E> {
-        return PersistentHashSet.emptyOf()
+        return emptyOf()
     }
 
     override fun iterator(): Iterator<E> {
@@ -99,6 +99,6 @@ internal class PersistentHashSet<E>(
 
     internal companion object {
         private val EMPTY = PersistentHashSet(TrieNode.EMPTY, 0)
-        internal fun <E> emptyOf(): PersistentSet<E> = PersistentHashSet.EMPTY
+        internal fun <E> emptyOf(): PersistentSet<E> = EMPTY
     }
 }

--- a/core/commonMain/src/implementations/immutableSet/TrieNode.kt
+++ b/core/commonMain/src/implementations/immutableSet/TrieNode.kt
@@ -43,7 +43,7 @@ private fun Array<Any?>.removeCellAtIndex(cellIndex: Int): Array<Any?> {
 
 /**
  * Writes all elements from [this] to [newArray], starting with [newArrayOffset], filtering
- * on the fly using [predicate]. By default filters out [TrieNode.EMPTY] instances
+ * on the fly using [predicate]. By default, filters out [TrieNode.EMPTY] instances
  *
  * return number of elements written to [newArray]
  **/
@@ -341,7 +341,7 @@ internal class TrieNode<E>(
     private fun elementsIdentityEquals(otherNode: TrieNode<E>): Boolean {
         if (this === otherNode) return true
         if (bitmap != otherNode.bitmap) return false
-        for (i in 0 until buffer.size) {
+        for (i in buffer.indices) {
             if (buffer[i] !== otherNode.buffer[i]) return false
         }
         return true
@@ -468,7 +468,7 @@ internal class TrieNode<E>(
         mutator: PersistentHashSetBuilder<*>
     ): Any? {
         if (this === otherNode) {
-            intersectionSizeRef += calculateSize();
+            intersectionSizeRef += calculateSize()
             return this
         }
         if (shift > MAX_SHIFT) {
@@ -571,7 +571,7 @@ internal class TrieNode<E>(
         mutator: PersistentHashSetBuilder<*>
     ): Any? {
         if (this === otherNode) {
-            intersectionSizeRef += calculateSize();
+            intersectionSizeRef += calculateSize()
             return EMPTY
         }
         if (shift > MAX_SHIFT) {
@@ -585,7 +585,7 @@ internal class TrieNode<E>(
         // node here is either us (if we are mutable) or a mutable copy
         val mutableNode =
             if (ownedBy == mutator.ownership) this
-            else TrieNode<E>(bitmap, buffer.copyOf(), mutator.ownership)
+            else TrieNode(bitmap, buffer.copyOf(), mutator.ownership)
         // keep track of the real mask
         var realBitMap = bitmap
         removalBitmap.forEachOneBit { positionMask, _ ->
@@ -806,8 +806,9 @@ internal class TrieNode<E>(
                 targetNode.mutableRemove(elementHash, element, shift + LOG_MAX_BRANCHING_FACTOR, mutator)
             }
             // If newNode is a single-element node, it is newly created, or targetNode is owned by mutator and a cell was removed in-place.
-            //      Otherwise the single element would have been lifted up.
-            // If targetNode is owned by mutator, this node is also owned by mutator. Thus no new node will be created to replace this node.
+            // Otherwise, the single element would have been lifted up.
+            // If targetNode is owned by mutator, this node is also owned by mutator.
+            // Thus, no new node will be created to replace this node.
             // If newNode !== targetNode, it is newly created.
             if (targetNode.ownedBy !== mutator.ownership && targetNode === newNode) return this
             return canonicalizeNodeAtIndex(cellIndex, newNode, mutator.ownership)

--- a/core/commonMain/src/implementations/persistentOrderedSet/PersistentOrderedSet.kt
+++ b/core/commonMain/src/implementations/persistentOrderedSet/PersistentOrderedSet.kt
@@ -122,7 +122,7 @@ internal class PersistentOrderedSet<E>(
         replaceWith = ReplaceWith("cleared()")
     )
     override fun clear(): PersistentSet<E> {
-        return PersistentOrderedSet.emptyOf()
+        return emptyOf()
     }
 
     override fun iterator(): Iterator<E> {

--- a/core/commonMain/src/internal/ListImplementation.kt
+++ b/core/commonMain/src/internal/ListImplementation.kt
@@ -11,14 +11,14 @@ internal object ListImplementation {
 
     @JvmStatic
     internal fun checkElementIndex(index: Int, size: Int) {
-        if (index < 0 || index >= size) {
+        if (index !in 0..<size) {
             throw IndexOutOfBoundsException("index: $index, size: $size")
         }
     }
 
     @JvmStatic
     internal fun checkPositionIndex(index: Int, size: Int) {
-        if (index < 0 || index > size) {
+        if (index !in 0..size) {
             throw IndexOutOfBoundsException("index: $index, size: $size")
         }
     }


### PR DESCRIPTION
No behavior changes. Based on #287. Also adds .git-blame-ignore-revs; before merging, re-point it at the hash #287 gets when squashed.

Replaces #288, which GitHub marked as merged after an accidental direct push to its base branch.
