### PR TITLE
Take the argument's value when two collision nodes share a key

### DIFF
--- a/core/commonMain/src/implementations/immutableMap/TrieNode.kt
+++ b/core/commonMain/src/implementations/immutableMap/TrieNode.kt
@@ -485,18 +485,27 @@ internal class TrieNode<K, V>(
         assert { otherNode.dataMap == 0 }
         val tempBuffer = this.buffer.copyOf(newSize = this.buffer.size + otherNode.buffer.size)
         var i = this.buffer.size
-        for (j in 0..<otherNode.buffer.size step ENTRY_SIZE) {
-            @Suppress("UNCHECKED_CAST")
-            if (!this.collisionContainsKey(otherNode.buffer[j] as K)) {
+        var replaced = false
+        var sharedKeys = true
+        for (j in otherNode.buffer.indices step ENTRY_SIZE) {
+            val keyIndex = this.collisionKeyIndex(otherNode.buffer[j])
+            if (keyIndex == -1) {
                 tempBuffer[i] = otherNode.buffer[j]
                 tempBuffer[i + 1] = otherNode.buffer[j + 1]
                 i += ENTRY_SIZE
-            } else intersectionCounter.count++
+            } else {
+                intersectionCounter.count++
+                if (tempBuffer[keyIndex] !== otherNode.buffer[j]) sharedKeys = false
+                if (tempBuffer[keyIndex + 1] !== otherNode.buffer[j + 1]) {
+                    tempBuffer[keyIndex + 1] = otherNode.buffer[j + 1]
+                    replaced = true
+                }
+            }
         }
 
         return when (val newSize = i) {
-            this.buffer.size -> this
-            otherNode.buffer.size -> otherNode
+            this.buffer.size if !replaced -> this
+            otherNode.buffer.size if sharedKeys -> otherNode
             tempBuffer.size -> TrieNode(0, 0, tempBuffer, owner)
             else -> TrieNode(0, 0, tempBuffer.copyOf(newSize), owner)
         }

--- a/core/commonTest/src/contract/map/ImmutableMapTest.kt
+++ b/core/commonTest/src/contract/map/ImmutableMapTest.kt
@@ -42,7 +42,7 @@ class ImmutableHashMapTest : ImmutableMapTest() {
 
         run {
             val x = immutableMapOf<IntWrapper, Int>() + (11..200).map { IntWrapper(it, it % 30) to it }
-            val y = immutableMapOf<IntWrapper, Int>() + (120..400).map { IntWrapper(it, it % 30) to it }
+            val y = immutableMapOf<IntWrapper, Int>() + (120..400).map { IntWrapper(it, it % 30) to -it }
             compareMaps(x.toMap() + y.toMap(), x.puttingAll(y))
             compareMaps(y.toMap() + x.toMap(), y.puttingAll(x))
         }

--- a/core/commonTest/src/contract/map/PersistentHashMapBuilderTest.kt
+++ b/core/commonTest/src/contract/map/PersistentHashMapBuilderTest.kt
@@ -13,6 +13,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
+import kotlin.test.assertSame
 import kotlin.test.assertTrue
 
 class PersistentHashMapBuilderTest {
@@ -134,5 +135,30 @@ class PersistentHashMapBuilderTest {
         reversedBuilder.putAll(persistentHashMapOf(a1 to 1, a2 to 2))
         assertEquals(3, reversedBuilder.size)
         assertEquals(persistentHashMapOf(a1 to 1, a2 to 2, sibling to 3), reversedBuilder.build())
+    }
+
+    @Test
+    fun `putAll should take the values of the argument builder without the two builders sharing storage`() {
+        val argument = persistentHashMapOf(a1 to 10, a2 to 20).builder()
+        val builder = persistentHashMapOf(a1 to 1, a2 to 2).builder()
+        builder.putAll(argument)
+        assertEquals(2, builder.size)
+
+        builder[a1] = 100
+        argument[a2] = 200
+
+        assertEquals(persistentHashMapOf(a1 to 100, a2 to 20), builder.build())
+        assertEquals(persistentHashMapOf(a1 to 10, a2 to 200), argument.build())
+    }
+
+    @Test
+    fun `putAll that replaces collision values should keep the stored key instances`() {
+        val storedKey = IntWrapper(1, 0)
+        val builder = persistentHashMapOf(storedKey to "a", a2 to "b").builder()
+
+        builder.putAll(persistentHashMapOf(IntWrapper(1, 0) to "x", IntWrapper(2, 0) to "y"))
+
+        assertEquals("x", builder[storedKey])
+        assertSame(storedKey, builder.keys.single { it == storedKey })
     }
 }

--- a/core/commonTest/src/contract/map/PersistentHashMapTest.kt
+++ b/core/commonTest/src/contract/map/PersistentHashMapTest.kt
@@ -11,6 +11,9 @@ import kotlinx.collections.immutable.plus
 import tests.IntWrapper
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNotSame
+import kotlin.test.assertNull
+import kotlin.test.assertSame
 import kotlin.test.assertTrue
 
 class PersistentHashMapTest {
@@ -104,5 +107,79 @@ class PersistentHashMapTest {
         val reversedSum = persistentHashMapOf(a3 to 4, sibling to 3) + persistentHashMapOf(a1 to 1, a2 to 2)
         assertEquals(4, reversedSum.size)
         assertEquals(expected, reversedSum)
+    }
+
+    @Test
+    fun `putAll should take the value of the argument for a key held by both collision nodes`() {
+        val receiver = persistentHashMapOf(a1 to 1, a2 to 2)
+        val argument = persistentHashMapOf(a1 to 10, a2 to 20)
+
+        assertEquals(persistentHashMapOf(a1 to 10, a2 to 20), receiver.puttingAll(argument))
+        assertEquals(persistentHashMapOf(a1 to 1, a2 to 2), argument.puttingAll(receiver))
+    }
+
+    @Test
+    fun `putAll should merge partially overlapping collision nodes`() {
+        val receiver = persistentHashMapOf(a1 to 1, a2 to 2)
+        val argument = persistentHashMapOf(a2 to 20, a3 to 4)
+
+        val sum = receiver.puttingAll(argument)
+        assertEquals(3, sum.size)
+        assertEquals(persistentHashMapOf(a1 to 1, a2 to 20, a3 to 4), sum)
+
+        val reversedSum = argument.puttingAll(receiver)
+        assertEquals(3, reversedSum.size)
+        assertEquals(persistentHashMapOf(a1 to 1, a2 to 2, a3 to 4), reversedSum)
+    }
+
+    @Test
+    fun `putAll should return a new map when the argument only replaces values of a collision node`() {
+        val receiver = persistentHashMapOf(a1 to 1, a2 to 2, a3 to 4, sibling to 3)
+        val argument = persistentHashMapOf(a1 to 10, a2 to 20)
+
+        val sum = receiver.puttingAll(argument)
+        assertNotSame(receiver, sum)
+        assertEquals(4, sum.size)
+        assertEquals(persistentHashMapOf(a1 to 10, a2 to 20, a3 to 4, sibling to 3), sum)
+
+        val reversedSum = argument.puttingAll(receiver)
+        assertEquals(4, reversedSum.size)
+        assertEquals(persistentHashMapOf(a1 to 1, a2 to 2, a3 to 4, sibling to 3), reversedSum)
+    }
+
+    @Test
+    fun `putAll should keep a null value the argument adds to a collision node`() {
+        val receiver = persistentHashMapOf(a1 to 1, a2 to null)
+        val argument = persistentHashMapOf(a2 to 20, a3 to null)
+
+        val sum = receiver.puttingAll(argument)
+        assertEquals(3, sum.size)
+        assertEquals(persistentHashMapOf(a1 to 1, a2 to 20, a3 to null), sum)
+        assertNull(sum[a3])
+    }
+
+    @Test
+    fun `putAll should take a value of the argument that is equal but not the same instance`() {
+        data class Value<T>(val value: T)
+
+        val value = Value(1)
+        val equalValue = Value(1)
+        val receiver = persistentHashMapOf(a1 to value, a2 to value)
+        val argument = persistentHashMapOf(a1 to equalValue, a2 to value)
+
+        val sum = receiver.puttingAll(argument)
+        assertNotSame(receiver, sum)
+        assertEquals(receiver, sum)
+        assertSame(equalValue, sum[a1])
+    }
+
+    @Test
+    fun `putAll should return the same map when the argument brings no new values`() {
+        val one = "one"
+        val two = "two"
+        val receiver = persistentHashMapOf(a1 to one, a2 to two, sibling to "three")
+        val argument = persistentHashMapOf(a1 to one, a2 to two)
+
+        assertSame(receiver, receiver.puttingAll(argument))
     }
 }

--- a/core/commonTest/src/implementations/map/HashMapTrieNodeTest.kt
+++ b/core/commonTest/src/implementations/map/HashMapTrieNodeTest.kt
@@ -422,6 +422,78 @@ class HashMapTrieNodeTest {
         assertEquals(3, sum[wrapper3])
     }
 
+    // Nodes drawn using square braces are collision nodes.
+    //
+    //                            putAll
+    //
+    //      +---+            +---+                     +---+
+    //      | * |            | * |                     | * |
+    //      +-+-+            +-+-+                     +-+-+
+    //        |                |                         |
+    //        *                *            ->           *
+    //        *                *                         *
+    //        *                *                         *
+    //        |                |                         |
+    // +------+------+  +------+------+       +------+------+------+
+    // [ 1, 1 | 2, 2 ]  [ 2, 4 | 3, 6 ]       [ 1, 1 | 2, 4 | 3, 6 ]
+    // +------+------+  +------+------+       +------+------+------+
+    //
+    @Test
+    fun putAllCollisionNodeMeetsCollisionNode() {
+        val wrapper1 = IntWrapper(1, 0)
+        val wrapper2 = IntWrapper(2, 0)
+        val wrapper3 = IntWrapper(3, 0)
+
+        val map = PersistentHashMap.emptyOf<IntWrapper, Int>().putting(wrapper1, 1).putting(wrapper2, 2)
+        val other = PersistentHashMap.emptyOf<IntWrapper, Int>().putting(wrapper2, 4).putting(wrapper3, 6)
+
+        val sum = map.puttingAll(other) as PersistentHashMap<IntWrapper, Int>
+
+        assertEquals(3, sum.size)
+        sum.node.accept { node: TrieNode<IntWrapper, Int>, shift: Int, _: Int, dataMap: Int, nodeMap: Int ->
+            if (shift > MAX_SHIFT) {
+                assertEquals(0b0, dataMap)
+                assertEquals(0b0, nodeMap)
+                assertTrue(arrayOf<Any?>(wrapper1, 1, wrapper2, 4, wrapper3, 6) contentEquals node.buffer)
+            } else {
+                assertEquals(0b0, dataMap)
+                assertEquals(0b1, nodeMap)
+            }
+        }
+    }
+
+    // Nodes drawn using square braces are collision nodes.
+    //
+    //                             putAll
+    //
+    //      +---+             +---+                       +---+
+    //      | * |             | * |                       | * |
+    //      +-+-+             +-+-+                       +-+-+
+    //        |                 |                           |
+    //        *                 *             ->            *
+    //        *                 *                           *
+    //        *                 *                           *
+    //        |                 |                           |
+    // +------+------+  +-------+-------+           +-------+-------+
+    // [ 1, 1 | 2, 2 ]  [ 1, 10 | 2, 20 ]           [ 1, 10 | 2, 20 ]
+    // +------+------+  +-------+-------+           +-------+-------+
+    //
+    // Every key of the receiver is shared, so the merged trie is the argument's trie.
+    //
+    @Test
+    fun putAllCollisionNodeMeetsCollisionNodeWithEqualKeys() {
+        val wrapper1 = IntWrapper(1, 0)
+        val wrapper2 = IntWrapper(2, 0)
+
+        val map = PersistentHashMap.emptyOf<IntWrapper, Int>().putting(wrapper1, 1).putting(wrapper2, 2)
+        val other = PersistentHashMap.emptyOf<IntWrapper, Int>().putting(wrapper1, 10).putting(wrapper2, 20)
+
+        val sum = map.puttingAll(other) as PersistentHashMap<IntWrapper, Int>
+
+        assertEquals(2, sum.size)
+        assertSame(other.node, sum.node)
+    }
+
     // TODO: Investigate performance impact of converting single-entry collision root node to compact node. See the following commented test:
 /*
     // Nodes drawn using square braces are collision nodes.


### PR DESCRIPTION
The shortcut that returns the receiver tested that nothing was appended, which stopped meaning nothing changed once a shared key takes the argument's value. Values are compared by `!==`, so a modification means here what it means in `put`.

The merge keeps the stored key instances, as the per-key `put` does, so the argument's collision node is shared only when every shared key is the same instance.

Fixes #300
