### PR TITLE
Update kotlinx.benchmark to 0.4.17

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ versionSuffix=SNAPSHOT
 
 kotlin_version=2.3.0
 dokkaVersion=2.2.0
-kotlinxBenchmarkVersion=0.4.15
+kotlinxBenchmarkVersion=0.4.17
 koverVersion=0.9.9
 
 org.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=2048m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8


### PR DESCRIPTION
kotlinx.benchmark 0.4.15 is using the NodeJsExec.create KGP API which will be removed in KGP 2.5.0. 0.4.17 has migrated off of this API.