### PR TITLE
addingAll replaces the stored element instance when the argument holds the element in a deeper node

### DIFF
--- a/core/commonMain/src/implementations/immutableSet/TrieNode.kt
+++ b/core/commonMain/src/implementations/immutableSet/TrieNode.kt
@@ -265,17 +265,26 @@ internal class TrieNode<E>(
             return this
         }
         val tempBuffer = this.buffer.copyOf(newSize = this.buffer.size + otherNode.buffer.size)
-        val totalWritten = otherNode.buffer.filterTo(tempBuffer, newArrayOffset = this.buffer.size) {
+        var totalSize = this.buffer.size
+        var sharedElements = true
+        for (j in otherNode.buffer.indices) {
             @Suppress("UNCHECKED_CAST")
-            !this.collisionContainsElement(it as E)
+            val otherElement = otherNode.buffer[j] as E
+            val index = this.buffer.indexOf(otherElement)
+            if (index == -1) {
+                tempBuffer[totalSize] = otherElement
+                totalSize++
+            } else {
+                intersectionSizeRef.count++
+                if (tempBuffer[index] !== otherElement) sharedElements = false
+            }
         }
-        val totalSize = totalWritten + this.buffer.size
-        intersectionSizeRef += (tempBuffer.size - totalSize)
-        if (totalSize == this.buffer.size) return this
-        if (totalSize == otherNode.buffer.size) return otherNode
-
-        val newBuffer = if (totalSize == tempBuffer.size) tempBuffer else tempBuffer.copyOf(newSize = totalSize)
-        return setProperties(newBitmap = 0, newBuffer, owner)
+        return when (totalSize) {
+            this.buffer.size -> this
+            otherNode.buffer.size if sharedElements -> otherNode
+            tempBuffer.size -> setProperties(newBitmap = 0, newBuffer = tempBuffer, owner)
+            else -> setProperties(newBitmap = 0, newBuffer = tempBuffer.copyOf(newSize = totalSize), owner)
+        }
     }
 
     private fun mutableCollisionRetainAll(
@@ -438,17 +447,17 @@ internal class TrieNode<E>(
                         otherIsNode -> @Suppress("UNCHECKED_CAST") {
                             otherNodeCell as TrieNode<E>
                             thisCell as E
-                            val oldSize = mutator.size
-                            if (shift == MAX_SHIFT) {
-                                otherNodeCell.mutableCollisionAdd(thisCell, mutator)
+                            val liftedNode = if (shift == MAX_SHIFT) {
+                                TrieNode<E>(0, arrayOf(thisCell), null)
                             } else {
-                                otherNodeCell.mutableAdd(
-                                    thisCell.hashCode(), thisCell,
-                                    shift + LOG_MAX_BRANCHING_FACTOR, mutator
-                                )
-                            }.also {
-                                if (mutator.size == oldSize) intersectionSizeRef.count++
+                                val elementPositionMask =
+                                    1 shl indexSegment(thisCell.hashCode(), shift + LOG_MAX_BRANCHING_FACTOR)
+                                TrieNode(elementPositionMask, arrayOf(thisCell), null)
                             }
+                            liftedNode.mutableAddAll(
+                                otherNodeCell, shift + LOG_MAX_BRANCHING_FACTOR,
+                                intersectionSizeRef, mutator
+                            )
                         }
                         // both are just E => compare them
                         thisCell == otherNodeCell -> thisCell.also { intersectionSizeRef.count++ }

--- a/core/commonTest/src/contract/set/PersistentHashSetBuilderTest.kt
+++ b/core/commonTest/src/contract/set/PersistentHashSetBuilderTest.kt
@@ -6,12 +6,15 @@
 package tests.contract.set
 
 import kotlinx.collections.immutable.implementations.immutableSet.PersistentHashSet
+import kotlinx.collections.immutable.implementations.immutableSet.PersistentHashSetBuilder
 import kotlinx.collections.immutable.persistentHashSetOf
 import tests.IntWrapper
+import kotlin.random.Random
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
+import kotlin.test.assertSame
 import kotlin.test.assertTrue
 
 class PersistentHashSetBuilderTest {
@@ -189,5 +192,185 @@ class PersistentHashSetBuilderTest {
         assertTrue(reversedBuilder.removeAll(persistentHashSetOf(a1, a2)))
         assertEquals(1, reversedBuilder.size)
         assertEquals(persistentHashSetOf(sibling), reversedBuilder.build())
+    }
+
+    @Test
+    fun `addAll should keep the stored element instance when the collision node is reached at the last level`() {
+        val storedElement = IntWrapper(1, 0)
+        val builder = persistentHashSetOf(storedElement, sibling).builder()
+
+        builder.addAll(persistentHashSetOf(IntWrapper(1, 0), IntWrapper(2, 0)))
+
+        assertEquals(3, builder.size)
+        assertSame(storedElement, builder.single { it == storedElement })
+        assertSame(sibling, builder.single { it == sibling })
+    }
+
+    @Test
+    fun `addAll should keep every stored instance when the receiver's collision node is an equality-subset of the argument's`() {
+        val storedElement1 = IntWrapper(1, 0)
+        val storedElement2 = IntWrapper(2, 0)
+        val builder = persistentHashSetOf(storedElement1, storedElement2).builder()
+
+        builder.addAll(persistentHashSetOf(IntWrapper(1, 0), IntWrapper(2, 0), IntWrapper(3, 0)))
+
+        assertEquals(3, builder.size)
+        assertSame(storedElement1, builder.single { it == storedElement1 })
+        assertSame(storedElement2, builder.single { it == storedElement2 })
+    }
+
+    @Test
+    fun `addAll should insert the element when the argument's subtree lacks it`() {
+        val storedElement = IntWrapper(1, 0)
+        val builder = persistentHashSetOf(storedElement).builder()
+
+        builder.addAll(persistentHashSetOf(IntWrapper(2, 32), IntWrapper(3, 64)))
+
+        assertEquals(3, builder.size)
+        assertTrue(builder.contains(IntWrapper(2, 32)))
+        assertTrue(builder.contains(IntWrapper(3, 64)))
+        assertSame(storedElement, builder.single { it == storedElement })
+    }
+
+    @Test
+    fun `addAll should push the element deeper when it collides with an argument element inside the subtree`() {
+        val storedElement = IntWrapper(1, 0)
+        val builder = persistentHashSetOf(storedElement).builder()
+
+        builder.addAll(persistentHashSetOf(IntWrapper(2, 1 shl 10), IntWrapper(3, 32)))
+
+        assertEquals(3, builder.size)
+        assertTrue(builder.contains(IntWrapper(2, 1 shl 10)))
+        assertTrue(builder.contains(IntWrapper(3, 32)))
+        assertSame(storedElement, builder.single { it == storedElement })
+    }
+
+    @Test
+    fun `addAll should reuse the argument's subtree when it holds the stored element instance`() {
+        val argument = persistentHashSetOf(a1, IntWrapper(2, 32)) as PersistentHashSet<IntWrapper>
+        val builder = (persistentHashSetOf(a1) as PersistentHashSet<IntWrapper>).builder() as PersistentHashSetBuilder<IntWrapper>
+
+        builder.addAll(argument)
+
+        assertEquals(2, builder.size)
+        assertSame(argument.node, builder.node)
+    }
+
+    @Test
+    fun `addAll should reuse the argument's collision node when its element is already the receiver's instance`() {
+        val argument = persistentHashSetOf(a1, a2) as PersistentHashSet<IntWrapper>
+        val builder = (persistentHashSetOf(a1) as PersistentHashSet<IntWrapper>).builder() as PersistentHashSetBuilder<IntWrapper>
+
+        builder.addAll(argument)
+
+        assertEquals(2, builder.size)
+        assertSame(argument.node, builder.node)
+    }
+
+    @Test
+    fun `addAll should reuse the argument's collision node when the receiver's elements are already its instances`() {
+        val argument = persistentHashSetOf(a1, a2, a3) as PersistentHashSet<IntWrapper>
+        val builder = (persistentHashSetOf(a1, a2) as PersistentHashSet<IntWrapper>).builder() as PersistentHashSetBuilder<IntWrapper>
+
+        builder.addAll(argument)
+
+        assertEquals(3, builder.size)
+        assertSame(argument.node, builder.node)
+    }
+
+    @Test
+    fun `addAll should not write the receiver's element into the argument's set`() {
+        val storedElement = IntWrapper(1, 0)
+        val argumentElement = IntWrapper(1, 0)
+        val argument = persistentHashSetOf(argumentElement, IntWrapper(2, 32))
+        val builder = persistentHashSetOf(storedElement).builder()
+
+        builder.addAll(argument)
+
+        assertSame(storedElement, builder.single { it == storedElement })
+        assertSame(argumentElement, argument.single { it == argumentElement })
+    }
+
+    @Test
+    fun `addAll should invalidate a live iterator when the argument holds the element in a subtree`() {
+        val builder = persistentHashSetOf(a1).builder()
+
+        val iterator = builder.iterator()
+        builder.addAll(persistentHashSetOf(IntWrapper(1, 0), IntWrapper(2, 32)))
+
+        assertTrue(builder.contains(a1))
+        assertFailsWith<ConcurrentModificationException> { iterator.next() }
+    }
+
+    @Test
+    fun `addAll of the stored elements should not invalidate an iterator`() {
+        val builder = persistentHashSetOf(a1, a2, sibling).builder()
+
+        val iterator = builder.iterator()
+        val visited = mutableListOf(iterator.next())
+        builder.addAll(persistentHashSetOf(a1, a2, sibling))
+        while (iterator.hasNext()) {
+            visited.add(iterator.next())
+        }
+
+        assertEquals(listOf(a1, a2, sibling), visited.sorted())
+    }
+
+    @Test
+    fun `addAll that merges an element into the argument's subtree should count one size change`() {
+        val overlapping = persistentHashSetOf(IntWrapper(1, 0)).builder() as PersistentHashSetBuilder<IntWrapper>
+        val modCount = overlapping.modCount
+        overlapping.addAll(persistentHashSetOf(IntWrapper(1, 0), IntWrapper(2, 32)))
+        assertEquals(modCount + 1, overlapping.modCount)
+
+        val disjoint = persistentHashSetOf(IntWrapper(1, 0)).builder() as PersistentHashSetBuilder<IntWrapper>
+        val disjointModCount = disjoint.modCount
+        disjoint.addAll(persistentHashSetOf(IntWrapper(2, 32), IntWrapper(3, 64)))
+        assertEquals(disjointModCount + 1, disjoint.modCount)
+
+        val collision =
+            persistentHashSetOf(IntWrapper(1, 0), sibling).builder() as PersistentHashSetBuilder<IntWrapper>
+        val collisionModCount = collision.modCount
+        collision.addAll(persistentHashSetOf(IntWrapper(2, 0), IntWrapper(4, 0)))
+        assertEquals(4, collision.size)
+        assertEquals(collisionModCount + 1, collision.modCount)
+    }
+
+    @Test
+    fun `addAll of random colliding sets should keep the stored element instances`() {
+        val hashes = intArrayOf(0, 1, 32, 33, 1 shl 10, 1 shl 30, (1 shl 30) or 32)
+        val random = Random(316)
+        repeat(200) { iteration ->
+            val receiverElements = mutableMapOf<Int, IntWrapper>()
+            val builder = persistentHashSetOf<IntWrapper>().builder()
+            for (id in 0..<14) {
+                if (random.nextBoolean()) {
+                    val element = IntWrapper(id, hashes[id % hashes.size])
+                    receiverElements[id] = element
+                    builder.add(element)
+                }
+            }
+            val argumentElements = mutableMapOf<Int, IntWrapper>()
+            val argumentBuilder = persistentHashSetOf<IntWrapper>().builder()
+            for (id in 0..<14) {
+                if (random.nextBoolean()) {
+                    val element = IntWrapper(id, hashes[id % hashes.size])
+                    argumentElements[id] = element
+                    argumentBuilder.add(element)
+                }
+            }
+
+            builder.addAll(argumentBuilder.build())
+
+            val shape = "iteration $iteration, receiver ${receiverElements.keys}, argument ${argumentElements.keys}"
+            assertEquals((receiverElements.keys + argumentElements.keys).size, builder.size, shape)
+            for ((id, element) in receiverElements) {
+                assertSame(element, builder.singleOrNull { it == element }, "$shape, id $id")
+            }
+            for ((id, element) in argumentElements) {
+                if (id in receiverElements) continue
+                assertSame(element, builder.singleOrNull { it == element }, "$shape, id $id")
+            }
+        }
     }
 }

--- a/core/commonTest/src/contract/set/PersistentHashSetTest.kt
+++ b/core/commonTest/src/contract/set/PersistentHashSetTest.kt
@@ -15,6 +15,7 @@ import tests.IntWrapper
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertSame
 import kotlin.test.assertTrue
 
 class PersistentHashSetTest {
@@ -194,5 +195,16 @@ class PersistentHashSetTest {
         assertTrue(persistentHashSetOf(a1, a2, sibling).containsAll(persistentHashSetOf(a1, a2)))
         assertFalse(persistentHashSetOf(a1, sibling).containsAll(persistentHashSetOf(a1, a2)))
         assertFalse(persistentHashSetOf(a1, a2, sibling).containsAll(persistentHashSetOf(a3, sibling)))
+    }
+
+    @Test
+    fun `addingAll should keep the stored element instance when the argument holds it in a subtree`() {
+        val storedElement = IntWrapper(1, 0)
+        val set = persistentHashSetOf(storedElement)
+
+        val updated = set.addingAll(persistentHashSetOf(IntWrapper(1, 0), IntWrapper(2, 32)))
+
+        assertEquals(2, updated.size)
+        assertSame(storedElement, updated.single { it == storedElement })
     }
 }


### PR DESCRIPTION
The fix mirrors #317's lift-and-merge and the #302 guard. However, unlike the map's, the lifted node stays unowned, since with the set's single bitmap an owned lift gets reused in place down a collision chain, and then the merge returns the lift instead of adopting the argument's untouched node.

Fixes #316