### PR TITLE
remove on a hash set builder iterator throws an AssertionError after a remove of a different element

### DIFF
--- a/core/commonMain/src/implementations/immutableSet/PersistentHashSetMutableIterator.kt
+++ b/core/commonMain/src/implementations/immutableSet/PersistentHashSetMutableIterator.kt
@@ -23,6 +23,7 @@ internal class PersistentHashSetMutableIterator<E>(private val builder: Persiste
 
     override fun remove() {
         checkNextWasInvoked()
+        checkForComodification()
         if (hasNext()) {
             val currentElement = currentElement()
 

--- a/core/commonTest/src/contract/set/PersistentHashSetBuilderTest.kt
+++ b/core/commonTest/src/contract/set/PersistentHashSetBuilderTest.kt
@@ -489,4 +489,61 @@ class PersistentHashSetBuilderTest {
             }
         }
     }
+
+    @Test
+    fun `iterator remove after a remove of a different element throws ConcurrentModificationException`() {
+        val builder = persistentHashSetOf(1, 2).builder()
+        val orderedElements = builder.toList()
+        val iterator = builder.iterator()
+        assertEquals(orderedElements[0], iterator.next())
+
+        builder.remove(orderedElements[1])
+
+        assertFailsWith<ConcurrentModificationException> { iterator.remove() }
+        assertEquals(1, builder.size)
+        assertTrue(builder.contains(orderedElements[0]))
+        assertFailsWith<ConcurrentModificationException> { iterator.next() }
+    }
+
+    @Test
+    fun `iterator remove on the exhausted iterator of a single element set after an external add throws ConcurrentModificationException`() {
+        val builder = persistentHashSetOf(1).builder()
+        val iterator = builder.iterator()
+        assertEquals(1, iterator.next())
+        assertFalse(iterator.hasNext())
+
+        builder.add(2)
+
+        assertFailsWith<ConcurrentModificationException> { iterator.remove() }
+        assertEquals(2, builder.size)
+        assertTrue(builder.contains(1))
+        assertFailsWith<ConcurrentModificationException> { iterator.next() }
+    }
+
+    @Test
+    fun `iterator remove without a preceding next after an external remove throws IllegalStateException`() {
+        val builder = persistentHashSetOf(1, 2).builder()
+        val iterator = builder.iterator()
+
+        builder.remove(1)
+
+        assertFailsWith<IllegalStateException> { iterator.remove() }
+        assertEquals(1, builder.size)
+    }
+
+    @Test
+    fun `iterator remove after external changes that cancel out in size throws ConcurrentModificationException`() {
+        val builder = persistentHashSetOf(1, 2, 3, 4).builder()
+        val iterator = builder.iterator()
+        val _ = iterator.next()
+        iterator.remove()
+        val orderedElements = builder.toList()
+        assertEquals(orderedElements[0], iterator.next())
+
+        builder.remove(orderedElements[2])
+        builder.add(9)
+
+        assertEquals(3, builder.size)
+        assertFailsWith<ConcurrentModificationException> { iterator.remove() }
+    }
 }


### PR DESCRIPTION
`remove()` was the only mutator on the set iterator without the comodification check `next()` carries. `assert` is a no-op on JS and Wasm, so there the reported `AssertionError` does not appear at all - `remove()` empties the builder and the following `next()` returns `undefined`.

Fixes #325