### PR TITLE
Support lazy failure messages in invariant asserts

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,6 +10,7 @@ buildscript {
 
 plugins {
     id("kotlinx.team.infra") version "0.4.0-dev-91"
+    id("org.jetbrains.kotlin.plugin.power-assert") apply false
 }
 
 infra {

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -155,6 +155,19 @@ kotlin {
     }
 }
 
+providers.gradleProperty("powerAssert").orNull?.let { requestedSourceSets ->
+    apply(plugin = "org.jetbrains.kotlin.plugin.power-assert")
+    configure<org.jetbrains.kotlin.powerassert.gradle.PowerAssertGradleExtension> {
+        functions.set(listOf("kotlinx.collections.immutable.internal.AssertScope.otherwise"))
+        includedSourceSets.set(
+            if (requestedSourceSets.isBlank())
+                kotlin.targets.mapNotNull { it.compilations.findByName("main")?.defaultSourceSet?.name }
+            else
+                requestedSourceSets.split(',')
+        )
+    }
+}
+
 dependencies {
     dokkaHtmlPlugin("org.jetbrains.dokka:kotlin-playground-samples-plugin")
     dokka(project)

--- a/core/commonMain/src/implementations/immutableList/PersistentVector.kt
+++ b/core/commonMain/src/implementations/immutableList/PersistentVector.kt
@@ -29,7 +29,7 @@ internal class PersistentVector<E>(
 
     init {
         require(size > MAX_BUFFER_SIZE) { "Trie-based persistent vector should have at least ${MAX_BUFFER_SIZE + 1} elements, got $size" }
-        assert { size - rootSize(size) <= tail.size.coerceAtMost(MAX_BUFFER_SIZE) }
+        assert { (size - rootSize(size) <= tail.size.coerceAtMost(MAX_BUFFER_SIZE)) otherwise { "Inconsistent tail" } }
     }
 
     private fun rootSize(): Int = rootSize(size)
@@ -176,7 +176,7 @@ internal class PersistentVector<E>(
 
     private fun removeFromTailAt(root: Array<Any?>, rootSize: Int, shift: Int, index: Int): PersistentList<E> {
         val tailSize = size - rootSize
-        assert { index < tailSize }
+        assert { (index < tailSize) otherwise { "Index outside the tail" } }
 
         if (tailSize == 1) {
             return pullLastBufferFromRoot(root, rootSize, shift)

--- a/core/commonMain/src/implementations/immutableList/PersistentVectorBuilder.kt
+++ b/core/commonMain/src/implementations/immutableList/PersistentVectorBuilder.kt
@@ -384,7 +384,7 @@ internal class PersistentVectorBuilder<E>(
         val buffersSize = (size - unaffectedElementsCount + elements.size - 1) / MAX_BUFFER_SIZE
 
         if (buffersSize == 0) {
-            assert { index >= rootSize() }
+            assert { (index >= rootSize()) otherwise { "Index inside the root" } }
 
             val startIndex = index and MAX_BUFFER_SIZE_MINUS_ONE
             val endIndex = (index + elements.size - 1) and MAX_BUFFER_SIZE_MINUS_ONE // inclusive
@@ -596,7 +596,7 @@ internal class PersistentVectorBuilder<E>(
     @IgnorableReturnValue
     private fun removeFromTailAt(root: Array<Any?>?, rootSize: Int, shift: Int, index: Int): Any? {
         val tailSize = size - rootSize
-        assert { index < tailSize }
+        assert { (index < tailSize) otherwise { "Index outside the tail" } }
 
         val removedElement: Any?
         if (tailSize == 1) {
@@ -856,7 +856,7 @@ internal class PersistentVectorBuilder<E>(
         val newTailSize = removeAll(predicate, tail, tailSize, bufferRef)
 
         if (newTailSize == tailSize) {
-            assert { bufferRef.value === tail }
+            assert { (bufferRef.value === tail) otherwise { "Tail buffer was replaced" } }
             return tailSize
         }
 

--- a/core/commonMain/src/implementations/immutableList/SmallPersistentVector.kt
+++ b/core/commonMain/src/implementations/immutableList/SmallPersistentVector.kt
@@ -14,7 +14,7 @@ import kotlinx.collections.immutable.mutate
 internal class SmallPersistentVector<E>(private val buffer: Array<Any?>) : AbstractPersistentList<E>() {
 
     init {
-        assert { buffer.size <= MAX_BUFFER_SIZE }
+        assert { (buffer.size <= MAX_BUFFER_SIZE) otherwise { "Buffer overflow" } }
     }
 
     override val size: Int

--- a/core/commonMain/src/implementations/immutableMap/PersistentHashMapBuilderContentIterators.kt
+++ b/core/commonMain/src/implementations/immutableMap/PersistentHashMapBuilderContentIterators.kt
@@ -123,14 +123,14 @@ internal open class PersistentHashMapBuilderBaseIterator<K, V, T>(
                 return
             }
 
-            assert { node.keyAtIndex(keyIndex) == key }
+            assert { (node.keyAtIndex(keyIndex) == key) otherwise { "Unexpected key at index" } }
 
             path[pathIndex].reset(node.buffer, ENTRY_SIZE * node.entryCount(), keyIndex)
             pathLastIndex = pathIndex
             return
         }
 
-        assert { node.hasNodeAt(keyPositionMask) } // key is in node
+        assert { node.hasNodeAt(keyPositionMask) otherwise { "No node for the key" } }
 
         val nodeIndex = node.nodeIndex(keyPositionMask)
         val targetNode = node.nodeAtIndex(nodeIndex)

--- a/core/commonMain/src/implementations/immutableMap/PersistentHashMapContentIterators.kt
+++ b/core/commonMain/src/implementations/immutableMap/PersistentHashMapContentIterators.kt
@@ -42,7 +42,7 @@ internal abstract class TrieNodeBaseIterator<out K, out V, out T> : Iterator<T> 
     }
 
     fun hasNextNode(): Boolean {
-        assert { index >= dataSize }
+        assert { (index >= dataSize) otherwise { "Index inside the data area" } }
         return index < buffer.size
     }
 

--- a/core/commonMain/src/implementations/immutableMap/TrieNode.kt
+++ b/core/commonMain/src/implementations/immutableMap/TrieNode.kt
@@ -162,7 +162,7 @@ internal class TrieNode<K, V>(
     }
 
     private fun updateValueAtIndex(keyIndex: Int, value: V): TrieNode<K, V> {
-        assert { buffer[keyIndex + 1] !== value }
+        assert { (buffer[keyIndex + 1] !== value) otherwise { "Updating with the same value" } }
 
         val newBuffer = buffer.copyOf()
         newBuffer[keyIndex + 1] = value
@@ -174,7 +174,7 @@ internal class TrieNode<K, V>(
         value: V,
         mutator: PersistentHashMapBuilder<K, V>
     ): TrieNode<K, V> {
-        assert { buffer[keyIndex + 1] !== value }
+        assert { (buffer[keyIndex + 1] !== value) otherwise { "Updating with the same value" } }
 
         // If the [mutator] is exclusive owner of this node, update value at specified index in-place.
         if (ownedBy === mutator.ownership) {
@@ -198,7 +198,7 @@ internal class TrieNode<K, V>(
     ): TrieNode<K, V> {
         if (newNode.hasSingleEntry) {
             if (buffer.size == 1) {
-                assert { dataMap == 0 && nodeMap xor positionMask == 0 }
+                assert { (dataMap == 0 && nodeMap xor positionMask == 0) otherwise { "Unexpected node maps" } }
                 newNode.dataMap = nodeMap
                 return newNode
             }
@@ -316,7 +316,7 @@ internal class TrieNode<K, V>(
         owner: MutabilityOwnership?
     ): TrieNode<K, V> {
         if (shift > MAX_SHIFT) {
-            assert { key1 != key2 }
+            assert { (key1 != key2) otherwise { "Duplicate key" } }
             // when two key hashes are entirely equal: the last level subtrie node stores them just as unordered list
             return TrieNode(0, 0, arrayOf(key1, value1, key2, value2), owner)
         }
@@ -474,10 +474,10 @@ internal class TrieNode<K, V>(
         intersectionCounter: DeltaCounter,
         owner: MutabilityOwnership
     ): TrieNode<K, V> {
-        assert { nodeMap == 0 }
-        assert { dataMap == 0 }
-        assert { otherNode.nodeMap == 0 }
-        assert { otherNode.dataMap == 0 }
+        assert { (nodeMap == 0) otherwise { "Not a collision node" } }
+        assert { (dataMap == 0) otherwise { "Not a collision node" } }
+        assert { (otherNode.nodeMap == 0) otherwise { "Not a collision node" } }
+        assert { (otherNode.dataMap == 0) otherwise { "Not a collision node" } }
         val tempBuffer = this.buffer.copyOf(newSize = this.buffer.size + otherNode.buffer.size)
         var i = this.buffer.size
         for (j in 0..<otherNode.buffer.size step ENTRY_SIZE) {

--- a/core/commonMain/src/implementations/immutableSet/PersistentHashSetMutableIterator.kt
+++ b/core/commonMain/src/implementations/immutableSet/PersistentHashSetMutableIterator.kt
@@ -40,7 +40,7 @@ internal class PersistentHashSetMutableIterator<E>(private val builder: Persiste
     private fun resetPath(hashCode: Int, node: TrieNode<*>, element: E, pathIndex: Int) {
         if (isCollision(node)) {
             val index = node.buffer.indexOf(element)
-            assert { index != -1 }
+            assert { (index != -1) otherwise { "Element not found" } }
             path[pathIndex].reset(node.buffer, index)
             pathLastIndex = pathIndex
             return
@@ -55,7 +55,7 @@ internal class PersistentHashSetMutableIterator<E>(private val builder: Persiste
         if (cell is TrieNode<*>) {
             resetPath(hashCode, cell, element, pathIndex + 1)
         } else {
-            assert { cell == element }
+            assert { (cell == element) otherwise { "Unexpected element" } }
             pathLastIndex = pathIndex
         }
     }

--- a/core/commonMain/src/implementations/immutableSet/TrieNode.kt
+++ b/core/commonMain/src/implementations/immutableSet/TrieNode.kt
@@ -56,12 +56,13 @@ private inline fun Array<Any?>.filterTo(
     var i = 0
     var j = 0
     while (i < size) {
-        assert { j <= i } // this is extremely important if newArray === this
+        // this is extremely important if newArray === this
+        assert { (j <= i) otherwise { "Backward copy" } }
         val e = this[i]
         if (predicate(e)) {
             newArray[newArrayOffset + j] = this[i]
             ++j
-            assert { newArrayOffset + j <= newArray.size }
+            assert { (newArrayOffset + j <= newArray.size) otherwise { "Array overflow" } }
         }
         ++i
     }
@@ -181,7 +182,7 @@ internal class TrieNode<E>(
         owner: MutabilityOwnership?
     ): TrieNode<E> {
         if (shift > MAX_SHIFT) {
-            assert { element1 != element2 }
+            assert { (element1 != element2) otherwise { "Duplicate element" } }
             // when two element hashes are entirely equal: the last level subtrie node stores them just as unordered list
             return TrieNode<E>(0, arrayOf(element1, element2), owner)
         }
@@ -784,7 +785,7 @@ internal class TrieNode<E>(
         }
         // element is directly in buffer
         if (element == buffer[cellIndex]) {
-            assert { shift == 0 || buffer.size > 1 }
+            assert { (shift == 0 || buffer.size > 1) otherwise { "Last cell of a non-root node" } }
             return removeCellAtIndex(cellIndex, cellPositionMask, owner = null)
         }
         return this
@@ -815,7 +816,7 @@ internal class TrieNode<E>(
         }
         // element is directly in buffer
         if (element == buffer[cellIndex]) {
-            assert { shift == 0 || buffer.size > 1 }
+            assert { (shift == 0 || buffer.size > 1) otherwise { "Last cell of a non-root node" } }
             mutator.size--
             return removeCellAtIndex(cellIndex, cellPositionMask, mutator.ownership) // check is empty
         }

--- a/core/commonMain/src/implementations/persistentOrderedMap/PersistentOrderedMap.kt
+++ b/core/commonMain/src/implementations/persistentOrderedMap/PersistentOrderedMap.kt
@@ -108,13 +108,13 @@ internal class PersistentOrderedMap<K, V>(
         var newMap = hashMap.removing(key)
         if (links.hasPrevious) {
             val previousLinks = newMap[links.previous]!!
-            assert { previousLinks.next == key }
+            assert { (previousLinks.next == key) otherwise { "Broken next link" } }
             @Suppress("UNCHECKED_CAST")
             newMap = newMap.putting(links.previous as K, previousLinks.withNext(links.next))
         }
         if (links.hasNext) {
             val nextLinks = newMap[links.next]!!
-            assert { nextLinks.previous == key }
+            assert { (nextLinks.previous == key) otherwise { "Broken previous link" } }
             @Suppress("UNCHECKED_CAST")
             newMap = newMap.putting(links.next as K, nextLinks.withPrevious(links.previous))
         }

--- a/core/commonMain/src/implementations/persistentOrderedMap/PersistentOrderedMapBuilder.kt
+++ b/core/commonMain/src/implementations/persistentOrderedMap/PersistentOrderedMapBuilder.kt
@@ -26,11 +26,11 @@ internal class PersistentOrderedMapBuilder<K, V>(map: PersistentOrderedMap<K, V>
 
     override fun build(): PersistentMap<K, V> {
         return builtMap?.also { map ->
-            assert { hashMapBuilder.builtMap != null }
-            assert { firstKey === map.firstKey }
-            assert { lastKey === map.lastKey }
+            assert { (hashMapBuilder.builtMap != null) otherwise { "Missing built hash map" } }
+            assert { (firstKey === map.firstKey) otherwise { "First key mismatch" } }
+            assert { (lastKey === map.lastKey) otherwise { "Last key mismatch" } }
         } ?: run {
-            assert { hashMapBuilder.builtMap == null }
+            assert { (hashMapBuilder.builtMap == null) otherwise { "Stale built hash map" } }
             val newHashMap = hashMapBuilder.build()
             val newOrdered = PersistentOrderedMap(firstKey, lastKey, newHashMap)
             builtMap = newOrdered
@@ -96,7 +96,7 @@ internal class PersistentOrderedMapBuilder<K, V>(map: PersistentOrderedMap<K, V>
         builtMap = null
         if (links.hasPrevious) {
             val previousLinks = hashMapBuilder[links.previous]!!
-            assert { previousLinks.next == key }
+            assert { (previousLinks.next == key) otherwise { "Broken next link" } }
             @Suppress("UNCHECKED_CAST")
             hashMapBuilder[links.previous as K] = previousLinks.withNext(links.next)
         } else {
@@ -104,7 +104,7 @@ internal class PersistentOrderedMapBuilder<K, V>(map: PersistentOrderedMap<K, V>
         }
         if (links.hasNext) {
             val nextLinks = hashMapBuilder[links.next]!!
-            assert { nextLinks.previous == key }
+            assert { (nextLinks.previous == key) otherwise { "Broken previous link" } }
             @Suppress("UNCHECKED_CAST")
             hashMapBuilder[links.next as K] = nextLinks.withPrevious(links.previous)
         } else {

--- a/core/commonMain/src/implementations/persistentOrderedSet/PersistentOrderedSet.kt
+++ b/core/commonMain/src/implementations/persistentOrderedSet/PersistentOrderedSet.kt
@@ -77,13 +77,13 @@ internal class PersistentOrderedSet<E>(
         var newMap = hashMap.removing(element)
         if (links.hasPrevious) {
             val previousLinks = newMap[links.previous]!!
-            assert { previousLinks.next == element }
+            assert { (previousLinks.next == element) otherwise { "Broken next link" } }
             @Suppress("UNCHECKED_CAST")
             newMap = newMap.putting(links.previous as E, previousLinks.withNext(links.next))
         }
         if (links.hasNext) {
             val nextLinks = newMap[links.next]!!
-            assert { nextLinks.previous == element }
+            assert { (nextLinks.previous == element) otherwise { "Broken previous link" } }
             @Suppress("UNCHECKED_CAST")
             newMap = newMap.putting(links.next as E, nextLinks.withPrevious(links.previous))
         }

--- a/core/commonMain/src/implementations/persistentOrderedSet/PersistentOrderedSetBuilder.kt
+++ b/core/commonMain/src/implementations/persistentOrderedSet/PersistentOrderedSetBuilder.kt
@@ -21,11 +21,11 @@ internal class PersistentOrderedSetBuilder<E>(set: PersistentOrderedSet<E>) :
 
     override fun build(): PersistentSet<E> {
         return builtSet?.also { set ->
-            assert { hashMapBuilder.builtMap != null }
-            assert { firstElement === set.firstElement }
-            assert { lastElement === set.lastElement }
+            assert { (hashMapBuilder.builtMap != null) otherwise { "Missing built hash map" } }
+            assert { (firstElement === set.firstElement) otherwise { "First element mismatch" } }
+            assert { (lastElement === set.lastElement) otherwise { "Last element mismatch" } }
         } ?: run {
-            assert { hashMapBuilder.builtMap == null }
+            assert { (hashMapBuilder.builtMap == null) otherwise { "Stale built hash map" } }
             val newMap = hashMapBuilder.build()
             val newSet = PersistentOrderedSet(firstElement, lastElement, newMap)
             builtSet = newSet
@@ -64,7 +64,7 @@ internal class PersistentOrderedSetBuilder<E>(set: PersistentOrderedSet<E>) :
         builtSet = null
         if (links.hasPrevious) {
             val previousLinks = hashMapBuilder[links.previous]!!
-            assert { previousLinks.next == element }
+            assert { (previousLinks.next == element) otherwise { "Broken next link" } }
             @Suppress("UNCHECKED_CAST")
             hashMapBuilder[links.previous as E] = previousLinks.withNext(links.next)
         } else {
@@ -72,7 +72,7 @@ internal class PersistentOrderedSetBuilder<E>(set: PersistentOrderedSet<E>) :
         }
         if (links.hasNext) {
             val nextLinks = hashMapBuilder[links.next]!!
-            assert { nextLinks.previous == element }
+            assert { (nextLinks.previous == element) otherwise { "Broken previous link" } }
             @Suppress("UNCHECKED_CAST")
             hashMapBuilder[links.next as E] = nextLinks.withPrevious(links.previous)
         } else {

--- a/core/commonMain/src/internal/commonFunctions.kt
+++ b/core/commonMain/src/internal/commonFunctions.kt
@@ -5,4 +5,15 @@
 
 package kotlinx.collections.immutable.internal
 
-internal expect fun assert(condition: () -> Boolean)
+internal expect fun assert(condition: AssertScope.() -> Boolean)
+
+internal object AssertScope {
+    inline infix fun Boolean.otherwise(lazyMessage: () -> Any): Boolean {
+        if (!this) assertionFailed(lazyMessage())
+        return true
+    }
+
+    fun assertionFailed(message: Any?): Nothing {
+        throw AssertionError(message)
+    }
+}

--- a/core/commonTest/src/ObjectWrapper.kt
+++ b/core/commonTest/src/ObjectWrapper.kt
@@ -20,7 +20,7 @@ class ObjectWrapper<K: Comparable<K>>(
         if (other !is ObjectWrapper<*>) {
             return false
         }
-        assert { obj != other.obj || hashCode == other.hashCode }  // if elements are equal hashCodes must be equal
+        assert { (obj != other.obj || hashCode == other.hashCode) otherwise { "Hash code mismatch" } }
         return obj == other.obj
     }
 

--- a/core/jsMain/src/internal/commonFunctions.kt
+++ b/core/jsMain/src/internal/commonFunctions.kt
@@ -5,4 +5,4 @@
 
 package kotlinx.collections.immutable.internal
 
-internal actual inline fun assert(condition: () -> Boolean) {}
+internal actual inline fun assert(condition: AssertScope.() -> Boolean) {}

--- a/core/jvmMain/src/internal/commonFunctions.kt
+++ b/core/jvmMain/src/internal/commonFunctions.kt
@@ -9,8 +9,8 @@ private class Assertions
 
 internal val ASSERTIONS_ENABLED = Assertions::class.java.desiredAssertionStatus()
 
-internal actual inline fun assert(condition: () -> Boolean) {
-    if (ASSERTIONS_ENABLED && !condition()) assertionFailed()
+internal actual inline fun assert(condition: AssertScope.() -> Boolean) {
+    if (ASSERTIONS_ENABLED && !AssertScope.condition()) assertionFailed()
 }
 
 internal fun assertionFailed() {

--- a/core/nativeMain/src/internal/commonFunctions.kt
+++ b/core/nativeMain/src/internal/commonFunctions.kt
@@ -6,6 +6,6 @@
 package kotlinx.collections.immutable.internal
 
 @OptIn(kotlin.experimental.ExperimentalNativeApi::class)
-internal actual inline fun assert(condition: () -> Boolean) {
-    kotlin.assert(condition())
+internal actual inline fun assert(condition: AssertScope.() -> Boolean) {
+    kotlin.assert(AssertScope.condition())
 }

--- a/core/wasmMain/src/internal/commonFunctions.kt
+++ b/core/wasmMain/src/internal/commonFunctions.kt
@@ -5,4 +5,4 @@
 
 package kotlinx.collections.immutable.internal
 
-internal actual inline fun assert(condition: () -> Boolean) {}
+internal actual inline fun assert(condition: AssertScope.() -> Boolean) {}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -11,10 +11,12 @@ pluginManagement {
     val dokkaVersion: String by settings
     val kotlinxBenchmarkVersion: String by settings
     val koverVersion: String by settings
+    val kotlin_version: String by settings
     plugins {
         id("org.jetbrains.dokka") version dokkaVersion
         id("org.jetbrains.kotlinx.benchmark") version kotlinxBenchmarkVersion
         id("org.jetbrains.kotlinx.kover") version koverVersion
+        id("org.jetbrains.kotlin.plugin.power-assert") version kotlin_version
     }
 }
 


### PR DESCRIPTION
Lets an invariant assert carry a message without paying for it when assertions are off: the condition lambda now takes AssertScope as its receiver, and its infix otherwise attaches a message evaluated only on failure.

```kotlin
assert { (nodeMap == 0) otherwise { "Not a collision node" } }
```

The messages are constants: with -PpowerAssert the diagram prints the values, and the dead branch at each inlined call site stays a string load. Disabled builds still evaluate nothing on any platform.

The Power-Assert plugin is applied only with -PpowerAssert: it instruments production compilations, so the transformed bytecode must never reach a published artifact. The property optionally takes compilation default source sets, e.g. -PpowerAssert=jvmMain,jvmTest.
