### PR TITLE
Dispatch bulk trie ops to collision helpers at the bottom level

### DIFF
--- a/core/commonMain/src/implementations/immutableMap/TrieNode.kt
+++ b/core/commonMain/src/implementations/immutableMap/TrieNode.kt
@@ -20,11 +20,16 @@ internal const val MAX_SHIFT = 30
 /**
  * Gets trie index segment of the specified [index] at the level specified by [shift].
  *
- * `shift` equal to zero corresponds to the root level.
- * For each lower level `shift` increments by [LOG_MAX_BRANCHING_FACTOR].
+ * [shift] equal to zero corresponds to the root level.
+ * For each lower level [shift] increments by [LOG_MAX_BRANCHING_FACTOR].
+ *
+ * [shift] must not exceed [MAX_SHIFT]. Kotlin takes `Int` shift counts mod 32, so overrunning it
+ * yields a garbage segment instead of failing.
  */
-internal fun indexSegment(index: Int, shift: Int): Int =
-    (index shr shift) and MAX_BRANCHING_FACTOR_MINUS_ONE
+internal fun indexSegment(index: Int, shift: Int): Int {
+    assert { shift <= MAX_SHIFT }
+    return (index shr shift) and MAX_BRANCHING_FACTOR_MINUS_ONE
+}
 
 private fun <K, V> Array<Any?>.insertEntryAtIndex(keyIndex: Int, key: K, value: V): Array<Any?> {
     val newBuffer = arrayOfNulls<Any?>(this.size + ENTRY_SIZE)
@@ -525,7 +530,11 @@ internal class TrieNode<K, V>(
                     val key = otherNode.keyAtIndex(keyIndex)
                     val value = otherNode.valueAtKeyIndex(keyIndex)
                     val oldSize = mutator.size
-                    targetNode.mutablePut(key.hashCode(), key, value, shift + LOG_MAX_BRANCHING_FACTOR, mutator).also {
+                    if (shift == MAX_SHIFT) {
+                        targetNode.mutableCollisionPut(key, value, mutator)
+                    } else {
+                        targetNode.mutablePut(key.hashCode(), key, value, shift + LOG_MAX_BRANCHING_FACTOR, mutator)
+                    }.also {
                         if (mutator.size == oldSize) intersectionCounter.count++
                     }
                 }
@@ -541,15 +550,24 @@ internal class TrieNode<K, V>(
                     // if otherTargetNode already has a value associated with the key, do not put this entry
                     val keyIndex = this.entryKeyIndex(positionMask)
                     val key = this.keyAtIndex(keyIndex)
-                    if (otherTargetNode.containsKey(key.hashCode(), key, shift + LOG_MAX_BRANCHING_FACTOR)) {
+                    val hasKey = if (shift == MAX_SHIFT) {
+                        otherTargetNode.collisionContainsKey(key)
+                    } else {
+                        otherTargetNode.containsKey(key.hashCode(), key, shift + LOG_MAX_BRANCHING_FACTOR)
+                    }
+                    if (hasKey) {
                         intersectionCounter.count++
                         otherTargetNode
                     } else {
                         val value = this.valueAtKeyIndex(keyIndex)
-                        otherTargetNode.mutablePut(
-                            key.hashCode(), key, value,
-                            shift + LOG_MAX_BRANCHING_FACTOR, mutator
-                        )
+                        if (shift == MAX_SHIFT) {
+                            otherTargetNode.mutableCollisionPut(key, value, mutator)
+                        } else {
+                            otherTargetNode.mutablePut(
+                                key.hashCode(), key, value,
+                                shift + LOG_MAX_BRANCHING_FACTOR, mutator
+                            )
+                        }
                     }
                 }
 

--- a/core/commonMain/src/implementations/immutableSet/TrieNode.kt
+++ b/core/commonMain/src/implementations/immutableSet/TrieNode.kt
@@ -19,11 +19,16 @@ internal const val MAX_SHIFT = 30
 /**
  * Gets trie index segment of the specified [index] at the level specified by [shift].
  *
- * `shift` equal to zero corresponds to the root level.
- * For each lower level `shift` increments by [LOG_MAX_BRANCHING_FACTOR].
+ * [shift] equal to zero corresponds to the root level.
+ * For each lower level [shift] increments by [LOG_MAX_BRANCHING_FACTOR].
+ *
+ * [shift] must not exceed [MAX_SHIFT]. Kotlin takes `Int` shift counts mod 32, so overrunning it
+ * yields a garbage segment instead of failing.
  */
-internal fun indexSegment(index: Int, shift: Int): Int =
-    (index shr shift) and MAX_BRANCHING_FACTOR_MINUS_ONE
+internal fun indexSegment(index: Int, shift: Int): Int {
+    assert { shift <= MAX_SHIFT }
+    return (index shr shift) and MAX_BRANCHING_FACTOR_MINUS_ONE
+}
 
 
 private fun <E> Array<Any?>.addElementAtIndex(index: Int, element: E): Array<Any?> {
@@ -387,7 +392,8 @@ internal class TrieNode<E>(
         }
         // for each bit set in the resulting mask,
         // either left, right or both masks contain the same bit
-        // Note: we shouldn't overrun MAX_SHIFT because both sides are correct TrieNodes, right?
+        // Note: shift can be MAX_SHIFT here, where a cell holding a node holds a collision node,
+        // so the node-vs-element branches dispatch to the collision helpers instead of descending
         newBitMap.forEachOneBit { positionMask, newNodeIndex ->
             val thisIndex = indexOfCellAt(positionMask)
             val otherNodeIndex = otherNode.indexOfCellAt(positionMask)
@@ -417,10 +423,14 @@ internal class TrieNode<E>(
                             thisCell as TrieNode<E>
                             otherNodeCell as E
                             val oldSize = mutator.size
-                            thisCell.mutableAdd(
-                                otherNodeCell.hashCode(), otherNodeCell,
-                                shift + LOG_MAX_BRANCHING_FACTOR, mutator
-                            ).also {
+                            if (shift == MAX_SHIFT) {
+                                thisCell.mutableCollisionAdd(otherNodeCell, mutator)
+                            } else {
+                                thisCell.mutableAdd(
+                                    otherNodeCell.hashCode(), otherNodeCell,
+                                    shift + LOG_MAX_BRANCHING_FACTOR, mutator
+                                )
+                            }.also {
                                 if (mutator.size == oldSize) intersectionSizeRef.count++
                             }
                         }
@@ -429,10 +439,14 @@ internal class TrieNode<E>(
                             otherNodeCell as TrieNode<E>
                             thisCell as E
                             val oldSize = mutator.size
-                            otherNodeCell.mutableAdd(
-                                thisCell.hashCode(), thisCell,
-                                shift + LOG_MAX_BRANCHING_FACTOR, mutator
-                            ).also {
+                            if (shift == MAX_SHIFT) {
+                                otherNodeCell.mutableCollisionAdd(thisCell, mutator)
+                            } else {
+                                otherNodeCell.mutableAdd(
+                                    thisCell.hashCode(), thisCell,
+                                    shift + LOG_MAX_BRANCHING_FACTOR, mutator
+                                )
+                            }.also {
                                 if (mutator.size == oldSize) intersectionSizeRef.count++
                             }
                         }
@@ -505,11 +519,15 @@ internal class TrieNode<E>(
                     thisIsNode -> @Suppress("UNCHECKED_CAST") {
                         thisCell as TrieNode<E>
                         otherNodeCell as E
-                        if (thisCell.contains(
+                        val hasElement = if (shift == MAX_SHIFT) {
+                            thisCell.collisionContainsElement(otherNodeCell)
+                        } else {
+                            thisCell.contains(
                                 otherNodeCell.hashCode(), otherNodeCell,
                                 shift + LOG_MAX_BRANCHING_FACTOR
                             )
-                        ) {
+                        }
+                        if (hasElement) {
                             intersectionSizeRef += 1
                             otherNodeCell
                         } else EMPTY
@@ -518,7 +536,12 @@ internal class TrieNode<E>(
                     otherIsNode -> @Suppress("UNCHECKED_CAST") {
                         otherNodeCell as TrieNode<E>
                         thisCell as E
-                        if (otherNodeCell.contains(thisCell.hashCode(), thisCell, shift + LOG_MAX_BRANCHING_FACTOR)) {
+                        val hasElement = if (shift == MAX_SHIFT) {
+                            otherNodeCell.collisionContainsElement(thisCell)
+                        } else {
+                            otherNodeCell.contains(thisCell.hashCode(), thisCell, shift + LOG_MAX_BRANCHING_FACTOR)
+                        }
+                        if (hasElement) {
                             intersectionSizeRef += 1
                             thisCell
                         } else EMPTY
@@ -610,10 +633,14 @@ internal class TrieNode<E>(
                         thisCell as TrieNode<E>
                         otherNodeCell as E
                         val oldSize = mutator.size
-                        val removed = thisCell.mutableRemove(
-                            otherNodeCell.hashCode(), otherNodeCell,
-                            shift + LOG_MAX_BRANCHING_FACTOR, mutator
-                        )
+                        val removed = if (shift == MAX_SHIFT) {
+                            thisCell.mutableCollisionRemove(otherNodeCell, mutator)
+                        } else {
+                            thisCell.mutableRemove(
+                                otherNodeCell.hashCode(), otherNodeCell,
+                                shift + LOG_MAX_BRANCHING_FACTOR, mutator
+                            )
+                        }
                         // additional check needed for removal
                         if (oldSize != mutator.size) {
                             intersectionSizeRef += 1
@@ -626,7 +653,12 @@ internal class TrieNode<E>(
                         otherNodeCell as TrieNode<E>
                         thisCell as E
                         // "removing" a node from a value is basically checking if the value is contained in the node
-                        if (otherNodeCell.contains(thisCell.hashCode(), thisCell, shift + LOG_MAX_BRANCHING_FACTOR)) {
+                        val hasElement = if (shift == MAX_SHIFT) {
+                            otherNodeCell.collisionContainsElement(thisCell)
+                        } else {
+                            otherNodeCell.contains(thisCell.hashCode(), thisCell, shift + LOG_MAX_BRANCHING_FACTOR)
+                        }
+                        if (hasElement) {
                             intersectionSizeRef += 1
                             EMPTY
                         } else thisCell
@@ -701,10 +733,15 @@ internal class TrieNode<E>(
                 thisIsNode -> @Suppress("UNCHECKED_CAST") {
                     thisCell as TrieNode<E>
                     otherNodeCell as E
-                    thisCell.contains(
-                        otherNodeCell.hashCode(), otherNodeCell,
-                        shift + LOG_MAX_BRANCHING_FACTOR
-                    ) || return false
+                    val hasElement = if (shift == MAX_SHIFT) {
+                        thisCell.collisionContainsElement(otherNodeCell)
+                    } else {
+                        thisCell.contains(
+                            otherNodeCell.hashCode(), otherNodeCell,
+                            shift + LOG_MAX_BRANCHING_FACTOR
+                        )
+                    }
+                    hasElement || return false
                 }
                 // left is just E, right is node => not possible
                 otherIsNode -> return false

--- a/core/commonTest/src/contract/map/PersistentHashMapBuilderTest.kt
+++ b/core/commonTest/src/contract/map/PersistentHashMapBuilderTest.kt
@@ -17,6 +17,10 @@ import kotlin.test.assertTrue
 
 class PersistentHashMapBuilderTest {
 
+    private val a1 = IntWrapper(1, 0)
+    private val a2 = IntWrapper(2, 0)
+    private val sibling = IntWrapper(3, 1 shl 30)
+
     @Test
     fun `should correctly iterate after removing integer key and promotion colliding key during iteration`() {
         val removedKey = 0
@@ -117,5 +121,18 @@ class PersistentHashMapBuilderTest {
             iterator1.remove()
             iterator2.next()
         }
+    }
+
+    @Test
+    fun `putAll should not duplicate a key stored in a bottom-level collision node`() {
+        val builder = persistentHashMapOf(a1 to 1, a2 to 2).builder()
+        builder.putAll(persistentHashMapOf(a1 to 10, sibling to 3))
+        assertEquals(3, builder.size)
+        assertEquals(persistentHashMapOf(a1 to 10, a2 to 2, sibling to 3), builder.build())
+
+        val reversedBuilder = persistentHashMapOf(a1 to 10, sibling to 3).builder()
+        reversedBuilder.putAll(persistentHashMapOf(a1 to 1, a2 to 2))
+        assertEquals(3, reversedBuilder.size)
+        assertEquals(persistentHashMapOf(a1 to 1, a2 to 2, sibling to 3), reversedBuilder.build())
     }
 }

--- a/core/commonTest/src/contract/map/PersistentHashMapTest.kt
+++ b/core/commonTest/src/contract/map/PersistentHashMapTest.kt
@@ -7,12 +7,18 @@ package tests.contract.map
 
 import kotlinx.collections.immutable.implementations.immutableMap.PersistentHashMap
 import kotlinx.collections.immutable.persistentHashMapOf
+import kotlinx.collections.immutable.plus
 import tests.IntWrapper
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 class PersistentHashMapTest {
+
+    private val a1 = IntWrapper(1, 0)
+    private val a2 = IntWrapper(2, 0)
+    private val a3 = IntWrapper(4, 0)
+    private val sibling = IntWrapper(3, 1 shl 30)
 
     @Test
     fun `if the collision is of size 2 and one of the keys is removed the remaining key must be promoted`() {
@@ -72,5 +78,31 @@ class PersistentHashMapTest {
         val afterMutableRemoving = builder.build()
 
         assertEquals(afterImmutableRemoving, afterMutableRemoving)
+    }
+
+    @Test
+    fun `putAll should not duplicate a key stored in a bottom-level collision node`() {
+        val sum = persistentHashMapOf(a1 to 1, a2 to 2) + persistentHashMapOf(a1 to 10, sibling to 3)
+        assertEquals(3, sum.size)
+        assertEquals(persistentHashMapOf(a1 to 10, a2 to 2, sibling to 3), sum)
+        assertEquals(10, sum[a1])
+
+        val reversedSum = persistentHashMapOf(a1 to 10, sibling to 3) + persistentHashMapOf(a1 to 1, a2 to 2)
+        assertEquals(3, reversedSum.size)
+        assertEquals(persistentHashMapOf(a1 to 1, a2 to 2, sibling to 3), reversedSum)
+        assertEquals(1, reversedSum[a1])
+    }
+
+    @Test
+    fun `putAll should insert a new key into a bottom-level collision node`() {
+        val expected = persistentHashMapOf(a1 to 1, a2 to 2, a3 to 4, sibling to 3)
+
+        val sum = persistentHashMapOf(a1 to 1, a2 to 2) + persistentHashMapOf(a3 to 4, sibling to 3)
+        assertEquals(4, sum.size)
+        assertEquals(expected, sum)
+
+        val reversedSum = persistentHashMapOf(a3 to 4, sibling to 3) + persistentHashMapOf(a1 to 1, a2 to 2)
+        assertEquals(4, reversedSum.size)
+        assertEquals(expected, reversedSum)
     }
 }

--- a/core/commonTest/src/contract/set/PersistentHashSetBuilderTest.kt
+++ b/core/commonTest/src/contract/set/PersistentHashSetBuilderTest.kt
@@ -16,6 +16,11 @@ import kotlin.test.assertTrue
 
 class PersistentHashSetBuilderTest {
 
+    private val a1 = IntWrapper(1, 0)
+    private val a2 = IntWrapper(2, 0)
+    private val a3 = IntWrapper(4, 0)
+    private val sibling = IntWrapper(3, 1 shl 30)
+
     @Test
     fun `should correctly iterate after removing integer element`() {
         val removedElement = 0
@@ -126,5 +131,63 @@ class PersistentHashSetBuilderTest {
         assertTrue(expected.equals(builder))
         assertEquals(expected, builder.build())
         assertEquals(builder.build(), expected)
+    }
+
+    @Test
+    fun `addAll should not duplicate an element shared with a bottom-level collision node`() {
+        val expected = persistentHashSetOf(a1, a2, sibling)
+
+        val builder = persistentHashSetOf(a1, a2).builder()
+        assertTrue(builder.addAll(persistentHashSetOf(a1, sibling)))
+        assertEquals(3, builder.size)
+        assertEquals(expected, builder.build())
+
+        val reversedBuilder = persistentHashSetOf(a1, sibling).builder()
+        assertTrue(reversedBuilder.addAll(persistentHashSetOf(a1, a2)))
+        assertEquals(3, reversedBuilder.size)
+        assertEquals(expected, reversedBuilder.build())
+    }
+
+    @Test
+    fun `addAll should insert a new element into a bottom-level collision node`() {
+        val expected = persistentHashSetOf(a1, a2, a3, sibling)
+
+        val builder = persistentHashSetOf(a1, a2).builder()
+        assertTrue(builder.addAll(persistentHashSetOf(a3, sibling)))
+        assertEquals(4, builder.size)
+        assertEquals(expected, builder.build())
+
+        val reversedBuilder = persistentHashSetOf(a3, sibling).builder()
+        assertTrue(reversedBuilder.addAll(persistentHashSetOf(a1, a2)))
+        assertEquals(4, reversedBuilder.size)
+        assertEquals(expected, reversedBuilder.build())
+    }
+
+    @Test
+    fun `retainAll should find elements inside a bottom-level collision node`() {
+        val expected = persistentHashSetOf(a1)
+
+        val builder = persistentHashSetOf(a1, a2).builder()
+        assertTrue(builder.retainAll(persistentHashSetOf(a1, sibling)))
+        assertEquals(1, builder.size)
+        assertEquals(expected, builder.build())
+
+        val reversedBuilder = persistentHashSetOf(a1, sibling).builder()
+        assertTrue(reversedBuilder.retainAll(persistentHashSetOf(a1, a2)))
+        assertEquals(1, reversedBuilder.size)
+        assertEquals(expected, reversedBuilder.build())
+    }
+
+    @Test
+    fun `removeAll should remove elements stored in a bottom-level collision node`() {
+        val builder = persistentHashSetOf(a1, a2).builder()
+        assertTrue(builder.removeAll(persistentHashSetOf(a1, sibling)))
+        assertEquals(1, builder.size)
+        assertEquals(persistentHashSetOf(a2), builder.build())
+
+        val reversedBuilder = persistentHashSetOf(a1, sibling).builder()
+        assertTrue(reversedBuilder.removeAll(persistentHashSetOf(a1, a2)))
+        assertEquals(1, reversedBuilder.size)
+        assertEquals(persistentHashSetOf(sibling), reversedBuilder.build())
     }
 }

--- a/core/commonTest/src/contract/set/PersistentHashSetTest.kt
+++ b/core/commonTest/src/contract/set/PersistentHashSetTest.kt
@@ -9,13 +9,20 @@ import kotlinx.collections.immutable.implementations.immutableSet.PersistentHash
 import kotlinx.collections.immutable.intersect
 import kotlinx.collections.immutable.persistentHashSetOf
 import kotlinx.collections.immutable.minus
+import kotlinx.collections.immutable.plus
 import kotlinx.collections.immutable.toPersistentHashSet
 import tests.IntWrapper
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 class PersistentHashSetTest {
+
+    private val a1 = IntWrapper(1, 0)
+    private val a2 = IntWrapper(2, 0)
+    private val a3 = IntWrapper(4, 0)
+    private val sibling = IntWrapper(3, 1 shl 30)
 
     @Test
     fun `persistentHashSet and their builder should be equal before and after modification`() {
@@ -112,5 +119,80 @@ class PersistentHashSetTest {
         assertEquals(persistentHashSetOf<Int>(), empty)
         assertEquals(empty, persistentHashSetOf())
         assertTrue(empty.isEmpty())
+    }
+
+    @Test
+    fun `plus should not duplicate an element shared with a bottom-level collision node`() {
+        val expected = persistentHashSetOf(a1, a2, sibling)
+
+        val union = persistentHashSetOf(a1, a2) + persistentHashSetOf(a1, sibling)
+        assertEquals(3, union.size)
+        assertEquals(3, union.toList().size)
+        assertEquals(expected, union)
+        assertEquals(union, expected)
+        val withoutA1 = union - a1
+        assertEquals(persistentHashSetOf(a2, sibling), withoutA1)
+        assertFalse(a1 in withoutA1)
+
+        val reversedUnion = persistentHashSetOf(a1, sibling) + persistentHashSetOf(a1, a2)
+        assertEquals(3, reversedUnion.size)
+        assertEquals(3, reversedUnion.toList().size)
+        assertEquals(expected, reversedUnion)
+        assertEquals(persistentHashSetOf(a2, sibling), reversedUnion - a1)
+    }
+
+    @Test
+    fun `plus should insert a new element into a bottom-level collision node`() {
+        val expected = persistentHashSetOf(a1, a2, a3, sibling)
+
+        val union = persistentHashSetOf(a1, a2) + persistentHashSetOf(a3, sibling)
+        assertEquals(4, union.size)
+        assertEquals(expected, union)
+
+        val reversedUnion = persistentHashSetOf(a3, sibling) + persistentHashSetOf(a1, a2)
+        assertEquals(4, reversedUnion.size)
+        assertEquals(expected, reversedUnion)
+    }
+
+    @Test
+    fun `intersect and minus should handle an element absent from a bottom-level collision node`() {
+        assertTrue((persistentHashSetOf(a1, a2) intersect persistentHashSetOf(a3, sibling)).isEmpty())
+        assertTrue((persistentHashSetOf(a3, sibling) intersect persistentHashSetOf(a1, a2)).isEmpty())
+
+        assertEquals(persistentHashSetOf(a1, a2), persistentHashSetOf(a1, a2) - persistentHashSetOf(a3, sibling))
+        assertEquals(persistentHashSetOf(a3, sibling), persistentHashSetOf(a3, sibling) - persistentHashSetOf(a1, a2))
+    }
+
+    @Test
+    fun `minus should remove an element from a bottom-level collision node`() {
+        val difference = persistentHashSetOf(a1, a2) - persistentHashSetOf(a1, sibling)
+        assertEquals(1, difference.size)
+        assertEquals(persistentHashSetOf(a2), difference)
+
+        val reversedDifference = persistentHashSetOf(a1, sibling) - persistentHashSetOf(a1, a2)
+        assertEquals(1, reversedDifference.size)
+        assertEquals(persistentHashSetOf(sibling), reversedDifference)
+    }
+
+    @Test
+    fun `intersect should find the shared element inside a bottom-level collision node`() {
+        val expected = persistentHashSetOf(a1)
+
+        val intersection = persistentHashSetOf(a1, a2) intersect persistentHashSetOf(a1, sibling)
+        assertEquals(expected, intersection)
+        assertEquals(intersection, expected)
+        assertEquals(listOf(a1), intersection.toList())
+
+        val reversedIntersection = persistentHashSetOf(a1, sibling) intersect persistentHashSetOf(a1, a2)
+        assertEquals(expected, reversedIntersection)
+        assertEquals(listOf(a1), reversedIntersection.toList())
+    }
+
+    @Test
+    fun `containsAll should find elements inside a bottom-level collision node`() {
+        assertTrue(persistentHashSetOf(a1, a2, sibling).containsAll(persistentHashSetOf(a1, sibling)))
+        assertTrue(persistentHashSetOf(a1, a2, sibling).containsAll(persistentHashSetOf(a1, a2)))
+        assertFalse(persistentHashSetOf(a1, sibling).containsAll(persistentHashSetOf(a1, a2)))
+        assertFalse(persistentHashSetOf(a1, a2, sibling).containsAll(persistentHashSetOf(a3, sibling)))
     }
 }

--- a/core/commonTest/src/implementations/map/HashMapTrieNodeTest.kt
+++ b/core/commonTest/src/implementations/map/HashMapTrieNodeTest.kt
@@ -363,6 +363,65 @@ class HashMapTrieNodeTest {
         }
     }
 
+    // Nodes drawn using square braces are collision nodes.
+    //
+    //                             putAll
+    //
+    //      +---+            +---+                     +---+
+    //      | * |            | * |                     | * |
+    //      +-+-+            +-+-+                     +-+-+
+    //        |                |                         |
+    //        *                *            ->           *
+    //        *                *                         *
+    //        *                *                         *
+    //        |                |                         |
+    //      +-+-+      +-------+------+              +---+------+
+    //      | * |      | 1, 10 | 3, 3 |              | * | 3, 3 |
+    //      +-+-+      +-------+------+              +-+-+------+
+    //        |                                        |
+    // +------+------+                         +-------+------+
+    // [ 1, 1 | 2, 2 ]                         [ 1, 10 | 2, 2 ]
+    // +------+------+                         +-------+------+
+    //
+    @Test
+    fun putAllCollisionNodeMeetsSingleEntry() {
+        val wrapper1 = IntWrapper(1, 0)
+        val wrapper2 = IntWrapper(2, 0)
+        val wrapper3 = IntWrapper(3, 1 shl MAX_SHIFT)
+
+        val collisionMap = PersistentHashMap.emptyOf<IntWrapper, Int>().putting(wrapper1, 1).putting(wrapper2, 2)
+        val entryMap = PersistentHashMap.emptyOf<IntWrapper, Int>().putting(wrapper1, 10).putting(wrapper3, 3)
+
+        val sum = collisionMap.puttingAll(entryMap) as PersistentHashMap<IntWrapper, Int>
+        val reversedSum = entryMap.puttingAll(collisionMap) as PersistentHashMap<IntWrapper, Int>
+
+        for (map in listOf(sum, reversedSum)) {
+            assertEquals(3, map.size)
+            map.node.accept { node: TrieNode<IntWrapper, Int>, shift: Int, _: Int, dataMap: Int, nodeMap: Int ->
+                when {
+                    shift > MAX_SHIFT -> {
+                        assertEquals(0b0, dataMap)
+                        assertEquals(0b0, nodeMap)
+                        assertEquals(4, node.buffer.size)
+                        assertEquals(setOf<Any?>(wrapper1, wrapper2), setOf(node.buffer[0], node.buffer[2]))
+                    }
+                    shift == MAX_SHIFT -> {
+                        assertEquals(0b10, dataMap)
+                        assertEquals(0b1, nodeMap)
+                    }
+                    else -> {
+                        assertEquals(0b0, dataMap)
+                        assertEquals(0b1, nodeMap)
+                    }
+                }
+            }
+        }
+        assertEquals(10, sum[wrapper1])
+        assertEquals(1, reversedSum[wrapper1])
+        assertEquals(2, sum[wrapper2])
+        assertEquals(3, sum[wrapper3])
+    }
+
     // TODO: Investigate performance impact of converting single-entry collision root node to compact node. See the following commented test:
 /*
     // Nodes drawn using square braces are collision nodes.


### PR DESCRIPTION
The node-vs-element branches of the bulk walkers now dispatch to the `collision*` helpers at `shift == MAX_SHIFT`, the way the single-element operations already do.

`indexSegment` also asserts the shift stays within `MAX_SHIFT`. Kotlin takes `Int` shift counts mod 32, so the overrun was silent.

Fixes #294
