### PR TITLE
Return the collision node as is when the put value is already stored

### DIFF
--- a/core/commonMain/src/implementations/immutableMap/TrieNode.kt
+++ b/core/commonMain/src/implementations/immutableMap/TrieNode.kt
@@ -388,7 +388,7 @@ internal class TrieNode<K, V>(
     }
 
     private fun collisionKeyIndex(key: Any?): Int {
-        for (i in 0..<buffer.size step ENTRY_SIZE) {
+        for (i in buffer.indices step ENTRY_SIZE) {
             if (key == keyAtIndex(i)) return i
         }
         return -1
@@ -422,6 +422,9 @@ internal class TrieNode<K, V>(
         val keyIndex = collisionKeyIndex(key)
         if (keyIndex != -1) { // found entry with the specified key
             mutator.operationResult = valueAtKeyIndex(keyIndex)
+            if (valueAtKeyIndex(keyIndex) === value) {
+                return this
+            }
 
             // If the [mutator] is exclusive owner of this node, update value of the entry in-place.
             if (ownedBy === mutator.ownership) {

--- a/core/commonTest/src/contract/map/ImmutableMapTest.kt
+++ b/core/commonTest/src/contract/map/ImmutableMapTest.kt
@@ -321,6 +321,11 @@ abstract class ImmutableMapTest {
         map.testNoOperation({ putting(equalKey, value) }, { put(equalKey, value) })
         map.testNotNoOperation({ putting(equalKey, equalValue) }, { put(equalKey, equalValue) })
 
+        val collisionMap = immutableMapOf(key to value, notEqualKey to notEqualValue)
+
+        collisionMap.testNoOperation({ putting(notEqualKey, notEqualValue) }, { put(notEqualKey, notEqualValue) })
+        collisionMap.testNotNoOperation({ putting(equalKey, equalValue) }, { put(equalKey, equalValue) })
+
         map.testNoOperation({ puttingAll(this) }, { putAll(this) })
         map.testNoOperation({ puttingAll(emptyMap()) }, { putAll(emptyMap()) })
     }

--- a/core/commonTest/src/contract/map/PersistentHashMapBuilderTest.kt
+++ b/core/commonTest/src/contract/map/PersistentHashMapBuilderTest.kt
@@ -152,6 +152,32 @@ class PersistentHashMapBuilderTest {
     }
 
     @Test
+    fun `put of a stored value should not rebuild a map whose key is in a bottom-level collision node`() {
+        val map = persistentHashMapOf(a1 to "a", a2 to "b", sibling to "c")
+        val stored = map[a1]!!
+
+        val builder = map.builder()
+        assertSame(stored, builder.put(a1, stored))
+        assertSame(map, builder.build())
+    }
+
+    @Test
+    fun `put of a stored value should not invalidate an iterator when the collision node is shared`() {
+        val builder = persistentHashMapOf(a1 to "a", a2 to "b", sibling to "c").builder()
+        builder[sibling] = "C"
+        val stored = builder[a1]!!
+
+        val iterator = builder.keys.iterator()
+        val visited = mutableListOf(iterator.next())
+        builder[a1] = stored
+        while (iterator.hasNext()) {
+            visited.add(iterator.next())
+        }
+
+        assertEquals(listOf(a1, a2, sibling), visited.sorted())
+    }
+
+    @Test
     fun `putAll that replaces collision values should keep the stored key instances`() {
         val storedKey = IntWrapper(1, 0)
         val builder = persistentHashMapOf(storedKey to "a", a2 to "b").builder()


### PR DESCRIPTION
`mutableCollisionPut` was the only put path without the identical-value check the other three have.

Fixes #304

