### PR TITLE
Add opt-in Power-Assert support for invariant asserts

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,6 +10,7 @@ buildscript {
 
 plugins {
     id("kotlinx.team.infra") version "0.4.0-dev-91"
+    id("org.jetbrains.kotlin.plugin.power-assert") apply false
 }
 
 infra {

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -153,6 +153,19 @@ kotlin {
     }
 }
 
+providers.gradleProperty("powerAssert").orNull?.let { requestedSourceSets ->
+    apply(plugin = "org.jetbrains.kotlin.plugin.power-assert")
+    configure<org.jetbrains.kotlin.powerassert.gradle.PowerAssertGradleExtension> {
+        functions.set(listOf("kotlinx.collections.immutable.internal.AssertScope.otherwise"))
+        includedSourceSets.set(
+            if (requestedSourceSets.isBlank())
+                kotlin.targets.mapNotNull { it.compilations.findByName("main")?.defaultSourceSet?.name }
+            else
+                requestedSourceSets.split(',')
+        )
+    }
+}
+
 dependencies {
     dokkaHtmlPlugin("org.jetbrains.dokka:kotlin-playground-samples-plugin")
     dokka(project)

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -11,10 +11,12 @@ pluginManagement {
     val dokkaVersion: String by settings
     val kotlinxBenchmarkVersion: String by settings
     val koverVersion: String by settings
+    val kotlin_version: String by settings
     plugins {
         id("org.jetbrains.dokka") version dokkaVersion
         id("org.jetbrains.kotlinx.benchmark") version kotlinxBenchmarkVersion
         id("org.jetbrains.kotlinx.kover") version koverVersion
+        id("org.jetbrains.kotlin.plugin.power-assert") version kotlin_version
     }
 }
 


### PR DESCRIPTION
With -PpowerAssert, a failed otherwise assert also renders the condition with its sub-expression values:

```
Incorrect size: -1
(size >= 0) otherwise { "Incorrect size: $size" }
 |    |
 -1   false
```

Opt-in only, because this instruments production compilations: transformed bytecode grows at every inlined call site and depends on the experimental kotlin-power-assert-runtime, so it must never reach a published artifact. The override takes compilation default source sets, e.g. -PpowerAssert=jvmMain,jvmTest; the plugin matches exactly those names, hence the computed default instead of commonMain (it would match only the metadata compilation). Unlike #270, which waits for Kotlin 2.4.20 to cover the test suite, this targets the invariant asserts in production sources.

AssertScope.otherwise is added in #297.
