### PR TITLE
Lift the single remaining element to the root in set retainAll

### DIFF
--- a/core/commonMain/src/implementations/immutableSet/TrieNode.kt
+++ b/core/commonMain/src/implementations/immutableSet/TrieNode.kt
@@ -784,6 +784,7 @@ internal class TrieNode<E>(
         }
         // element is directly in buffer
         if (element == buffer[cellIndex]) {
+            assert { shift == 0 || buffer.size > 1 }
             return removeCellAtIndex(cellIndex, cellPositionMask, owner = null)
         }
         return this
@@ -814,6 +815,7 @@ internal class TrieNode<E>(
         }
         // element is directly in buffer
         if (element == buffer[cellIndex]) {
+            assert { shift == 0 || buffer.size > 1 }
             mutator.size--
             return removeCellAtIndex(cellIndex, cellPositionMask, mutator.ownership) // check is empty
         }

--- a/core/commonMain/src/implementations/immutableSet/TrieNode.kt
+++ b/core/commonMain/src/implementations/immutableSet/TrieNode.kt
@@ -539,6 +539,13 @@ internal class TrieNode<E>(
         val realSize = realBitMap.countOneBits()
         return when {
             realBitMap == 0 -> EMPTY
+            // single values are kept only on root level
+            realSize == 1 && shift != 0 ->
+                when (val single = mutableNode.buffer[mutableNode.indexOfCellAt(realBitMap)]) {
+                    is TrieNode<*> -> TrieNode<E>(realBitMap, arrayOf(single), mutator.ownership)
+                    else -> single
+                }
+
             realBitMap == newBitMap -> {
                 when {
                     mutableNode.elementsIdentityEquals(this) -> this
@@ -546,12 +553,6 @@ internal class TrieNode<E>(
                     else -> mutableNode
                 }
             }
-            // single values are kept only on root level
-            realSize == 1 && shift != 0 ->
-                when (val single = mutableNode.buffer[mutableNode.indexOfCellAt(realBitMap)]) {
-                    is TrieNode<*> -> TrieNode<E>(realBitMap, arrayOf(single), mutator.ownership)
-                    else -> single
-                }
 
             else -> {
                 // clean up all the EMPTYs in the resulting buffer

--- a/core/commonTest/src/contract/set/ImmutableSetTest.kt
+++ b/core/commonTest/src/contract/set/ImmutableSetTest.kt
@@ -366,6 +366,7 @@ abstract class ImmutableSetTestBase {
     private fun <E> testSpecializedEquality(set: Set<E>, elements: Array<E>, isEqual: Boolean) {
         fun testEqualsAndHashCode(lhs: Any, rhs: Any) {
             assertEquals(isEqual, lhs == rhs)
+            assertEquals(isEqual, rhs == lhs)
             if (isEqual) assertEquals(lhs.hashCode(), rhs.hashCode())
         }
 

--- a/core/commonTest/src/contract/set/PersistentHashSetBuilderTest.kt
+++ b/core/commonTest/src/contract/set/PersistentHashSetBuilderTest.kt
@@ -116,4 +116,15 @@ class PersistentHashSetBuilderTest {
             iterator2.next()
         }
     }
+
+    @Test
+    fun `retainAll should promote the only remaining element to the root`() {
+        val builder = persistentHashSetOf(1, 33).builder()
+        builder.retainAll(persistentHashSetOf(1, 65))
+        val expected = persistentHashSetOf(1)
+
+        assertTrue(expected.equals(builder))
+        assertEquals(expected, builder.build())
+        assertEquals(builder.build(), expected)
+    }
 }

--- a/core/commonTest/src/contract/set/PersistentHashSetTest.kt
+++ b/core/commonTest/src/contract/set/PersistentHashSetTest.kt
@@ -6,9 +6,11 @@
 package tests.contract.set
 
 import kotlinx.collections.immutable.implementations.immutableSet.PersistentHashSet
+import kotlinx.collections.immutable.intersect
 import kotlinx.collections.immutable.persistentHashSetOf
 import kotlinx.collections.immutable.minus
 import kotlinx.collections.immutable.toPersistentHashSet
+import tests.IntWrapper
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
@@ -55,5 +57,60 @@ class PersistentHashSetTest {
         val actual = set1 - set2
 
         assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `intersect should promote the only remaining element to the root`() {
+        val intersection = persistentHashSetOf(1, 33) intersect persistentHashSetOf(1, 65)
+        val expected = persistentHashSetOf(1)
+
+        assertEquals(expected, intersection)
+        assertEquals(intersection, expected)
+        assertEquals(expected.hashCode(), intersection.hashCode())
+        assertEquals(1, intersection.size)
+        assertTrue(1 in intersection)
+        assertEquals(listOf(1), intersection.toList())
+    }
+
+    @Test
+    fun `intersect should promote the only remaining element through multiple levels`() {
+        val intersection = persistentHashSetOf(1, 1 + (1 shl 10)) intersect persistentHashSetOf(1, 1 + (1 shl 11))
+        val expected = persistentHashSetOf(1)
+
+        assertEquals(expected, intersection)
+        assertEquals(intersection, expected)
+        assertEquals(expected.hashCode(), intersection.hashCode())
+    }
+
+    @Test
+    fun `intersect should keep a single remaining sub-node on its level`() {
+        val intersection = persistentHashSetOf(1, 1 + (1 shl 10), 33) intersect
+                persistentHashSetOf(1, 1 + (1 shl 10), 65)
+        val expected = persistentHashSetOf(1, 1 + (1 shl 10))
+
+        assertEquals(expected, intersection)
+        assertEquals(intersection, expected)
+        assertEquals(expected.hashCode(), intersection.hashCode())
+    }
+
+    @Test
+    fun `intersect of colliding elements should promote the only remaining element to the root`() {
+        val intersection = persistentHashSetOf(IntWrapper(1, 0), IntWrapper(2, 0)) intersect
+                persistentHashSetOf(IntWrapper(1, 0), IntWrapper(3, 0))
+        val expected = persistentHashSetOf(IntWrapper(1, 0))
+
+        assertEquals(expected, intersection)
+        assertEquals(intersection, expected)
+        assertEquals(expected.hashCode(), intersection.hashCode())
+    }
+
+    @Test
+    fun `removing the only remaining element after intersect should result in an empty set`() {
+        val intersection = persistentHashSetOf(1, 33) intersect persistentHashSetOf(1, 65)
+        val empty = intersection - 1
+
+        assertEquals(persistentHashSetOf<Int>(), empty)
+        assertEquals(empty, persistentHashSetOf())
+        assertTrue(empty.isEmpty())
     }
 }


### PR DESCRIPTION
`mutableRetainAll` now does the single-element lift-up before the identity-reuse early return that used to skip it, matching the branch order of `mutableRemoveAll`.

Fixes #291