### PR TITLE
setValue during iteration invalidates the ordered map builder's iterator

### DIFF
--- a/core/commonMain/src/implementations/immutableMap/PersistentHashMapBuilder.kt
+++ b/core/commonMain/src/implementations/immutableMap/PersistentHashMapBuilder.kt
@@ -27,11 +27,16 @@ internal class PersistentHashMapBuilder<K, V>(map: PersistentHashMap<K, V>) :
     internal var operationResult: V? = null
     internal var modCount = 0
 
+    // The ordered map builder's chain of links moves only together with the size.
+    internal var sizeModCount = 0
+        private set
+
     // Size change implies structural changes.
     override var size = map.size
         set(value) {
             field = value
             modCount++
+            sizeModCount++
         }
 
     override fun build(): PersistentHashMap<K, V> {

--- a/core/commonMain/src/implementations/persistentOrderedMap/PersistentOrderedMapBuilderContentIterators.kt
+++ b/core/commonMain/src/implementations/persistentOrderedMap/PersistentOrderedMapBuilderContentIterators.kt
@@ -15,7 +15,7 @@ internal open class PersistentOrderedMapBuilderLinksIterator<K, V>(
 
     internal var lastIteratedKey: Any? = EndOfChain
     private var nextWasInvoked = false
-    private var expectedModCount = builder.hashMapBuilder.modCount
+    private var expectedModCount = builder.hashMapBuilder.sizeModCount
     internal var index = 0
 
     override fun hasNext(): Boolean {
@@ -42,7 +42,7 @@ internal open class PersistentOrderedMapBuilderLinksIterator<K, V>(
         builder.remove(lastIteratedKey)
         lastIteratedKey = null
         nextWasInvoked = false
-        expectedModCount = builder.hashMapBuilder.modCount
+        expectedModCount = builder.hashMapBuilder.sizeModCount
         index--
     }
 
@@ -57,7 +57,7 @@ internal open class PersistentOrderedMapBuilderLinksIterator<K, V>(
     }
 
     private fun checkForComodification() {
-        if (builder.hashMapBuilder.modCount != expectedModCount)
+        if (builder.hashMapBuilder.sizeModCount != expectedModCount)
             throw ConcurrentModificationException()
     }
 }
@@ -86,7 +86,7 @@ private class MutableMapEntry<K, V>(
     key: K,
     private var links: LinkedValue<V>
 ) : MapEntry<K, V>(key, links.value), MutableMap.MutableEntry<K, V> {
-    private val expectedModCount = builder.hashMapBuilder.modCount
+    private val expectedModCount = builder.hashMapBuilder.sizeModCount
 
     override val value: V
         get() = links.value
@@ -94,7 +94,7 @@ private class MutableMapEntry<K, V>(
     override fun setValue(newValue: V): V {
         val result = links.value
         links = links.withValue(newValue)
-        if (builder.hashMapBuilder.modCount == expectedModCount) {
+        if (builder.hashMapBuilder.sizeModCount == expectedModCount) {
             builder.setLinkedValue(key, links)
         } else {
             builder[key] = newValue

--- a/core/commonTest/src/contract/map/PersistentOrderedMapBuilderTest.kt
+++ b/core/commonTest/src/contract/map/PersistentOrderedMapBuilderTest.kt
@@ -8,6 +8,7 @@ package tests.contract.map
 import kotlinx.collections.immutable.persistentMapOf
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertNull
 
 class PersistentOrderedMapBuilderTest {
@@ -23,6 +24,104 @@ class PersistentOrderedMapBuilderTest {
         assertNull(builder.remove(absent))
         assertEquals(persistentMapOf(a to 1, b to 2), builder.build())
         assertEquals(listOf(a, b), builder.build().keys.toList())
+    }
+
+    @Test
+    fun `entry setValue during iteration keeps the iterator valid`() {
+        val builder = persistentMapOf(1 to "a", 2 to "b", 3 to "c").builder()
+
+        val visitedKeys = mutableListOf<Int>()
+        for (entry in builder.entries) {
+            visitedKeys.add(entry.key)
+            assertEquals(entry.value, entry.setValue(entry.value + "!"))
+        }
+
+        assertEquals(listOf(1, 2, 3), visitedKeys)
+        val built = builder.build()
+        assertEquals(listOf(1, 2, 3), built.keys.toList())
+        assertEquals(listOf("a!", "b!", "c!"), built.values.toList())
+    }
+
+    @Test
+    fun `entry setValue during iteration survives an intervening build`() {
+        val builder = persistentMapOf(1 to "a", 2 to "b", 3 to "c").builder()
+        val iterator = builder.entries.iterator()
+        assertEquals("a", iterator.next().setValue("a!"))
+
+        val snapshot = builder.build()
+        while (iterator.hasNext()) {
+            val entry = iterator.next()
+            assertEquals(entry.value, entry.setValue(entry.value + "!"))
+        }
+
+        assertEquals(persistentMapOf(1 to "a!", 2 to "b", 3 to "c"), snapshot)
+        val built = builder.build()
+        assertEquals(listOf(1, 2, 3), built.keys.toList())
+        assertEquals(listOf("a!", "b!", "c!"), built.values.toList())
+    }
+
+    @Test
+    fun `iterator remove after entry setValue keeps the iterator valid`() {
+        val builder = persistentMapOf(1 to "a", 2 to "b", 3 to "c").builder()
+        val iterator = builder.entries.iterator()
+        assertEquals("a", iterator.next().setValue("a!"))
+        val _ = iterator.next()
+
+        iterator.remove()
+
+        assertEquals(3, iterator.next().key)
+        val built = builder.build()
+        assertEquals(listOf(1, 3), built.keys.toList())
+        assertEquals(listOf("a!", "c"), built.values.toList())
+    }
+
+    @Test
+    fun `put of a new value for a stored key during iteration keeps the iterator valid`() {
+        val builder = persistentMapOf(1 to "a", 2 to "b", 3 to "c").builder()
+        val iterator = builder.entries.iterator()
+        val _ = iterator.next()
+
+        assertEquals("b", builder.put(2, "b!"))
+
+        assertEquals(2, iterator.next().key)
+        assertEquals(3, iterator.next().key)
+        assertEquals(listOf("a", "b!", "c"), builder.build().values.toList())
+    }
+
+    @Test
+    fun `put of a new value for a stored key during iteration keeps the keys and values iterators valid`() {
+        val builder = persistentMapOf(1 to "a", 2 to "b", 3 to "c").builder()
+        val keys = builder.keys.iterator()
+        val values = builder.values.iterator()
+        assertEquals(1, keys.next())
+        assertEquals("a", values.next())
+
+        assertEquals("b", builder.put(2, "b!"))
+
+        assertEquals(2, keys.next())
+        assertEquals("b!", values.next())
+    }
+
+    @Test
+    fun `put of a new key during iteration throws ConcurrentModificationException`() {
+        val builder = persistentMapOf(1 to "a", 2 to "b", 3 to "c").builder()
+        val iterator = builder.entries.iterator()
+        val _ = iterator.next()
+
+        builder[4] = "d"
+
+        assertFailsWith<ConcurrentModificationException> { iterator.next() }
+    }
+
+    @Test
+    fun `remove of a key during iteration throws ConcurrentModificationException`() {
+        val builder = persistentMapOf(1 to "a", 2 to "b", 3 to "c").builder()
+        val iterator = builder.entries.iterator()
+        val _ = iterator.next()
+
+        assertEquals("c", builder.remove(3))
+
+        assertFailsWith<ConcurrentModificationException> { iterator.next() }
     }
 
     private class TraceKey(val value: Int, private val hash: Int) {


### PR DESCRIPTION
The ordered map builder's iterators compared against `hashMapBuilder.modCount`, which also counts trie node replacements. They walk the chain by key and re-read every step, so a replaced node cannot invalidate them - unlike the hash map builder's own iterators, which cache trie buffers. `sizeModCount` counts the size changes alone, and that is enough because the chain of links moves only together with the size, as #274 already relies on.

A value-replacing `put` during iteration no longer throws either, as in `HashMap`.

Fixes #307

