### PR TITLE
Update Kotlin to 2.4.10

### DIFF
--- a/core/api/kotlinx-collections-immutable.api
+++ b/core/api/kotlinx-collections-immutable.api
@@ -91,6 +91,7 @@ public abstract interface class kotlinx/collections/immutable/ImmutableCollectio
 }
 
 public abstract interface class kotlinx/collections/immutable/ImmutableList : java/util/List, kotlin/jvm/internal/markers/KMappedMarker, kotlinx/collections/immutable/ImmutableCollection {
+	public synthetic fun subList (II)Ljava/util/List;
 	public abstract fun subList (II)Lkotlinx/collections/immutable/ImmutableList;
 }
 
@@ -99,9 +100,15 @@ public final class kotlinx/collections/immutable/ImmutableList$DefaultImpls {
 }
 
 public abstract interface class kotlinx/collections/immutable/ImmutableMap : java/util/Map, kotlin/jvm/internal/markers/KMappedMarker {
+	public synthetic fun entrySet ()Ljava/util/Set;
+	public fun entrySet ()Lkotlinx/collections/immutable/ImmutableSet;
 	public abstract fun getEntries ()Lkotlinx/collections/immutable/ImmutableSet;
 	public abstract fun getKeys ()Lkotlinx/collections/immutable/ImmutableSet;
 	public abstract fun getValues ()Lkotlinx/collections/immutable/ImmutableCollection;
+	public synthetic fun keySet ()Ljava/util/Set;
+	public fun keySet ()Lkotlinx/collections/immutable/ImmutableSet;
+	public synthetic fun values ()Ljava/util/Collection;
+	public fun values ()Lkotlinx/collections/immutable/ImmutableCollection;
 }
 
 public abstract interface class kotlinx/collections/immutable/ImmutableSet : java/util/Set, kotlin/jvm/internal/markers/KMappedMarker, kotlinx/collections/immutable/ImmutableCollection {
@@ -141,31 +148,47 @@ public final class kotlinx/collections/immutable/PersistentCollection$DefaultImp
 
 public abstract interface class kotlinx/collections/immutable/PersistentList : kotlinx/collections/immutable/ImmutableList, kotlinx/collections/immutable/PersistentCollection {
 	public abstract fun add (ILjava/lang/Object;)Lkotlinx/collections/immutable/PersistentList;
+	public synthetic fun add (Ljava/lang/Object;)Lkotlinx/collections/immutable/PersistentCollection;
 	public abstract fun add (Ljava/lang/Object;)Lkotlinx/collections/immutable/PersistentList;
 	public abstract fun addAll (ILjava/util/Collection;)Lkotlinx/collections/immutable/PersistentList;
+	public synthetic fun addAll (Ljava/util/Collection;)Lkotlinx/collections/immutable/PersistentCollection;
 	public abstract fun addAll (Ljava/util/Collection;)Lkotlinx/collections/immutable/PersistentList;
+	public synthetic fun adding (Ljava/lang/Object;)Lkotlinx/collections/immutable/PersistentCollection;
 	public abstract fun adding (Ljava/lang/Object;)Lkotlinx/collections/immutable/PersistentList;
+	public synthetic fun addingAll (Ljava/util/Collection;)Lkotlinx/collections/immutable/PersistentCollection;
 	public abstract fun addingAll (Ljava/util/Collection;)Lkotlinx/collections/immutable/PersistentList;
 	public abstract fun addingAllAt (ILjava/util/Collection;)Lkotlinx/collections/immutable/PersistentList;
 	public abstract fun addingAt (ILjava/lang/Object;)Lkotlinx/collections/immutable/PersistentList;
+	public synthetic fun builder ()Lkotlinx/collections/immutable/PersistentCollection$Builder;
 	public abstract fun builder ()Lkotlinx/collections/immutable/PersistentList$Builder;
+	public synthetic fun clear ()Lkotlinx/collections/immutable/PersistentCollection;
 	public abstract fun clear ()Lkotlinx/collections/immutable/PersistentList;
+	public synthetic fun cleared ()Lkotlinx/collections/immutable/PersistentCollection;
 	public abstract fun cleared ()Lkotlinx/collections/immutable/PersistentList;
+	public synthetic fun remove (Ljava/lang/Object;)Lkotlinx/collections/immutable/PersistentCollection;
 	public abstract fun remove (Ljava/lang/Object;)Lkotlinx/collections/immutable/PersistentList;
+	public synthetic fun removeAll (Ljava/util/Collection;)Lkotlinx/collections/immutable/PersistentCollection;
 	public abstract fun removeAll (Ljava/util/Collection;)Lkotlinx/collections/immutable/PersistentList;
+	public synthetic fun removeAll (Lkotlin/jvm/functions/Function1;)Lkotlinx/collections/immutable/PersistentCollection;
 	public abstract fun removeAll (Lkotlin/jvm/functions/Function1;)Lkotlinx/collections/immutable/PersistentList;
 	public abstract fun removeAt (I)Lkotlinx/collections/immutable/PersistentList;
+	public synthetic fun removing (Ljava/lang/Object;)Lkotlinx/collections/immutable/PersistentCollection;
 	public abstract fun removing (Ljava/lang/Object;)Lkotlinx/collections/immutable/PersistentList;
+	public synthetic fun removingAll (Ljava/util/Collection;)Lkotlinx/collections/immutable/PersistentCollection;
 	public abstract fun removingAll (Ljava/util/Collection;)Lkotlinx/collections/immutable/PersistentList;
+	public synthetic fun removingAll (Lkotlin/jvm/functions/Function1;)Lkotlinx/collections/immutable/PersistentCollection;
 	public abstract fun removingAll (Lkotlin/jvm/functions/Function1;)Lkotlinx/collections/immutable/PersistentList;
 	public abstract fun removingAt (I)Lkotlinx/collections/immutable/PersistentList;
 	public abstract fun replacingAt (ILjava/lang/Object;)Lkotlinx/collections/immutable/PersistentList;
+	public synthetic fun retainAll (Ljava/util/Collection;)Lkotlinx/collections/immutable/PersistentCollection;
 	public abstract fun retainAll (Ljava/util/Collection;)Lkotlinx/collections/immutable/PersistentList;
+	public synthetic fun retainingAll (Ljava/util/Collection;)Lkotlinx/collections/immutable/PersistentCollection;
 	public abstract fun retainingAll (Ljava/util/Collection;)Lkotlinx/collections/immutable/PersistentList;
 	public abstract fun set (ILjava/lang/Object;)Lkotlinx/collections/immutable/PersistentList;
 }
 
 public abstract interface class kotlinx/collections/immutable/PersistentList$Builder : java/util/List, kotlin/jvm/internal/markers/KMutableList, kotlinx/collections/immutable/PersistentCollection$Builder {
+	public synthetic fun build ()Lkotlinx/collections/immutable/PersistentCollection;
 	public abstract fun build ()Lkotlinx/collections/immutable/PersistentList;
 }
 
@@ -211,24 +234,40 @@ public final class kotlinx/collections/immutable/PersistentMap$DefaultImpls {
 }
 
 public abstract interface class kotlinx/collections/immutable/PersistentSet : kotlinx/collections/immutable/ImmutableSet, kotlinx/collections/immutable/PersistentCollection {
+	public synthetic fun add (Ljava/lang/Object;)Lkotlinx/collections/immutable/PersistentCollection;
 	public abstract fun add (Ljava/lang/Object;)Lkotlinx/collections/immutable/PersistentSet;
+	public synthetic fun addAll (Ljava/util/Collection;)Lkotlinx/collections/immutable/PersistentCollection;
 	public abstract fun addAll (Ljava/util/Collection;)Lkotlinx/collections/immutable/PersistentSet;
+	public synthetic fun adding (Ljava/lang/Object;)Lkotlinx/collections/immutable/PersistentCollection;
 	public abstract fun adding (Ljava/lang/Object;)Lkotlinx/collections/immutable/PersistentSet;
+	public synthetic fun addingAll (Ljava/util/Collection;)Lkotlinx/collections/immutable/PersistentCollection;
 	public abstract fun addingAll (Ljava/util/Collection;)Lkotlinx/collections/immutable/PersistentSet;
+	public synthetic fun builder ()Lkotlinx/collections/immutable/PersistentCollection$Builder;
 	public abstract fun builder ()Lkotlinx/collections/immutable/PersistentSet$Builder;
+	public synthetic fun clear ()Lkotlinx/collections/immutable/PersistentCollection;
 	public abstract fun clear ()Lkotlinx/collections/immutable/PersistentSet;
+	public synthetic fun cleared ()Lkotlinx/collections/immutable/PersistentCollection;
 	public abstract fun cleared ()Lkotlinx/collections/immutable/PersistentSet;
+	public synthetic fun remove (Ljava/lang/Object;)Lkotlinx/collections/immutable/PersistentCollection;
 	public abstract fun remove (Ljava/lang/Object;)Lkotlinx/collections/immutable/PersistentSet;
+	public synthetic fun removeAll (Ljava/util/Collection;)Lkotlinx/collections/immutable/PersistentCollection;
 	public abstract fun removeAll (Ljava/util/Collection;)Lkotlinx/collections/immutable/PersistentSet;
+	public synthetic fun removeAll (Lkotlin/jvm/functions/Function1;)Lkotlinx/collections/immutable/PersistentCollection;
 	public abstract fun removeAll (Lkotlin/jvm/functions/Function1;)Lkotlinx/collections/immutable/PersistentSet;
+	public synthetic fun removing (Ljava/lang/Object;)Lkotlinx/collections/immutable/PersistentCollection;
 	public abstract fun removing (Ljava/lang/Object;)Lkotlinx/collections/immutable/PersistentSet;
+	public synthetic fun removingAll (Ljava/util/Collection;)Lkotlinx/collections/immutable/PersistentCollection;
 	public abstract fun removingAll (Ljava/util/Collection;)Lkotlinx/collections/immutable/PersistentSet;
+	public synthetic fun removingAll (Lkotlin/jvm/functions/Function1;)Lkotlinx/collections/immutable/PersistentCollection;
 	public abstract fun removingAll (Lkotlin/jvm/functions/Function1;)Lkotlinx/collections/immutable/PersistentSet;
+	public synthetic fun retainAll (Ljava/util/Collection;)Lkotlinx/collections/immutable/PersistentCollection;
 	public abstract fun retainAll (Ljava/util/Collection;)Lkotlinx/collections/immutable/PersistentSet;
+	public synthetic fun retainingAll (Ljava/util/Collection;)Lkotlinx/collections/immutable/PersistentCollection;
 	public abstract fun retainingAll (Ljava/util/Collection;)Lkotlinx/collections/immutable/PersistentSet;
 }
 
 public abstract interface class kotlinx/collections/immutable/PersistentSet$Builder : java/util/Set, kotlin/jvm/internal/markers/KMutableSet, kotlinx/collections/immutable/PersistentCollection$Builder {
+	public synthetic fun build ()Lkotlinx/collections/immutable/PersistentCollection;
 	public abstract fun build ()Lkotlinx/collections/immutable/PersistentSet;
 }
 

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -27,10 +27,8 @@ val jdkToolchainVersion = 21
 kotlin {
     applyDefaultHierarchyTemplate()
     explicitApi()
-    abiValidation {
-        @OptIn(ExperimentalAbiValidation::class)
-        enabled = true
-    }
+    @OptIn(ExperimentalAbiValidation::class)
+    abiValidation { }
     compilerOptions {
         freeCompilerArgs.add("-Xreturn-value-checker=full")
     }
@@ -210,11 +208,11 @@ tasks {
         description = "Checks that jvmMain/java9/module-info.java exports exactly the public-API packages."
 
         @OptIn(ExperimentalAbiValidation::class)
-        val dumpDir = kotlin.abiValidation.legacyDump.legacyDumpTaskProvider.flatMap { it.dumpDir }
+        val dumpDir = kotlin.abiValidation.referenceDumpDir
         val moduleInfoFile = layout.projectDirectory.file("jvmMain/java9/module-info.java")
 
         inputs.file(moduleInfoFile).withPropertyName("moduleInfo")
-        inputs.dir(dumpDir).withPropertyName("legacyDumpDir")
+        inputs.dir(dumpDir).withPropertyName("referenceDumpDir")
 
         val exportsRegex = Regex("""exports\s+([\w.]+)\s*;""")
         val classDeclRegex = Regex("""^(?:public|protected).*\bclass\s+(\S+)""")
@@ -257,11 +255,7 @@ tasks {
     }
 
     check {
-        dependsOn(
-            // TODO: https://youtrack.jetbrains.com/issue/KT-78525
-            checkLegacyAbi,
-            checkModuleInfoExports
-        )
+        dependsOn(checkModuleInfoExports)
     }
 
     val compileJvmModuleInfo by registering(JavaCompile::class) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@ group=org.jetbrains.kotlinx
 version=0.5.1
 versionSuffix=SNAPSHOT
 
-kotlin_version=2.3.0
+kotlin_version=2.4.10
 dokkaVersion=2.2.0
 kotlinxBenchmarkVersion=0.4.15
 koverVersion=0.9.9

--- a/kotlin-js-store/yarn.lock
+++ b/kotlin-js-store/yarn.lock
@@ -226,6 +226,11 @@ is-fullwidth-code-point@^3.0.0:
   resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz#f116f8064fe90b3f7844a38997c0b75051269f1d"
   integrity sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==
 
+is-path-inside@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/is-path-inside/-/is-path-inside-3.0.3.tgz#d231362e53a07ff2b0e0ea7fed049161ffd16283"
+  integrity sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==
+
 is-plain-obj@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-2.1.0.tgz#45e42e37fccf1f40da8e5f76ee21515840c09287"
@@ -301,10 +306,10 @@ minimatch@^9.0.4, minimatch@^9.0.5:
   resolved "https://registry.yarnpkg.com/minipass/-/minipass-7.1.3.tgz#79389b4eb1bb2d003a9bba87d492f2bd37bdc65b"
   integrity sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==
 
-mocha@11.7.2:
-  version "11.7.2"
-  resolved "https://registry.yarnpkg.com/mocha/-/mocha-11.7.2.tgz#3c0079fe5cc2f8ea86d99124debcc42bb1ab22b5"
-  integrity sha512-lkqVJPmqqG/w5jmmFtiRvtA2jkDyNVUcefFJKb2uyX4dekk8Okgqop3cgbFiaIvj8uCRJVTP5x9dfxGyXm2jvQ==
+mocha@11.7.5:
+  version "11.7.5"
+  resolved "https://registry.yarnpkg.com/mocha/-/mocha-11.7.5.tgz#58f5bbfa5e0211ce7e5ee6128107cefc2515a627"
+  integrity sha512-mTT6RgopEYABzXWFx+GcJ+ZQ32kp4fMf0xvpZIIfSq9Z8lC/++MtcCnQ9t5FP2veYEP95FIYSvW+U9fV4xrlig==
   dependencies:
     browser-stdout "^1.3.1"
     chokidar "^4.0.1"
@@ -314,6 +319,7 @@ mocha@11.7.2:
     find-up "^5.0.0"
     glob "^10.4.5"
     he "^1.2.0"
+    is-path-inside "^3.0.3"
     js-yaml "^4.1.0"
     log-symbols "^4.1.0"
     minimatch "^9.0.5"
@@ -438,7 +444,16 @@ source-map@^0.6.0:
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
 
-"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0":
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -456,7 +471,14 @@ string-width@^5.0.1, string-width@^5.1.2:
     emoji-regex "^9.2.2"
     strip-ansi "^7.0.1"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -501,7 +523,16 @@ workerpool@^9.2.0:
   resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-9.3.4.tgz#f6c92395b2141afd78e2a889e80cb338fe9fca41"
   integrity sha512-TmPRQYYSAnnDiEB0P/Ytip7bFGvqnSU6I2BcuSw7Hx+JSg/DsUi5ebYfc8GYaSdpuvOcEs6dXxPurOYpe9QFwg==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==


### PR DESCRIPTION
The ABI validation DSL changed shape in 2.4.10: invoking abiValidation() is what enables it now, and check depends on the ABI check out of the box, which removes the explicit wiring for KT-78525. The additions in the JVM ABI dump are bridge methods newly emitted by the 2.4 compiler, verified against the published 0.5.0 bytecode; the klib dumps are unchanged.
