### PR TITLE
retainingAll replaces the stored element instance when the receiver holds the element in a deeper node

### DIFF
--- a/core/commonMain/src/implementations/immutableMap/PersistentHashMapBuilderContentIterators.kt
+++ b/core/commonMain/src/implementations/immutableMap/PersistentHashMapBuilderContentIterators.kt
@@ -53,6 +53,7 @@ internal open class PersistentHashMapBuilderBaseIterator<K, V, T>(
 
     override fun remove() {
         checkNextWasInvoked()
+        checkForComodification()
         if (hasNext()) {
             val currentKey = currentKey()
 

--- a/core/commonMain/src/implementations/immutableMap/PersistentHashMapBuilderContentIterators.kt
+++ b/core/commonMain/src/implementations/immutableMap/PersistentHashMapBuilderContentIterators.kt
@@ -73,6 +73,11 @@ internal open class PersistentHashMapBuilderBaseIterator<K, V, T>(
     fun setValue(key: K, newValue: V) {
         if (!builder.containsKey(key)) return
 
+        if (builder.modCount != expectedModCount) {
+            builder[key] = newValue
+            return
+        }
+
         if (hasNext()) {
             val currentKey = currentKey()
             builder[key] = newValue

--- a/core/commonMain/src/implementations/immutableSet/TrieNode.kt
+++ b/core/commonMain/src/implementations/immutableSet/TrieNode.kt
@@ -265,17 +265,26 @@ internal class TrieNode<E>(
             return this
         }
         val tempBuffer = this.buffer.copyOf(newSize = this.buffer.size + otherNode.buffer.size)
-        val totalWritten = otherNode.buffer.filterTo(tempBuffer, newArrayOffset = this.buffer.size) {
+        var totalSize = this.buffer.size
+        var sharedElements = true
+        for (j in otherNode.buffer.indices) {
             @Suppress("UNCHECKED_CAST")
-            !this.collisionContainsElement(it as E)
+            val otherElement = otherNode.buffer[j] as E
+            val index = this.buffer.indexOf(otherElement)
+            if (index == -1) {
+                tempBuffer[totalSize] = otherElement
+                totalSize++
+            } else {
+                intersectionSizeRef.count++
+                if (tempBuffer[index] !== otherElement) sharedElements = false
+            }
         }
-        val totalSize = totalWritten + this.buffer.size
-        intersectionSizeRef += (tempBuffer.size - totalSize)
-        if (totalSize == this.buffer.size) return this
-        if (totalSize == otherNode.buffer.size) return otherNode
-
-        val newBuffer = if (totalSize == tempBuffer.size) tempBuffer else tempBuffer.copyOf(newSize = totalSize)
-        return setProperties(newBitmap = 0, newBuffer, owner)
+        return when (totalSize) {
+            this.buffer.size -> this
+            otherNode.buffer.size if sharedElements -> otherNode
+            tempBuffer.size -> setProperties(newBitmap = 0, newBuffer = tempBuffer, owner)
+            else -> setProperties(newBitmap = 0, newBuffer = tempBuffer.copyOf(newSize = totalSize), owner)
+        }
     }
 
     private fun mutableCollisionRetainAll(
@@ -438,17 +447,17 @@ internal class TrieNode<E>(
                         otherIsNode -> @Suppress("UNCHECKED_CAST") {
                             otherNodeCell as TrieNode<E>
                             thisCell as E
-                            val oldSize = mutator.size
-                            if (shift == MAX_SHIFT) {
-                                otherNodeCell.mutableCollisionAdd(thisCell, mutator)
+                            val liftedNode = if (shift == MAX_SHIFT) {
+                                TrieNode<E>(0, arrayOf(thisCell), null)
                             } else {
-                                otherNodeCell.mutableAdd(
-                                    thisCell.hashCode(), thisCell,
-                                    shift + LOG_MAX_BRANCHING_FACTOR, mutator
-                                )
-                            }.also {
-                                if (mutator.size == oldSize) intersectionSizeRef.count++
+                                val elementPositionMask =
+                                    1 shl indexSegment(thisCell.hashCode(), shift + LOG_MAX_BRANCHING_FACTOR)
+                                TrieNode(elementPositionMask, arrayOf(thisCell), null)
                             }
+                            liftedNode.mutableAddAll(
+                                otherNodeCell, shift + LOG_MAX_BRANCHING_FACTOR,
+                                intersectionSizeRef, mutator
+                            )
                         }
                         // both are just E => compare them
                         thisCell == otherNodeCell -> thisCell.also { intersectionSizeRef.count++ }

--- a/core/commonMain/src/implementations/immutableSet/TrieNode.kt
+++ b/core/commonMain/src/implementations/immutableSet/TrieNode.kt
@@ -225,6 +225,12 @@ internal class TrieNode<E>(
         return buffer.contains(element)
     }
 
+    private fun collisionElementOrEmpty(element: E): Any? {
+        val index = buffer.indexOf(element)
+        if (index == -1) return EMPTY
+        return buffer[index]
+    }
+
     private fun collisionAdd(element: E): TrieNode<E> {
         if (collisionContainsElement(element)) return this
         val newBuffer = buffer.addElementAtIndex(0, element)
@@ -299,16 +305,24 @@ internal class TrieNode<E>(
         val tempBuffer =
             if (owner === ownedBy) buffer
             else arrayOfNulls<Any?>(minOf(buffer.size, otherNode.buffer.size))
-        val totalWritten = buffer.filterTo(tempBuffer) {
-            @Suppress("UNCHECKED_CAST")
-            otherNode.collisionContainsElement(it as E)
+        var totalWritten = 0
+        var sharedElements = true
+        for (i in buffer.indices) {
+            assert { totalWritten <= i }
+            val element = buffer[i]
+            val otherIndex = otherNode.buffer.indexOf(element)
+            if (otherIndex != -1) {
+                tempBuffer[totalWritten] = element
+                totalWritten++
+                if (otherNode.buffer[otherIndex] !== element) sharedElements = false
+            }
         }
         intersectionSizeRef += totalWritten
         return when (totalWritten) {
             0 -> EMPTY
             1 -> tempBuffer[0]
             this.buffer.size -> this
-            otherNode.buffer.size -> otherNode
+            otherNode.buffer.size if sharedElements -> otherNode
             tempBuffer.size -> setProperties(newBitmap = 0, newBuffer = tempBuffer, owner)
             else -> setProperties(newBitmap = 0, newBuffer = tempBuffer.copyOf(newSize = totalWritten), owner)
         }
@@ -360,22 +374,27 @@ internal class TrieNode<E>(
     }
 
     fun contains(elementHash: Int, element: E, shift: Int): Boolean {
+        return elementOrEmpty(elementHash, element, shift) !== EMPTY
+    }
+
+    private fun elementOrEmpty(elementHash: Int, element: E, shift: Int): Any? {
         val cellPositionMask = 1 shl indexSegment(elementHash, shift)
 
         if (hasNoCellAt(cellPositionMask)) { // element is absent
-            return false
+            return EMPTY
         }
 
         val cellIndex = indexOfCellAt(cellPositionMask)
         if (buffer[cellIndex] is TrieNode<*>) { // element may be in node
             val targetNode = nodeAtIndex(cellIndex)
             if (shift == MAX_SHIFT) {
-                return targetNode.collisionContainsElement(element)
+                return targetNode.collisionElementOrEmpty(element)
             }
-            return targetNode.contains(elementHash, element, shift + LOG_MAX_BRANCHING_FACTOR)
+            return targetNode.elementOrEmpty(elementHash, element, shift + LOG_MAX_BRANCHING_FACTOR)
         }
         // element is directly in buffer
-        return element == buffer[cellIndex]
+        val cell = buffer[cellIndex]
+        return if (element == cell) cell else EMPTY
     }
 
     fun mutableAddAll(
@@ -528,18 +547,16 @@ internal class TrieNode<E>(
                     thisIsNode -> @Suppress("UNCHECKED_CAST") {
                         thisCell as TrieNode<E>
                         otherNodeCell as E
-                        val hasElement = if (shift == MAX_SHIFT) {
-                            thisCell.collisionContainsElement(otherNodeCell)
+                        val storedElement = if (shift == MAX_SHIFT) {
+                            thisCell.collisionElementOrEmpty(otherNodeCell)
                         } else {
-                            thisCell.contains(
+                            thisCell.elementOrEmpty(
                                 otherNodeCell.hashCode(), otherNodeCell,
                                 shift + LOG_MAX_BRANCHING_FACTOR
                             )
                         }
-                        if (hasElement) {
-                            intersectionSizeRef += 1
-                            otherNodeCell
-                        } else EMPTY
+                        if (storedElement !== EMPTY) intersectionSizeRef += 1
+                        storedElement
                     }
                     // same as last case, but reversed
                     otherIsNode -> @Suppress("UNCHECKED_CAST") {

--- a/core/commonTest/src/contract/map/PersistentHashMapBuilderTest.kt
+++ b/core/commonTest/src/contract/map/PersistentHashMapBuilderTest.kt
@@ -593,4 +593,188 @@ class PersistentHashMapBuilderTest {
         assertFalse(iterator.hasNext())
         assertFalse(builder.build().containsKey(entry.key))
     }
+
+    @Test
+    fun `entry setValue after a remove of a different key writes the value and the following next throws`() {
+        val builder = persistentHashMapOf(1 to "a", 2 to "b").builder()
+        val iterator = builder.entries.iterator()
+        val entry = iterator.next()
+        val oldValue = entry.value
+        val otherKey = if (entry.key == 1) 2 else 1
+
+        builder.remove(otherKey)
+
+        assertEquals(oldValue, entry.setValue("z"))
+        assertEquals("z", builder[entry.key])
+        assertEquals(1, builder.size)
+        assertFailsWith<ConcurrentModificationException> { iterator.next() }
+    }
+
+    @Test
+    fun `entry setValue after a remove of a key other than the upcoming one writes the value and the following next throws`() {
+        val builder = persistentHashMapOf(1 to "a", 2 to "b", 3 to "c").builder()
+        val orderedKeys = builder.keys.toList()
+        val iterator = builder.entries.iterator()
+        val entry = iterator.next()
+        val oldValue = entry.value
+
+        assertEquals(orderedKeys[0], entry.key)
+        builder.remove(orderedKeys[2])
+
+        assertEquals(oldValue, entry.setValue("z"))
+        assertEquals("z", builder[entry.key])
+        assertEquals(2, builder.size)
+        assertFailsWith<ConcurrentModificationException> { iterator.next() }
+    }
+
+    @Test
+    fun `entry setValue after an external remove of its own key writes nothing and the following next throws`() {
+        val builder = persistentHashMapOf(1 to "a", 2 to "b").builder()
+        val iterator = builder.entries.iterator()
+        val entry = iterator.next()
+        val oldValue = entry.value
+
+        builder.remove(entry.key)
+
+        assertEquals(oldValue, entry.setValue("z"))
+        assertFalse(builder.containsKey(entry.key))
+        assertEquals(1, builder.size)
+        assertFailsWith<ConcurrentModificationException> { iterator.next() }
+    }
+
+    @Test
+    fun `entry setValue after an external put of a new key writes the value and the following next throws`() {
+        val builder = persistentHashMapOf(1 to "a", 2 to "b").builder()
+        val iterator = builder.entries.iterator()
+        val entry = iterator.next()
+        val oldValue = entry.value
+
+        builder[3] = "c"
+
+        assertEquals(oldValue, entry.setValue("z"))
+        assertEquals("z", builder[entry.key])
+        assertEquals(3, builder.size)
+        assertFailsWith<ConcurrentModificationException> { iterator.next() }
+    }
+
+    @Test
+    fun `entry setValue after an external value overwrite of a different key writes the value and the following next throws`() {
+        val builder = persistentHashMapOf(1 to "a", 2 to "b", 3 to "c").builder()
+        val iterator = builder.entries.iterator()
+        val entry = iterator.next()
+        val oldValue = entry.value
+        val otherKey = (setOf(1, 2, 3) - entry.key).first()
+
+        builder[otherKey] = "overwritten"
+
+        assertEquals(oldValue, entry.setValue("z"))
+        assertEquals("z", builder[entry.key])
+        assertEquals("overwritten", builder[otherKey])
+        assertEquals(3, builder.size)
+        assertFailsWith<ConcurrentModificationException> { iterator.next() }
+    }
+
+    @Test
+    fun `entry setValue on the exhausted iterator of a single entry map after an external put writes the value and the following next throws`() {
+        val builder = persistentHashMapOf(1 to "a").builder()
+        val iterator = builder.entries.iterator()
+        val entry = iterator.next()
+
+        assertFalse(iterator.hasNext())
+        builder[2] = "b"
+
+        assertEquals("a", entry.setValue("z"))
+        assertEquals("z", builder[1])
+        assertEquals(2, builder.size)
+        assertFailsWith<ConcurrentModificationException> { iterator.next() }
+    }
+
+    @Test
+    fun `entry setValue after a remove of a colliding key writes the value and the following next throws`() {
+        val builder = persistentHashMapOf(
+            IntWrapper(1, 0) to "a",
+            IntWrapper(2, 0) to "b",
+            IntWrapper(3, 0) to "c"
+        ).builder()
+        val orderedKeys = builder.keys.toList()
+        val iterator = builder.entries.iterator()
+        val entry = iterator.next()
+        val oldValue = entry.value
+
+        builder.remove(orderedKeys[1])
+
+        assertEquals(oldValue, entry.setValue("z"))
+        assertEquals("z", builder[entry.key])
+        assertEquals(2, builder.size)
+        assertFailsWith<ConcurrentModificationException> { iterator.next() }
+    }
+
+    @Test
+    fun `entry setValue after a remove that shrinks the collision node writes the value and the following next throws`() {
+        val builder = persistentHashMapOf(
+            IntWrapper(1, 0) to "a",
+            IntWrapper(2, 0) to "b",
+            IntWrapper(3, 1) to "c"
+        ).builder()
+        val orderedKeys = builder.keys.toList()
+        val iterator = builder.entries.iterator()
+        val _ = iterator.next()
+        val entry = iterator.next()
+        val oldValue = entry.value
+
+        assertEquals(IntWrapper(3, 1), orderedKeys[0])
+        builder.remove(orderedKeys[2])
+
+        assertEquals(oldValue, entry.setValue("z"))
+        assertEquals("z", builder[entry.key])
+        assertEquals(2, builder.size)
+        assertFailsWith<ConcurrentModificationException> { iterator.next() }
+    }
+
+    @Test
+    fun `setting values through the iterator updates every entry and preserves the iteration order`() {
+        val builder = persistentHashMapOf(
+            IntWrapper(1, 0) to "a",
+            IntWrapper(2, 0) to "b",
+            IntWrapper(3, 1) to "c",
+            IntWrapper(4, 32) to "d"
+        ).builder()
+        val orderedKeys = builder.keys.toList()
+        val visited = mutableListOf<IntWrapper>()
+        val iterator = builder.entries.iterator()
+
+        while (iterator.hasNext()) {
+            val entry = iterator.next()
+            visited.add(entry.key)
+            val _ = entry.setValue(entry.value + "!")
+        }
+
+        assertEquals(orderedKeys, visited)
+        assertEquals(4, builder.size)
+        assertEquals("a!", builder[IntWrapper(1, 0)])
+        assertEquals("b!", builder[IntWrapper(2, 0)])
+        assertEquals("c!", builder[IntWrapper(3, 1)])
+        assertEquals("d!", builder[IntWrapper(4, 32)])
+    }
+
+    @Test
+    fun `setting the value of an earlier entry after a later one keeps the iterator valid`() {
+        val builder = persistentHashMapOf(1 to "a", 2 to "b", 3 to "c").builder()
+        val orderedKeys = builder.keys.toList()
+        val iterator = builder.entries.iterator()
+        val first = iterator.next()
+        val second = iterator.next()
+        val firstValue = first.value
+        val secondValue = second.value
+
+        assertEquals(secondValue, second.setValue("y"))
+        assertEquals(firstValue, first.setValue("x"))
+        assertEquals("x", first.setValue("xx"))
+
+        assertEquals("xx", builder[orderedKeys[0]])
+        assertEquals("y", builder[orderedKeys[1]])
+        assertEquals(3, builder.size)
+        assertEquals(orderedKeys[2], iterator.next().key)
+        assertFalse(iterator.hasNext())
+    }
 }

--- a/core/commonTest/src/contract/map/PersistentHashMapBuilderTest.kt
+++ b/core/commonTest/src/contract/map/PersistentHashMapBuilderTest.kt
@@ -746,7 +746,7 @@ class PersistentHashMapBuilderTest {
         while (iterator.hasNext()) {
             val entry = iterator.next()
             visited.add(entry.key)
-            val _ = entry.setValue(entry.value + "!")
+            entry.setValue(entry.value + "!")
         }
 
         assertEquals(orderedKeys, visited)

--- a/core/commonTest/src/contract/map/PersistentHashMapBuilderTest.kt
+++ b/core/commonTest/src/contract/map/PersistentHashMapBuilderTest.kt
@@ -777,4 +777,45 @@ class PersistentHashMapBuilderTest {
         assertEquals(orderedKeys[2], iterator.next().key)
         assertFalse(iterator.hasNext())
     }
+
+    @Test
+    fun `iterator remove after a remove of a different key throws ConcurrentModificationException`() {
+        val builder = persistentHashMapOf(1 to "a", 2 to "b").builder()
+        val orderedKeys = builder.keys.toList()
+        val iterator = builder.entries.iterator()
+        assertEquals(orderedKeys[0], iterator.next().key)
+
+        builder.remove(orderedKeys[1])
+
+        assertFailsWith<ConcurrentModificationException> { iterator.remove() }
+        assertEquals(1, builder.size)
+        assertTrue(builder.containsKey(orderedKeys[0]))
+        assertFailsWith<ConcurrentModificationException> { iterator.next() }
+    }
+
+    @Test
+    fun `iterator remove on the exhausted iterator of a single entry map after an external put throws ConcurrentModificationException`() {
+        val builder = persistentHashMapOf(1 to "a").builder()
+        val iterator = builder.entries.iterator()
+        val _ = iterator.next()
+        assertFalse(iterator.hasNext())
+
+        builder[2] = "b"
+
+        assertFailsWith<ConcurrentModificationException> { iterator.remove() }
+        assertEquals(2, builder.size)
+        assertEquals("a", builder[1])
+        assertFailsWith<ConcurrentModificationException> { iterator.next() }
+    }
+
+    @Test
+    fun `iterator remove without a preceding next after an external remove throws IllegalStateException`() {
+        val builder = persistentHashMapOf(1 to "a", 2 to "b").builder()
+        val iterator = builder.entries.iterator()
+
+        builder.remove(1)
+
+        assertFailsWith<IllegalStateException> { iterator.remove() }
+        assertEquals(1, builder.size)
+    }
 }

--- a/core/commonTest/src/contract/set/PersistentHashSetBuilderTest.kt
+++ b/core/commonTest/src/contract/set/PersistentHashSetBuilderTest.kt
@@ -6,12 +6,15 @@
 package tests.contract.set
 
 import kotlinx.collections.immutable.implementations.immutableSet.PersistentHashSet
+import kotlinx.collections.immutable.implementations.immutableSet.PersistentHashSetBuilder
 import kotlinx.collections.immutable.persistentHashSetOf
 import tests.IntWrapper
+import kotlin.random.Random
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
+import kotlin.test.assertSame
 import kotlin.test.assertTrue
 
 class PersistentHashSetBuilderTest {
@@ -189,5 +192,185 @@ class PersistentHashSetBuilderTest {
         assertTrue(reversedBuilder.removeAll(persistentHashSetOf(a1, a2)))
         assertEquals(1, reversedBuilder.size)
         assertEquals(persistentHashSetOf(sibling), reversedBuilder.build())
+    }
+
+    @Test
+    fun `addAll should keep the stored element instance when the collision node is reached at the last level`() {
+        val storedElement = IntWrapper(1, 0)
+        val builder = persistentHashSetOf(storedElement, sibling).builder()
+
+        builder.addAll(persistentHashSetOf(IntWrapper(1, 0), IntWrapper(2, 0)))
+
+        assertEquals(3, builder.size)
+        assertSame(storedElement, builder.single { it == storedElement })
+        assertSame(sibling, builder.single { it == sibling })
+    }
+
+    @Test
+    fun `addAll should keep every stored instance when the receiver's collision node is an equality-subset of the argument's`() {
+        val storedElement1 = IntWrapper(1, 0)
+        val storedElement2 = IntWrapper(2, 0)
+        val builder = persistentHashSetOf(storedElement1, storedElement2).builder()
+
+        builder.addAll(persistentHashSetOf(IntWrapper(1, 0), IntWrapper(2, 0), IntWrapper(3, 0)))
+
+        assertEquals(3, builder.size)
+        assertSame(storedElement1, builder.single { it == storedElement1 })
+        assertSame(storedElement2, builder.single { it == storedElement2 })
+    }
+
+    @Test
+    fun `addAll should insert the element when the argument's subtree lacks it`() {
+        val storedElement = IntWrapper(1, 0)
+        val builder = persistentHashSetOf(storedElement).builder()
+
+        builder.addAll(persistentHashSetOf(IntWrapper(2, 32), IntWrapper(3, 64)))
+
+        assertEquals(3, builder.size)
+        assertTrue(builder.contains(IntWrapper(2, 32)))
+        assertTrue(builder.contains(IntWrapper(3, 64)))
+        assertSame(storedElement, builder.single { it == storedElement })
+    }
+
+    @Test
+    fun `addAll should push the element deeper when it collides with an argument element inside the subtree`() {
+        val storedElement = IntWrapper(1, 0)
+        val builder = persistentHashSetOf(storedElement).builder()
+
+        builder.addAll(persistentHashSetOf(IntWrapper(2, 1 shl 10), IntWrapper(3, 32)))
+
+        assertEquals(3, builder.size)
+        assertTrue(builder.contains(IntWrapper(2, 1 shl 10)))
+        assertTrue(builder.contains(IntWrapper(3, 32)))
+        assertSame(storedElement, builder.single { it == storedElement })
+    }
+
+    @Test
+    fun `addAll should reuse the argument's subtree when it holds the stored element instance`() {
+        val argument = persistentHashSetOf(a1, IntWrapper(2, 32)) as PersistentHashSet<IntWrapper>
+        val builder = (persistentHashSetOf(a1) as PersistentHashSet<IntWrapper>).builder() as PersistentHashSetBuilder<IntWrapper>
+
+        builder.addAll(argument)
+
+        assertEquals(2, builder.size)
+        assertSame(argument.node, builder.node)
+    }
+
+    @Test
+    fun `addAll should reuse the argument's collision node when its element is already the receiver's instance`() {
+        val argument = persistentHashSetOf(a1, a2) as PersistentHashSet<IntWrapper>
+        val builder = (persistentHashSetOf(a1) as PersistentHashSet<IntWrapper>).builder() as PersistentHashSetBuilder<IntWrapper>
+
+        builder.addAll(argument)
+
+        assertEquals(2, builder.size)
+        assertSame(argument.node, builder.node)
+    }
+
+    @Test
+    fun `addAll should reuse the argument's collision node when the receiver's elements are already its instances`() {
+        val argument = persistentHashSetOf(a1, a2, a3) as PersistentHashSet<IntWrapper>
+        val builder = (persistentHashSetOf(a1, a2) as PersistentHashSet<IntWrapper>).builder() as PersistentHashSetBuilder<IntWrapper>
+
+        builder.addAll(argument)
+
+        assertEquals(3, builder.size)
+        assertSame(argument.node, builder.node)
+    }
+
+    @Test
+    fun `addAll should not write the receiver's element into the argument's set`() {
+        val storedElement = IntWrapper(1, 0)
+        val argumentElement = IntWrapper(1, 0)
+        val argument = persistentHashSetOf(argumentElement, IntWrapper(2, 32))
+        val builder = persistentHashSetOf(storedElement).builder()
+
+        builder.addAll(argument)
+
+        assertSame(storedElement, builder.single { it == storedElement })
+        assertSame(argumentElement, argument.single { it == argumentElement })
+    }
+
+    @Test
+    fun `addAll should invalidate a live iterator when the argument holds the element in a subtree`() {
+        val builder = persistentHashSetOf(a1).builder()
+
+        val iterator = builder.iterator()
+        builder.addAll(persistentHashSetOf(IntWrapper(1, 0), IntWrapper(2, 32)))
+
+        assertTrue(builder.contains(a1))
+        assertFailsWith<ConcurrentModificationException> { iterator.next() }
+    }
+
+    @Test
+    fun `addAll of the stored elements should not invalidate an iterator`() {
+        val builder = persistentHashSetOf(a1, a2, sibling).builder()
+
+        val iterator = builder.iterator()
+        val visited = mutableListOf(iterator.next())
+        builder.addAll(persistentHashSetOf(a1, a2, sibling))
+        while (iterator.hasNext()) {
+            visited.add(iterator.next())
+        }
+
+        assertEquals(listOf(a1, a2, sibling), visited.sorted())
+    }
+
+    @Test
+    fun `addAll that merges an element into the argument's subtree should count one size change`() {
+        val overlapping = persistentHashSetOf(IntWrapper(1, 0)).builder() as PersistentHashSetBuilder<IntWrapper>
+        val modCount = overlapping.modCount
+        overlapping.addAll(persistentHashSetOf(IntWrapper(1, 0), IntWrapper(2, 32)))
+        assertEquals(modCount + 1, overlapping.modCount)
+
+        val disjoint = persistentHashSetOf(IntWrapper(1, 0)).builder() as PersistentHashSetBuilder<IntWrapper>
+        val disjointModCount = disjoint.modCount
+        disjoint.addAll(persistentHashSetOf(IntWrapper(2, 32), IntWrapper(3, 64)))
+        assertEquals(disjointModCount + 1, disjoint.modCount)
+
+        val collision =
+            persistentHashSetOf(IntWrapper(1, 0), sibling).builder() as PersistentHashSetBuilder<IntWrapper>
+        val collisionModCount = collision.modCount
+        collision.addAll(persistentHashSetOf(IntWrapper(2, 0), IntWrapper(4, 0)))
+        assertEquals(4, collision.size)
+        assertEquals(collisionModCount + 1, collision.modCount)
+    }
+
+    @Test
+    fun `addAll of random colliding sets should keep the stored element instances`() {
+        val hashes = intArrayOf(0, 1, 32, 33, 1 shl 10, 1 shl 30, (1 shl 30) or 32)
+        val random = Random(316)
+        repeat(200) { iteration ->
+            val receiverElements = mutableMapOf<Int, IntWrapper>()
+            val builder = persistentHashSetOf<IntWrapper>().builder()
+            for (id in 0..<14) {
+                if (random.nextBoolean()) {
+                    val element = IntWrapper(id, hashes[id % hashes.size])
+                    receiverElements[id] = element
+                    builder.add(element)
+                }
+            }
+            val argumentElements = mutableMapOf<Int, IntWrapper>()
+            val argumentBuilder = persistentHashSetOf<IntWrapper>().builder()
+            for (id in 0..<14) {
+                if (random.nextBoolean()) {
+                    val element = IntWrapper(id, hashes[id % hashes.size])
+                    argumentElements[id] = element
+                    argumentBuilder.add(element)
+                }
+            }
+
+            builder.addAll(argumentBuilder.build())
+
+            val shape = "iteration $iteration, receiver ${receiverElements.keys}, argument ${argumentElements.keys}"
+            assertEquals((receiverElements.keys + argumentElements.keys).size, builder.size, shape)
+            for ((id, element) in receiverElements) {
+                assertSame(element, builder.singleOrNull { it == element }, "$shape, id $id")
+            }
+            for ((id, element) in argumentElements) {
+                if (id in receiverElements) continue
+                assertSame(element, builder.singleOrNull { it == element }, "$shape, id $id")
+            }
+        }
     }
 }

--- a/core/commonTest/src/contract/set/PersistentHashSetBuilderTest.kt
+++ b/core/commonTest/src/contract/set/PersistentHashSetBuilderTest.kt
@@ -7,6 +7,7 @@ package tests.contract.set
 
 import kotlinx.collections.immutable.implementations.immutableSet.PersistentHashSet
 import kotlinx.collections.immutable.implementations.immutableSet.PersistentHashSetBuilder
+import kotlinx.collections.immutable.implementations.immutableSet.TrieNode
 import kotlinx.collections.immutable.persistentHashSetOf
 import tests.IntWrapper
 import kotlin.random.Random
@@ -369,6 +370,121 @@ class PersistentHashSetBuilderTest {
             }
             for ((id, element) in argumentElements) {
                 if (id in receiverElements) continue
+                assertSame(element, builder.singleOrNull { it == element }, "$shape, id $id")
+            }
+        }
+    }
+
+    @Test
+    fun `retainAll should keep the stored element instance when the collision node is reached at the last level`() {
+        val storedElement = IntWrapper(1, 0)
+        val builder = persistentHashSetOf(storedElement, IntWrapper(2, 0), sibling).builder()
+
+        assertTrue(builder.retainAll(persistentHashSetOf(IntWrapper(1, 0), IntWrapper(3, 1 shl 30))))
+
+        assertEquals(2, builder.size)
+        assertSame(storedElement, builder.single { it == storedElement })
+        assertSame(sibling, builder.single { it == sibling })
+    }
+
+    @Test
+    fun `retainAll should drop the argument's element when the receiver's subtree does not hold it`() {
+        val storedElement = IntWrapper(5, 1)
+
+        val leafMiss = persistentHashSetOf(IntWrapper(1, 0), IntWrapper(2, 32), storedElement).builder()
+        assertTrue(leafMiss.retainAll(persistentHashSetOf(IntWrapper(6, 0), IntWrapper(5, 1))))
+        assertEquals(1, leafMiss.size)
+        assertSame(storedElement, leafMiss.single())
+
+        val absentCell = persistentHashSetOf(IntWrapper(1, 0), IntWrapper(2, 32), storedElement).builder()
+        assertTrue(absentCell.retainAll(persistentHashSetOf(IntWrapper(7, 64), IntWrapper(5, 1))))
+        assertEquals(1, absentCell.size)
+        assertSame(storedElement, absentCell.single())
+
+        val collisionMiss = persistentHashSetOf(a1, a2, sibling).builder()
+        assertTrue(collisionMiss.retainAll(persistentHashSetOf(a3, sibling)))
+        assertEquals(1, collisionMiss.size)
+        assertSame(sibling, collisionMiss.single())
+    }
+
+    @Test
+    fun `retainAll should keep every stored instance when compacting a collision node the builder owns`() {
+        val builder = persistentHashSetOf<IntWrapper>().builder()
+        builder.add(a1)
+        builder.add(a2)
+        builder.add(a3)
+
+        assertTrue(builder.retainAll(persistentHashSetOf(IntWrapper(1, 0), IntWrapper(2, 0))))
+
+        assertEquals(2, builder.size)
+        assertSame(a1, builder.single { it == a1 })
+        assertSame(a2, builder.single { it == a2 })
+    }
+
+    @Test
+    fun `retainAll should reuse the argument's node when it already holds the receiver's element instance`() {
+        val argument = persistentHashSetOf(a1) as PersistentHashSet<IntWrapper>
+        val builder = (persistentHashSetOf(a1, IntWrapper(2, 32)) as PersistentHashSet<IntWrapper>)
+                .builder() as PersistentHashSetBuilder<IntWrapper>
+
+        builder.retainAll(argument)
+
+        assertEquals(1, builder.size)
+        assertSame(argument.node, builder.node)
+    }
+
+    @Test
+    fun `retainAll should reuse the argument's collision node when its elements are the receiver's instances`() {
+        val argument = persistentHashSetOf(a1, a2) as PersistentHashSet<IntWrapper>
+        val builder = (persistentHashSetOf(a1, a2, a3) as PersistentHashSet<IntWrapper>)
+                .builder() as PersistentHashSetBuilder<IntWrapper>
+
+        builder.retainAll(argument)
+
+        assertEquals(2, builder.size)
+        assertSame(collisionNodeOf(argument.node), collisionNodeOf(builder.node))
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun collisionNodeOf(node: TrieNode<IntWrapper>): TrieNode<IntWrapper> {
+        var current = node
+        while (current.bitmap != 0) {
+            current = current.buffer[0] as TrieNode<IntWrapper>
+        }
+        return current
+    }
+
+    @Test
+    fun `retainAll of random colliding sets should keep the stored element instances`() {
+        val hashes = intArrayOf(0, 1, 32, 33, 1 shl 10, 1 shl 30, (1 shl 30) or 32)
+        val random = Random(322)
+        repeat(200) { iteration ->
+            val receiverElements = mutableMapOf<Int, IntWrapper>()
+            val builder = persistentHashSetOf<IntWrapper>().builder()
+            for (id in 0..<21) {
+                if (random.nextBoolean()) {
+                    val element = IntWrapper(id, hashes[id % hashes.size])
+                    receiverElements[id] = element
+                    builder.add(element)
+                }
+            }
+            val argumentElements = mutableMapOf<Int, IntWrapper>()
+            val argumentBuilder = persistentHashSetOf<IntWrapper>().builder()
+            for (id in 0..<21) {
+                if (random.nextBoolean()) {
+                    val element = IntWrapper(id, hashes[id % hashes.size])
+                    argumentElements[id] = element
+                    argumentBuilder.add(element)
+                }
+            }
+
+            builder.retainAll(argumentBuilder.build())
+
+            val shape = "iteration $iteration, receiver ${receiverElements.keys}, argument ${argumentElements.keys}"
+            val retainedIds = receiverElements.keys intersect argumentElements.keys
+            assertEquals(retainedIds.size, builder.size, shape)
+            for (id in retainedIds) {
+                val element = receiverElements.getValue(id)
                 assertSame(element, builder.singleOrNull { it == element }, "$shape, id $id")
             }
         }

--- a/core/commonTest/src/contract/set/PersistentHashSetTest.kt
+++ b/core/commonTest/src/contract/set/PersistentHashSetTest.kt
@@ -15,6 +15,7 @@ import tests.IntWrapper
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertSame
 import kotlin.test.assertTrue
 
 class PersistentHashSetTest {
@@ -194,5 +195,16 @@ class PersistentHashSetTest {
         assertTrue(persistentHashSetOf(a1, a2, sibling).containsAll(persistentHashSetOf(a1, a2)))
         assertFalse(persistentHashSetOf(a1, sibling).containsAll(persistentHashSetOf(a1, a2)))
         assertFalse(persistentHashSetOf(a1, a2, sibling).containsAll(persistentHashSetOf(a3, sibling)))
+    }
+
+    @Test
+    fun `addingAll should keep the stored element instance when the argument holds it in a subtree`() {
+        val storedElement = IntWrapper(1, 0)
+        val set = persistentHashSetOf(storedElement)
+
+        val updated = set.addingAll(persistentHashSetOf(IntWrapper(1, 0), IntWrapper(2, 32)))
+
+        assertEquals(2, updated.size)
+        assertSame(storedElement, updated.single { it == storedElement })
     }
 }

--- a/core/commonTest/src/contract/set/PersistentHashSetTest.kt
+++ b/core/commonTest/src/contract/set/PersistentHashSetTest.kt
@@ -207,4 +207,28 @@ class PersistentHashSetTest {
         assertEquals(2, updated.size)
         assertSame(storedElement, updated.single { it == storedElement })
     }
+
+    @Test
+    fun `retainingAll should keep the stored element instance when the receiver holds it in a subtree`() {
+        val storedElement = IntWrapper(1, 0)
+        val set = persistentHashSetOf(storedElement, IntWrapper(2, 32))
+
+        val updated = set.retainingAll(persistentHashSetOf(IntWrapper(1, 0)))
+
+        assertEquals(1, updated.size)
+        assertSame(storedElement, updated.single { it == storedElement })
+    }
+
+    @Test
+    fun `retainingAll should keep every stored instance when the argument's collision node is an equality-subset`() {
+        val storedElement1 = IntWrapper(1, 0)
+        val storedElement2 = IntWrapper(2, 0)
+        val set = persistentHashSetOf(storedElement1, storedElement2, IntWrapper(3, 0))
+
+        val updated = set.retainingAll(persistentHashSetOf(IntWrapper(1, 0), IntWrapper(2, 0)))
+
+        assertEquals(2, updated.size)
+        assertSame(storedElement1, updated.single { it == storedElement1 })
+        assertSame(storedElement2, updated.single { it == storedElement2 })
+    }
 }


### PR DESCRIPTION
The collision guard mirrors #321's. However, where the receiver holds a node and the argument holds the element, the fix is a lookup, not a lift-and-merge, since the intersection of a subtree with a single element is at most that element.

Fixes #322