### PR TITLE
set on a persistent list builder invalidates a live iterator depending on how the builder was created

### DIFF
--- a/core/commonMain/src/implementations/immutableList/PersistentVectorBuilder.kt
+++ b/core/commonMain/src/implementations/immutableList/PersistentVectorBuilder.kt
@@ -42,6 +42,10 @@ internal class PersistentVectorBuilder<E>(
 
     internal fun getModCount() = modCount
 
+    // Counts the sets that replaced a trie buffer with its copy; the iterators re-anchor their cached path on it.
+    internal var trieModCount = 0
+        private set
+
     override fun build(): PersistentList<E> {
         return builtVector ?: run {
             val root = root
@@ -972,12 +976,6 @@ internal class PersistentVectorBuilder<E>(
         checkElementIndex(index, size)
         if (rootSize() <= index) {
             val mutableTail = makeMutable(tail)
-
-            // Creating new tail implies structural change.
-            if (mutableTail !== tail) {
-                modCount++
-            }
-
             val tailIndex = index and MAX_BUFFER_SIZE_MINUS_ONE
             val oldElement = mutableTail[tailIndex]
             mutableTail[tailIndex] = element
@@ -997,12 +995,9 @@ internal class PersistentVectorBuilder<E>(
         val mutableRoot = makeMutable(root)
 
         if (shift == 0) {
-            // Creating new leaf implies structural change.
-            // Actually, while descending to this leaf several nodes could be recreated.
-            // However, this builder is exclusive owner of this leaf iff it is exclusive owner of all leaf's ancestors.
-            // Hence, checking recreation of this leaf is enough to determine if a structural change occurred.
+            // This builder owns the leaf iff it owns all the leaf's ancestors, so the leaf alone tells whether the path was copied.
             if (mutableRoot !== root) {
-                modCount++
+                trieModCount++
             }
 
             oldElementCarry.value = mutableRoot[bufferIndex]

--- a/core/commonMain/src/implementations/immutableList/PersistentVectorMutableIterator.kt
+++ b/core/commonMain/src/implementations/immutableList/PersistentVectorMutableIterator.kt
@@ -24,6 +24,12 @@ internal class PersistentVectorMutableIterator<T>(
     private var expectedModCount = builder.getModCount()
 
     /**
+     * The trieModCount the cached path of [trieIterator] was built at.
+     * Used to rebuild the path after a set copied a trie buffer.
+     */
+    private var pathModCount = builder.trieModCount
+
+    /**
      * Iterates over leaves of the builder.root trie.
      * This property is equal to null if builder.root is null.
      */
@@ -43,6 +49,7 @@ internal class PersistentVectorMutableIterator<T>(
     override fun previous(): T {
         checkForComodification()
         checkHasPrevious()
+        ensurePathIsLive()
 
         lastIteratedIndex = index - 1
 
@@ -59,6 +66,7 @@ internal class PersistentVectorMutableIterator<T>(
     override fun next(): T {
         checkForComodification()
         checkHasNext()
+        ensurePathIsLive()
 
         lastIteratedIndex = index
 
@@ -80,7 +88,12 @@ internal class PersistentVectorMutableIterator<T>(
         setupTrieIterator()
     }
 
+    private fun ensurePathIsLive() {
+        if (pathModCount != builder.trieModCount) setupTrieIterator()
+    }
+
     private fun setupTrieIterator() {
+        pathModCount = builder.trieModCount
         val root = builder.root
         if (root == null) {
             trieIterator = null
@@ -119,9 +132,6 @@ internal class PersistentVectorMutableIterator<T>(
         checkHasIterated()
 
         builder[lastIteratedIndex] = element
-
-        expectedModCount = builder.getModCount()
-        setupTrieIterator()
     }
 
     private fun checkForComodification() {

--- a/core/commonMain/src/implementations/immutableMap/PersistentHashMapBuilder.kt
+++ b/core/commonMain/src/implementations/immutableMap/PersistentHashMapBuilder.kt
@@ -27,7 +27,7 @@ internal class PersistentHashMapBuilder<K, V>(map: PersistentHashMap<K, V>) :
     internal var operationResult: V? = null
     internal var modCount = 0
 
-    // The ordered map builder's chain of links moves only together with the size.
+    // The ordered map builder's chain of links moves only together with the size, and so does the shape of the trie.
     internal var sizeModCount = 0
         private set
 

--- a/core/commonMain/src/implementations/immutableMap/PersistentHashMapBuilderContentIterators.kt
+++ b/core/commonMain/src/implementations/immutableMap/PersistentHashMapBuilderContentIterators.kt
@@ -53,6 +53,7 @@ internal open class PersistentHashMapBuilderBaseIterator<K, V, T>(
 
     override fun remove() {
         checkNextWasInvoked()
+        checkForComodification()
         if (hasNext()) {
             val currentKey = currentKey()
 

--- a/core/commonMain/src/implementations/immutableMap/PersistentHashMapBuilderContentIterators.kt
+++ b/core/commonMain/src/implementations/immutableMap/PersistentHashMapBuilderContentIterators.kt
@@ -73,6 +73,11 @@ internal open class PersistentHashMapBuilderBaseIterator<K, V, T>(
     fun setValue(key: K, newValue: V) {
         if (!builder.containsKey(key)) return
 
+        if (builder.modCount != expectedModCount) {
+            builder[key] = newValue
+            return
+        }
+
         if (hasNext()) {
             val currentKey = currentKey()
             builder[key] = newValue

--- a/core/commonMain/src/implementations/immutableMap/PersistentHashMapBuilderContentIterators.kt
+++ b/core/commonMain/src/implementations/immutableMap/PersistentHashMapBuilderContentIterators.kt
@@ -42,10 +42,12 @@ internal open class PersistentHashMapBuilderBaseIterator<K, V, T>(
 
     private var lastIteratedKey: K? = null
     private var nextWasInvoked = false
-    private var expectedModCount = builder.modCount
+    private var expectedSizeModCount = builder.sizeModCount
+    private var pathModCount = builder.modCount
 
     override fun next(): T {
         checkForComodification()
+        ensurePathIsLive()
         lastIteratedKey = currentKey()
         nextWasInvoked = true
         return super.next()
@@ -58,46 +60,40 @@ internal open class PersistentHashMapBuilderBaseIterator<K, V, T>(
             val currentKey = currentKey()
 
             builder.remove(lastIteratedKey)
-            resetPath(
-                currentKey.hashCode(), builder.node, currentKey,
-                0, lastIteratedKey.hashCode(), afterRemove = true
-            )
+            resetPath(currentKey.hashCode(), builder.node, currentKey, 0)
         } else {
             builder.remove(lastIteratedKey)
         }
 
         lastIteratedKey = null
         nextWasInvoked = false
-        expectedModCount = builder.modCount
+        expectedSizeModCount = builder.sizeModCount
+        pathModCount = builder.modCount
     }
 
     fun setValue(key: K, newValue: V) {
         if (!builder.containsKey(key)) return
 
-        if (builder.modCount != expectedModCount) {
+        if (builder.sizeModCount != expectedSizeModCount) {
             builder[key] = newValue
             return
         }
 
-        if (hasNext()) {
-            val currentKey = currentKey()
-            builder[key] = newValue
-            resetPath(currentKey.hashCode(), builder.node, currentKey, 0)
-        } else {
-            builder[key] = newValue
-        }
-
-        expectedModCount = builder.modCount
+        builder[key] = newValue
+        ensurePathIsLive()
     }
 
-    private fun resetPath(
-        keyHash: Int,
-        node: TrieNode<*, *>,
-        key: K,
-        pathIndex: Int,
-        removedKeyHash: Int = 0,
-        afterRemove: Boolean = false
-    ) {
+    private fun ensurePathIsLive() {
+        if (builder.modCount == pathModCount) return
+
+        if (hasNext()) {
+            val currentKey = currentKey()
+            resetPath(currentKey.hashCode(), builder.node, currentKey, 0)
+        }
+        pathModCount = builder.modCount
+    }
+
+    private fun resetPath(keyHash: Int, node: TrieNode<*, *>, key: K, pathIndex: Int) {
         val shift = pathIndex * LOG_MAX_BRANCHING_FACTOR
 
         if (shift > MAX_SHIFT) { // collision
@@ -113,23 +109,17 @@ internal open class PersistentHashMapBuilderBaseIterator<K, V, T>(
 
         if (node.hasEntryAt(keyPositionMask)) { // key is directly in buffer
             val keyIndex = node.entryKeyIndex(keyPositionMask)
+            assert { node.keyAtIndex(keyIndex) == key }
 
-            // After removing an element, we need to handle node promotion properly to maintain a correct iteration order.
-            // `removedKeyPositionMask` represents the bit position of the removed key's hash at the current level.
-            // This is needed to detect if the current key was potentially promoted from a deeper level.
-            val removedKeyPositionMask = if (afterRemove) 1 shl indexSegment(removedKeyHash, shift) else 0
-
-            // Check if the removed key is at the same position as the current key and was previously at a deeper level.
-            // This indicates a node promotion occurred during removal,
-            // and we need to handle it in a special way to prevent re-traversing already visited elements.
-            if (keyPositionMask == removedKeyPositionMask && pathIndex < pathLastIndex) {
-                // Instead of traversing the normal way, we create a special path entry at the previous depth
-                // that points directly to the promoted entry, maintaining the original iteration sequence.
-                path[pathLastIndex].reset(arrayOf(node.buffer[keyIndex], node.buffer[keyIndex + 1]), ENTRY_SIZE)
+            if (pathIndex < pathLastIndex) {
+                // The key was promoted out of a removed subnode into entries this level has already walked:
+                // return it once through a window onto its slot, then go on with the subnodes after the removed one.
+                val slot = node.nodeIndex(keyPositionMask)
+                path[pathIndex].reset(node.buffer, slot, slot)
+                path[pathIndex + 1].resetToEntry(node.buffer, keyIndex)
+                pathLastIndex = pathIndex + 1
                 return
             }
-
-            assert { node.keyAtIndex(keyIndex) == key }
 
             path[pathIndex].reset(node.buffer, ENTRY_SIZE * node.entryCount(), keyIndex)
             pathLastIndex = pathIndex
@@ -141,7 +131,7 @@ internal open class PersistentHashMapBuilderBaseIterator<K, V, T>(
         val nodeIndex = node.nodeIndex(keyPositionMask)
         val targetNode = node.nodeAtIndex(nodeIndex)
         path[pathIndex].reset(node.buffer, ENTRY_SIZE * node.entryCount(), nodeIndex)
-        resetPath(keyHash, targetNode, key, pathIndex + 1, removedKeyHash, afterRemove)
+        resetPath(keyHash, targetNode, key, pathIndex + 1)
     }
 
     private fun checkNextWasInvoked() {
@@ -150,7 +140,7 @@ internal open class PersistentHashMapBuilderBaseIterator<K, V, T>(
     }
 
     private fun checkForComodification() {
-        if (builder.modCount != expectedModCount)
+        if (builder.sizeModCount != expectedSizeModCount)
             throw ConcurrentModificationException()
     }
 }

--- a/core/commonMain/src/implementations/immutableMap/PersistentHashMapBuilderContentIterators.kt
+++ b/core/commonMain/src/implementations/immutableMap/PersistentHashMapBuilderContentIterators.kt
@@ -16,21 +16,46 @@ internal class TrieNodeMutableEntriesIterator<K, V>(
         assert { hasNextKey() }
         index += 2
         @Suppress("UNCHECKED_CAST")
-        return MutableMapEntry(parentIterator, buffer[index - 2] as K, buffer[index - 1] as V)
+        return MutableMapEntry(parentIterator, buffer[index - 2] as K, buffer, index - 2)
     }
 }
 
 private class MutableMapEntry<K, V>(
     private val parentIterator: PersistentHashMapBuilderEntriesIterator<K, V>,
-    key: K,
-    override var value: V
-) : MapEntry<K, V>(key, value), MutableMap.MutableEntry<K, V> {
+    override val key: K,
+    override var buffer: Array<Any?>,
+    override var index: Int
+) : AbstractMapEntry<K, V>(), TrieNodeSlot, MutableMap.MutableEntry<K, V> {
+    private var expectedModCount = parentIterator.builder.modCount
+    private var lastValue = slotValue()
+
+    override val value: V
+        get() {
+            ensureSlotIsLive()
+            return lastValue
+        }
 
     override fun setValue(newValue: V): V {
-        val result = value
-        value = newValue
-        parentIterator.setValue(key, newValue)
+        ensureSlotIsLive()
+        val result = lastValue
+        lastValue = newValue
+        if (index != -1) parentIterator.setValue(key, newValue)
         return result
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun slotValue() = buffer[index + 1] as V
+
+    private fun ensureSlotIsLive() {
+        val builder = parentIterator.builder
+        if (builder.modCount != expectedModCount) {
+            expectedModCount = builder.modCount
+            if (!builder.node.locate(key.hashCode(), key, 0, this)) {
+                buffer = TrieNode.EMPTY.buffer
+                index = -1
+            }
+        }
+        if (index != -1) lastValue = slotValue()
     }
 }
 
@@ -72,15 +97,9 @@ internal open class PersistentHashMapBuilderBaseIterator<K, V, T>(
     }
 
     fun setValue(key: K, newValue: V) {
-        if (!builder.containsKey(key)) return
-
-        if (builder.sizeModCount != expectedSizeModCount) {
-            builder[key] = newValue
-            return
-        }
-
+        assert { builder.containsKey(key) }
         builder[key] = newValue
-        ensurePathIsLive()
+        if (builder.sizeModCount == expectedSizeModCount) ensurePathIsLive()
     }
 
     private fun ensurePathIsLive() {
@@ -146,7 +165,7 @@ internal open class PersistentHashMapBuilderBaseIterator<K, V, T>(
 }
 
 internal class PersistentHashMapBuilderEntriesIterator<K, V>(
-    builder: PersistentHashMapBuilder<K, V>
+    internal val builder: PersistentHashMapBuilder<K, V>
 ) : MutableIterator<MutableMap.MutableEntry<K, V>> {
     private val base = PersistentHashMapBuilderBaseIterator<K, V, MutableMap.MutableEntry<K, V>>(
         builder, Array(TRIE_MAX_HEIGHT + 1) {

--- a/core/commonMain/src/implementations/immutableMap/PersistentHashMapContentIterators.kt
+++ b/core/commonMain/src/implementations/immutableMap/PersistentHashMapContentIterators.kt
@@ -99,13 +99,15 @@ internal class TrieNodeEntriesIterator<out K, out V> : TrieNodeBaseIterator<K, V
     }
 }
 
-internal open class MapEntry<out K, out V>(override val key: K, override val value: V) : Map.Entry<K, V> {
+internal abstract class AbstractMapEntry<out K, out V> : Map.Entry<K, V> {
     override fun hashCode(): Int = key.hashCode() xor value.hashCode()
     override fun equals(other: Any?): Boolean =
         (other as? Map.Entry<*, *>)?.let { it.key == key && it.value == value } ?: false
 
     override fun toString(): String = "$key=$value"
 }
+
+internal class MapEntry<out K, out V>(override val key: K, override val value: V) : AbstractMapEntry<K, V>()
 
 
 internal abstract class PersistentHashMapBaseIterator<K, V, T>(

--- a/core/commonMain/src/implementations/immutableMap/PersistentHashMapContentIterators.kt
+++ b/core/commonMain/src/implementations/immutableMap/PersistentHashMapContentIterators.kt
@@ -14,12 +14,22 @@ internal abstract class TrieNodeBaseIterator<out K, out V, out T> : Iterator<T> 
     protected var buffer = TrieNode.EMPTY.buffer
         private set
     private var dataSize = 0
+    private var end = 0
     protected var index = 0
 
-    fun reset(buffer: Array<Any?>, dataSize: Int, index: Int) {
+    private fun reset(buffer: Array<Any?>, dataSize: Int, index: Int, end: Int) {
         this.buffer = buffer
         this.dataSize = dataSize
         this.index = index
+        this.end = end
+    }
+
+    fun reset(buffer: Array<Any?>, dataSize: Int, index: Int) {
+        reset(buffer, dataSize, index, buffer.size)
+    }
+
+    fun resetToEntry(buffer: Array<Any?>, keyIndex: Int) {
+        reset(buffer, keyIndex + ENTRY_SIZE, keyIndex, keyIndex + ENTRY_SIZE)
     }
 
     fun reset(buffer: Array<Any?>, dataSize: Int) {
@@ -43,7 +53,7 @@ internal abstract class TrieNodeBaseIterator<out K, out V, out T> : Iterator<T> 
 
     fun hasNextNode(): Boolean {
         assert { index >= dataSize }
-        return index < buffer.size
+        return index < end
     }
 
     fun currentNode(): TrieNode<out K, out V> {

--- a/core/commonMain/src/implementations/immutableMap/TrieNode.kt
+++ b/core/commonMain/src/implementations/immutableMap/TrieNode.kt
@@ -74,6 +74,12 @@ private fun Array<Any?>.removeNodeAtIndex(nodeIndex: Int): Array<Any?> {
 }
 
 
+/** A key's node buffer and index in it, `-1` while the key is absent, live while the builder's `modCount` stands. */
+internal interface TrieNodeSlot {
+    var buffer: Array<Any?>
+    var index: Int
+}
+
 internal class TrieNode<K, V>(
     private var dataMap: Int,
     private var nodeMap: Int,
@@ -403,6 +409,14 @@ internal class TrieNode<K, V>(
         return if (keyIndex != -1) valueAtKeyIndex(keyIndex) else null
     }
 
+    private fun collisionLocate(key: K, slot: TrieNodeSlot): Boolean {
+        val keyIndex = collisionKeyIndex(key)
+        if (keyIndex == -1) return false
+        slot.buffer = buffer
+        slot.index = keyIndex
+        return true
+    }
+
     private fun collisionPut(key: K, value: V): ModificationResult<K, V>? {
         val keyIndex = collisionKeyIndex(key)
         if (keyIndex != -1) {
@@ -664,6 +678,30 @@ internal class TrieNode<K, V>(
 
         // key is absent
         return null
+    }
+
+    /** Points [slot] at the entry with [key]. Returns `false`, leaving [slot] as it was, when the key is absent. */
+    fun locate(keyHash: Int, key: K, shift: Int, slot: TrieNodeSlot): Boolean {
+        val keyPositionMask = 1 shl indexSegment(keyHash, shift)
+
+        if (hasEntryAt(keyPositionMask)) { // key is directly in buffer
+            val keyIndex = entryKeyIndex(keyPositionMask)
+            if (key == keyAtIndex(keyIndex)) {
+                slot.buffer = buffer
+                slot.index = keyIndex
+                return true
+            }
+            return false
+        }
+        if (hasNodeAt(keyPositionMask)) { // key is in node
+            val targetNode = nodeAtIndex(nodeIndex(keyPositionMask))
+            if (shift == MAX_SHIFT) {
+                return targetNode.collisionLocate(key, slot)
+            }
+            return targetNode.locate(keyHash, key, shift + LOG_MAX_BRANCHING_FACTOR, slot)
+        }
+
+        return false
     }
 
     fun mutablePutAll(

--- a/core/commonMain/src/implementations/immutableMap/TrieNode.kt
+++ b/core/commonMain/src/implementations/immutableMap/TrieNode.kt
@@ -490,6 +490,7 @@ internal class TrieNode<K, V>(
         var i = this.buffer.size
         var replaced = false
         var sharedKeys = true
+        var sameOrder = true
         for (j in otherNode.buffer.indices step ENTRY_SIZE) {
             val keyIndex = this.collisionKeyIndex(otherNode.buffer[j])
             if (keyIndex == -1) {
@@ -499,6 +500,7 @@ internal class TrieNode<K, V>(
             } else {
                 intersectionCounter.count++
                 if (tempBuffer[keyIndex] !== otherNode.buffer[j]) sharedKeys = false
+                if (keyIndex != j) sameOrder = false
                 if (tempBuffer[keyIndex + 1] !== otherNode.buffer[j + 1]) {
                     tempBuffer[keyIndex + 1] = otherNode.buffer[j + 1]
                     replaced = true
@@ -510,7 +512,7 @@ internal class TrieNode<K, V>(
 
         return when (val newSize = i) {
             this.buffer.size if !replaced -> this
-            otherNode.buffer.size if sharedKeys -> otherNode
+            otherNode.buffer.size if sharedKeys && (sameOrder || newSize != this.buffer.size) -> otherNode
             tempBuffer.size -> TrieNode(0, 0, tempBuffer, mutator.ownership)
             else -> TrieNode(0, 0, tempBuffer.copyOf(newSize), mutator.ownership)
         }

--- a/core/commonMain/src/implementations/immutableSet/PersistentHashSetMutableIterator.kt
+++ b/core/commonMain/src/implementations/immutableSet/PersistentHashSetMutableIterator.kt
@@ -23,6 +23,7 @@ internal class PersistentHashSetMutableIterator<E>(private val builder: Persiste
 
     override fun remove() {
         checkNextWasInvoked()
+        checkForComodification()
         if (hasNext()) {
             val currentElement = currentElement()
 

--- a/core/commonMain/src/implementations/immutableSet/TrieNode.kt
+++ b/core/commonMain/src/implementations/immutableSet/TrieNode.kt
@@ -265,17 +265,26 @@ internal class TrieNode<E>(
             return this
         }
         val tempBuffer = this.buffer.copyOf(newSize = this.buffer.size + otherNode.buffer.size)
-        val totalWritten = otherNode.buffer.filterTo(tempBuffer, newArrayOffset = this.buffer.size) {
+        var totalSize = this.buffer.size
+        var sharedElements = true
+        for (j in otherNode.buffer.indices) {
             @Suppress("UNCHECKED_CAST")
-            !this.collisionContainsElement(it as E)
+            val otherElement = otherNode.buffer[j] as E
+            val index = this.buffer.indexOf(otherElement)
+            if (index == -1) {
+                tempBuffer[totalSize] = otherElement
+                totalSize++
+            } else {
+                intersectionSizeRef.count++
+                if (tempBuffer[index] !== otherElement) sharedElements = false
+            }
         }
-        val totalSize = totalWritten + this.buffer.size
-        intersectionSizeRef += (tempBuffer.size - totalSize)
-        if (totalSize == this.buffer.size) return this
-        if (totalSize == otherNode.buffer.size) return otherNode
-
-        val newBuffer = if (totalSize == tempBuffer.size) tempBuffer else tempBuffer.copyOf(newSize = totalSize)
-        return setProperties(newBitmap = 0, newBuffer, owner)
+        return when (totalSize) {
+            this.buffer.size -> this
+            otherNode.buffer.size if sharedElements -> otherNode
+            tempBuffer.size -> setProperties(newBitmap = 0, newBuffer = tempBuffer, owner)
+            else -> setProperties(newBitmap = 0, newBuffer = tempBuffer.copyOf(newSize = totalSize), owner)
+        }
     }
 
     private fun mutableCollisionRetainAll(
@@ -438,17 +447,17 @@ internal class TrieNode<E>(
                         otherIsNode -> @Suppress("UNCHECKED_CAST") {
                             otherNodeCell as TrieNode<E>
                             thisCell as E
-                            val oldSize = mutator.size
-                            if (shift == MAX_SHIFT) {
-                                otherNodeCell.mutableCollisionAdd(thisCell, mutator)
+                            val liftedNode = if (shift == MAX_SHIFT) {
+                                TrieNode<E>(0, arrayOf(thisCell), null)
                             } else {
-                                otherNodeCell.mutableAdd(
-                                    thisCell.hashCode(), thisCell,
-                                    shift + LOG_MAX_BRANCHING_FACTOR, mutator
-                                )
-                            }.also {
-                                if (mutator.size == oldSize) intersectionSizeRef.count++
+                                val elementPositionMask =
+                                    1 shl indexSegment(thisCell.hashCode(), shift + LOG_MAX_BRANCHING_FACTOR)
+                                TrieNode(elementPositionMask, arrayOf(thisCell), null)
                             }
+                            liftedNode.mutableAddAll(
+                                otherNodeCell, shift + LOG_MAX_BRANCHING_FACTOR,
+                                intersectionSizeRef, mutator
+                            )
                         }
                         // both are just E => compare them
                         thisCell == otherNodeCell -> thisCell.also { intersectionSizeRef.count++ }

--- a/core/commonMain/src/implementations/immutableSet/TrieNode.kt
+++ b/core/commonMain/src/implementations/immutableSet/TrieNode.kt
@@ -225,6 +225,12 @@ internal class TrieNode<E>(
         return buffer.contains(element)
     }
 
+    private fun collisionElementOrEmpty(element: E): Any? {
+        val index = buffer.indexOf(element)
+        if (index == -1) return EMPTY
+        return buffer[index]
+    }
+
     private fun collisionAdd(element: E): TrieNode<E> {
         if (collisionContainsElement(element)) return this
         val newBuffer = buffer.addElementAtIndex(0, element)
@@ -299,16 +305,24 @@ internal class TrieNode<E>(
         val tempBuffer =
             if (owner === ownedBy) buffer
             else arrayOfNulls<Any?>(minOf(buffer.size, otherNode.buffer.size))
-        val totalWritten = buffer.filterTo(tempBuffer) {
-            @Suppress("UNCHECKED_CAST")
-            otherNode.collisionContainsElement(it as E)
+        var totalWritten = 0
+        var sharedElements = true
+        for (i in buffer.indices) {
+            assert { totalWritten <= i }
+            val element = buffer[i]
+            val otherIndex = otherNode.buffer.indexOf(element)
+            if (otherIndex != -1) {
+                tempBuffer[totalWritten] = element
+                totalWritten++
+                if (otherNode.buffer[otherIndex] !== element) sharedElements = false
+            }
         }
         intersectionSizeRef += totalWritten
         return when (totalWritten) {
             0 -> EMPTY
             1 -> tempBuffer[0]
             this.buffer.size -> this
-            otherNode.buffer.size -> otherNode
+            otherNode.buffer.size if sharedElements -> otherNode
             tempBuffer.size -> setProperties(newBitmap = 0, newBuffer = tempBuffer, owner)
             else -> setProperties(newBitmap = 0, newBuffer = tempBuffer.copyOf(newSize = totalWritten), owner)
         }
@@ -360,22 +374,27 @@ internal class TrieNode<E>(
     }
 
     fun contains(elementHash: Int, element: E, shift: Int): Boolean {
+        return elementOrEmpty(elementHash, element, shift) !== EMPTY
+    }
+
+    private fun elementOrEmpty(elementHash: Int, element: E, shift: Int): Any? {
         val cellPositionMask = 1 shl indexSegment(elementHash, shift)
 
         if (hasNoCellAt(cellPositionMask)) { // element is absent
-            return false
+            return EMPTY
         }
 
         val cellIndex = indexOfCellAt(cellPositionMask)
         if (buffer[cellIndex] is TrieNode<*>) { // element may be in node
             val targetNode = nodeAtIndex(cellIndex)
             if (shift == MAX_SHIFT) {
-                return targetNode.collisionContainsElement(element)
+                return targetNode.collisionElementOrEmpty(element)
             }
-            return targetNode.contains(elementHash, element, shift + LOG_MAX_BRANCHING_FACTOR)
+            return targetNode.elementOrEmpty(elementHash, element, shift + LOG_MAX_BRANCHING_FACTOR)
         }
         // element is directly in buffer
-        return element == buffer[cellIndex]
+        val cell = buffer[cellIndex]
+        return if (element == cell) cell else EMPTY
     }
 
     fun mutableAddAll(
@@ -528,18 +547,16 @@ internal class TrieNode<E>(
                     thisIsNode -> @Suppress("UNCHECKED_CAST") {
                         thisCell as TrieNode<E>
                         otherNodeCell as E
-                        val hasElement = if (shift == MAX_SHIFT) {
-                            thisCell.collisionContainsElement(otherNodeCell)
+                        val storedElement = if (shift == MAX_SHIFT) {
+                            thisCell.collisionElementOrEmpty(otherNodeCell)
                         } else {
-                            thisCell.contains(
+                            thisCell.elementOrEmpty(
                                 otherNodeCell.hashCode(), otherNodeCell,
                                 shift + LOG_MAX_BRANCHING_FACTOR
                             )
                         }
-                        if (hasElement) {
-                            intersectionSizeRef += 1
-                            otherNodeCell
-                        } else EMPTY
+                        if (storedElement !== EMPTY) intersectionSizeRef += 1
+                        storedElement
                     }
                     // same as last case, but reversed
                     otherIsNode -> @Suppress("UNCHECKED_CAST") {

--- a/core/commonMain/src/implementations/persistentOrderedMap/PersistentOrderedMapBuilderContentIterators.kt
+++ b/core/commonMain/src/implementations/persistentOrderedMap/PersistentOrderedMapBuilderContentIterators.kt
@@ -39,6 +39,7 @@ internal open class PersistentOrderedMapBuilderLinksIterator<K, V>(
 
     override fun remove() {
         checkNextWasInvoked()
+        checkForComodification()
         builder.remove(lastIteratedKey)
         lastIteratedKey = null
         nextWasInvoked = false

--- a/core/commonMain/src/implementations/persistentOrderedMap/PersistentOrderedMapBuilderContentIterators.kt
+++ b/core/commonMain/src/implementations/persistentOrderedMap/PersistentOrderedMapBuilderContentIterators.kt
@@ -16,10 +16,9 @@ internal open class PersistentOrderedMapBuilderLinksIterator<K, V>(
     internal var lastIteratedKey: Any? = EndOfChain
     private var nextWasInvoked = false
     private var expectedModCount = builder.hashMapBuilder.sizeModCount
-    internal var index = 0
 
     override fun hasNext(): Boolean {
-        return index < builder.size
+        return nextKey !== EndOfChain
     }
 
     @IgnorableReturnValue
@@ -28,7 +27,6 @@ internal open class PersistentOrderedMapBuilderLinksIterator<K, V>(
         checkHasNext()
         lastIteratedKey = nextKey
         nextWasInvoked = true
-        index++
         @Suppress("UNCHECKED_CAST")
         val result = builder.hashMapBuilder.getOrElse(nextKey as K) {
             throw ConcurrentModificationException("Hash code of a key ($nextKey) has changed after it was added to the persistent map.")
@@ -44,7 +42,6 @@ internal open class PersistentOrderedMapBuilderLinksIterator<K, V>(
         lastIteratedKey = null
         nextWasInvoked = false
         expectedModCount = builder.hashMapBuilder.sizeModCount
-        index--
     }
 
     private fun checkHasNext() {

--- a/core/commonMain/src/implementations/persistentOrderedMap/PersistentOrderedMapBuilderContentIterators.kt
+++ b/core/commonMain/src/implementations/persistentOrderedMap/PersistentOrderedMapBuilderContentIterators.kt
@@ -5,17 +5,21 @@
 
 package kotlinx.collections.immutable.implementations.persistentOrderedMap
 
-import kotlinx.collections.immutable.implementations.immutableMap.MapEntry
+import kotlinx.collections.immutable.implementations.immutableMap.AbstractMapEntry
+import kotlinx.collections.immutable.implementations.immutableMap.TrieNode
+import kotlinx.collections.immutable.implementations.immutableMap.TrieNodeSlot
 import kotlinx.collections.immutable.internal.EndOfChain
 
 internal open class PersistentOrderedMapBuilderLinksIterator<K, V>(
     private var nextKey: Any?,
     internal val builder: PersistentOrderedMapBuilder<K, V>
-) : MutableIterator<LinkedValue<V>> {
+) : MutableIterator<LinkedValue<V>>, TrieNodeSlot {
 
     internal var lastIteratedKey: Any? = EndOfChain
     private var nextWasInvoked = false
-    private var expectedModCount = builder.hashMapBuilder.sizeModCount
+    private var expectedSizeModCount = builder.hashMapBuilder.sizeModCount
+    override var buffer: Array<Any?> = TrieNode.EMPTY.buffer
+    override var index = -1
 
     override fun hasNext(): Boolean {
         return nextKey !== EndOfChain
@@ -28,9 +32,12 @@ internal open class PersistentOrderedMapBuilderLinksIterator<K, V>(
         lastIteratedKey = nextKey
         nextWasInvoked = true
         @Suppress("UNCHECKED_CAST")
-        val result = builder.hashMapBuilder.getOrElse(nextKey as K) {
+        val key = nextKey as K
+        if (!builder.hashMapBuilder.node.locate(key.hashCode(), key, 0, this)) {
             throw ConcurrentModificationException("Hash code of a key ($nextKey) has changed after it was added to the persistent map.")
         }
+        @Suppress("UNCHECKED_CAST")
+        val result = buffer[index + 1] as LinkedValue<V>
         nextKey = result.next
         return result
     }
@@ -41,7 +48,7 @@ internal open class PersistentOrderedMapBuilderLinksIterator<K, V>(
         builder.remove(lastIteratedKey)
         lastIteratedKey = null
         nextWasInvoked = false
-        expectedModCount = builder.hashMapBuilder.sizeModCount
+        expectedSizeModCount = builder.hashMapBuilder.sizeModCount
     }
 
     private fun checkHasNext() {
@@ -55,7 +62,7 @@ internal open class PersistentOrderedMapBuilderLinksIterator<K, V>(
     }
 
     private fun checkForComodification() {
-        if (builder.hashMapBuilder.sizeModCount != expectedModCount)
+        if (builder.hashMapBuilder.sizeModCount != expectedSizeModCount)
             throw ConcurrentModificationException()
     }
 }
@@ -69,9 +76,9 @@ internal class PersistentOrderedMapBuilderEntriesIterator<K, V>(map: PersistentO
     }
 
     override fun next(): MutableMap.MutableEntry<K, V> {
-        val links = internal.next()
+        internal.next()
         @Suppress("UNCHECKED_CAST")
-        return MutableMapEntry(internal.builder, internal.lastIteratedKey as K, links)
+        return MutableMapEntry(internal.builder, internal.lastIteratedKey as K, internal.buffer, internal.index)
     }
 
     override fun remove() {
@@ -81,23 +88,43 @@ internal class PersistentOrderedMapBuilderEntriesIterator<K, V>(map: PersistentO
 
 private class MutableMapEntry<K, V>(
     private val builder: PersistentOrderedMapBuilder<K, V>,
-    key: K,
-    private var links: LinkedValue<V>
-) : MapEntry<K, V>(key, links.value), MutableMap.MutableEntry<K, V> {
-    private val expectedModCount = builder.hashMapBuilder.sizeModCount
+    override val key: K,
+    override var buffer: Array<Any?>,
+    override var index: Int
+) : AbstractMapEntry<K, V>(), TrieNodeSlot, MutableMap.MutableEntry<K, V> {
+    private var expectedModCount = builder.hashMapBuilder.modCount
+    private var lastValue = links().value
 
     override val value: V
-        get() = links.value
+        get() {
+            ensureSlotIsLive()
+            return lastValue
+        }
 
     override fun setValue(newValue: V): V {
-        val result = links.value
-        links = links.withValue(newValue)
-        if (builder.hashMapBuilder.sizeModCount == expectedModCount) {
-            builder.setLinkedValue(key, links)
-        } else if (builder.containsKey(key)) {
-            builder[key] = newValue
+        ensureSlotIsLive()
+        val result = lastValue
+        lastValue = newValue
+        if (index != -1) {
+            val links = links()
+            if (links.value !== newValue) builder.setLinkedValue(key, links.withValue(newValue))
         }
         return result
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun links() = buffer[index + 1] as LinkedValue<V>
+
+    private fun ensureSlotIsLive() {
+        val hashMapBuilder = builder.hashMapBuilder
+        if (hashMapBuilder.modCount != expectedModCount) {
+            expectedModCount = hashMapBuilder.modCount
+            if (!hashMapBuilder.node.locate(key.hashCode(), key, 0, this)) {
+                buffer = TrieNode.EMPTY.buffer
+                index = -1
+            }
+        }
+        if (index != -1) lastValue = links().value
     }
 }
 

--- a/core/commonMain/src/implementations/persistentOrderedMap/PersistentOrderedMapContentIterators.kt
+++ b/core/commonMain/src/implementations/persistentOrderedMap/PersistentOrderedMapContentIterators.kt
@@ -6,15 +6,14 @@
 package kotlinx.collections.immutable.implementations.persistentOrderedMap
 
 import kotlinx.collections.immutable.implementations.immutableMap.MapEntry
+import kotlinx.collections.immutable.internal.EndOfChain
 
 internal open class PersistentOrderedMapLinksIterator<K, V>(
     internal var nextKey: Any?,
     private val hashMap: Map<K, LinkedValue<V>>
 ) : Iterator<LinkedValue<V>> {
-    internal var index = 0
-
     override fun hasNext(): Boolean {
-        return index < hashMap.size
+        return nextKey !== EndOfChain
     }
 
     @IgnorableReturnValue
@@ -26,7 +25,6 @@ internal open class PersistentOrderedMapLinksIterator<K, V>(
         val result = hashMap.getOrElse(nextKey as K) {
             throw ConcurrentModificationException("Hash code of a key ($nextKey) has changed after it was added to the persistent map.")
         }
-        index++
         nextKey = result.next
         return result
     }

--- a/core/commonMain/src/implementations/persistentOrderedSet/PersistentOrderedSetIterator.kt
+++ b/core/commonMain/src/implementations/persistentOrderedSet/PersistentOrderedSetIterator.kt
@@ -5,14 +5,14 @@
 
 package kotlinx.collections.immutable.implementations.persistentOrderedSet
 
+import kotlinx.collections.immutable.internal.EndOfChain
+
 internal open class PersistentOrderedSetIterator<E>(
     private var nextElement: Any?,
     internal val map: Map<E, Links>
 ) : Iterator<E> {
-    internal var index = 0
-
     override fun hasNext(): Boolean {
-        return index < map.size
+        return nextElement !== EndOfChain
     }
 
     override fun next(): E {
@@ -20,7 +20,6 @@ internal open class PersistentOrderedSetIterator<E>(
 
         @Suppress("UNCHECKED_CAST")
         val result = nextElement as E
-        index++
         nextElement = map.getOrElse(result) {
             throw ConcurrentModificationException("Hash code of an element ($result) has changed after it was added to the persistent set.")
         }.next

--- a/core/commonMain/src/implementations/persistentOrderedSet/PersistentOrderedSetMutableIterator.kt
+++ b/core/commonMain/src/implementations/persistentOrderedSet/PersistentOrderedSetMutableIterator.kt
@@ -22,6 +22,7 @@ internal class PersistentOrderedSetMutableIterator<E>(private val builder: Persi
 
     override fun remove() {
         checkNextWasInvoked()
+        checkForComodification()
         builder.remove(lastIteratedElement)
         lastIteratedElement = null
         nextWasInvoked = false

--- a/core/commonMain/src/implementations/persistentOrderedSet/PersistentOrderedSetMutableIterator.kt
+++ b/core/commonMain/src/implementations/persistentOrderedSet/PersistentOrderedSetMutableIterator.kt
@@ -27,7 +27,6 @@ internal class PersistentOrderedSetMutableIterator<E>(private val builder: Persi
         lastIteratedElement = null
         nextWasInvoked = false
         expectedModCount = builder.hashMapBuilder.modCount
-        index--
     }
 
     private fun checkNextWasInvoked() {

--- a/core/commonTest/src/contract/list/ImmutableListTest.kt
+++ b/core/commonTest/src/contract/list/ImmutableListTest.kt
@@ -163,17 +163,9 @@ class ImmutableListTest {
         val list = "abcxaxyz12".toImmutableList().toPersistentList()
         val builder = list.builder()
 
-        // builder needs to recreate the inner trie to apply the modification.
-        // So, structural changes in builder causes CME on subList iteration.
-        var subList = builder.subList(2, 5)
+        // the first `set` copies the tail the builder does not own, the second one writes in place; neither is a structural change
+        val subList = builder.subList(2, 5)
         builder[4] = 'x'
-        testOn(TestPlatform.JVM) {
-            assertFailsWith<ConcurrentModificationException> { subList.joinToString("") }
-        }
-
-        // builder is the exclusive owner of the inner trie.
-        // So, `set(index, value)` doesn't lead to structural changes.
-        subList = builder.subList(2, 5)
         assertEquals("cxx", subList.joinToString(""))
         builder[4] = 'b'
         assertEquals("cxb", subList.joinToString(""))

--- a/core/commonTest/src/contract/list/PersistentListBuilderTest.kt
+++ b/core/commonTest/src/contract/list/PersistentListBuilderTest.kt
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2016-2026 JetBrains s.r.o.
+ * Use of this source code is governed by the Apache 2.0 License that can be found in the LICENSE.txt file.
+ */
+
+package tests.contract.list
+
+import kotlinx.collections.immutable.PersistentList
+import kotlinx.collections.immutable.implementations.immutableList.PersistentVectorBuilder
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.toPersistentList
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertSame
+
+class PersistentListBuilderTest {
+
+    // 3: tail only, 40: the root is the single leaf, 100: a root over leaves, 1100: a root over level-1 nodes over leaves
+    private fun builders(size: Int): List<Pair<String, PersistentList.Builder<Int>>> {
+        val fromList = List(size) { it }.toPersistentList().builder()
+        val fromAdds = persistentListOf<Int>().builder().apply { addAll(List(size) { it }) }
+        return listOf("from a list" to fromList, "from adds" to fromAdds)
+    }
+
+    @Test
+    fun `next after a set of the upcoming index returns the new element at every depth whether the builder came from a list or from adds`() {
+        for (size in listOf(3, 40, 100, 1100)) {
+            for ((flavour, builder) in builders(size)) {
+                val iterator = builder.iterator()
+                assertEquals(0, iterator.next(), "$flavour at size $size")
+
+                builder[1] = -1
+                assertEquals(-1, iterator.next(), "$flavour at size $size")
+
+                val _ = builder.build()
+                builder[2] = -2
+                assertEquals(-2, iterator.next(), "$flavour at size $size after build")
+            }
+        }
+    }
+
+    @Test
+    fun `next after a set that copies a leaf under an owned root returns the new element`() {
+        val builder = List(100) { it }.toPersistentList().builder() as PersistentVectorBuilder<Int>
+        builder[40] = 40 // copies the root and the leaf of indices 32 to 63, the leaf of indices 0 to 31 stays unowned
+        val root = builder.root
+        val iterator = builder.iterator()
+
+        builder[0] = -1
+
+        assertSame(root, builder.root)
+        assertEquals(-1, iterator.next())
+    }
+
+    @Test
+    fun `previous after a set of the first element returns the new element from a cursor at the end at every depth`() {
+        for (size in listOf(40, 100, 1100)) {
+            for ((flavour, builder) in builders(size)) {
+                val iterator = builder.listIterator(size)
+
+                builder[0] = -1
+
+                assertEquals((size - 1 downTo 1) + listOf(-1), List(size) { iterator.previous() }, "$flavour at size $size")
+            }
+        }
+    }
+
+    @Test
+    fun `previous after the iterator set of the visited index returns the new element`() {
+        for ((flavour, builder) in builders(40)) {
+            val iterator = builder.listIterator()
+            repeat(5) { val _ = iterator.next() }
+            assertEquals(5, iterator.next(), flavour)
+
+            iterator.set(-1)
+
+            assertEquals(-1, iterator.previous(), flavour)
+        }
+    }
+
+    @Test
+    fun `next and previous of two iterators in one leaf return the elements set through the other`() {
+        for ((flavour, builder) in builders(100)) {
+            val first = builder.listIterator(40)
+            val second = builder.listIterator(41)
+            assertEquals(40, first.next(), flavour)
+            assertEquals(41, second.next(), flavour)
+
+            first.set(-1) // copies the leaf of indices 32 to 63 when the builder came from a list
+            second.set(-2)
+
+            assertEquals(-2, first.next(), flavour)
+            assertEquals(listOf(-2, -1), List(2) { second.previous() }, flavour)
+        }
+    }
+
+    @Test
+    fun `reverse of the builder reverses all the elements whether the builder came from a list or from adds`() {
+        for ((flavour, builder) in builders(40)) {
+            builder.reverse()
+
+            assertEquals((39 downTo 0).toList(), builder.toList(), flavour)
+        }
+    }
+
+    @Test
+    fun `an add and a removeAt that cancel out in size still invalidate a live iterator`() {
+        for ((flavour, builder) in builders(3)) {
+            val iterator = builder.iterator()
+            val _ = iterator.next()
+
+            builder.add(-3)
+            val _ = builder.removeAt(3)
+
+            assertFailsWith<ConcurrentModificationException>(flavour) { iterator.next() }
+        }
+    }
+}

--- a/core/commonTest/src/contract/map/PersistentHashMapBuilderTest.kt
+++ b/core/commonTest/src/contract/map/PersistentHashMapBuilderTest.kt
@@ -593,4 +593,188 @@ class PersistentHashMapBuilderTest {
         assertFalse(iterator.hasNext())
         assertFalse(builder.build().containsKey(entry.key))
     }
+
+    @Test
+    fun `entry setValue after a remove of a different key writes the value and the following next throws`() {
+        val builder = persistentHashMapOf(1 to "a", 2 to "b").builder()
+        val iterator = builder.entries.iterator()
+        val entry = iterator.next()
+        val oldValue = entry.value
+        val otherKey = if (entry.key == 1) 2 else 1
+
+        builder.remove(otherKey)
+
+        assertEquals(oldValue, entry.setValue("z"))
+        assertEquals("z", builder[entry.key])
+        assertEquals(1, builder.size)
+        assertFailsWith<ConcurrentModificationException> { iterator.next() }
+    }
+
+    @Test
+    fun `entry setValue after a remove of a key other than the upcoming one writes the value and the following next throws`() {
+        val builder = persistentHashMapOf(1 to "a", 2 to "b", 3 to "c").builder()
+        val orderedKeys = builder.keys.toList()
+        val iterator = builder.entries.iterator()
+        val entry = iterator.next()
+        val oldValue = entry.value
+
+        assertEquals(orderedKeys[0], entry.key)
+        builder.remove(orderedKeys[2])
+
+        assertEquals(oldValue, entry.setValue("z"))
+        assertEquals("z", builder[entry.key])
+        assertEquals(2, builder.size)
+        assertFailsWith<ConcurrentModificationException> { iterator.next() }
+    }
+
+    @Test
+    fun `entry setValue after an external remove of its own key writes nothing and the following next throws`() {
+        val builder = persistentHashMapOf(1 to "a", 2 to "b").builder()
+        val iterator = builder.entries.iterator()
+        val entry = iterator.next()
+        val oldValue = entry.value
+
+        builder.remove(entry.key)
+
+        assertEquals(oldValue, entry.setValue("z"))
+        assertFalse(builder.containsKey(entry.key))
+        assertEquals(1, builder.size)
+        assertFailsWith<ConcurrentModificationException> { iterator.next() }
+    }
+
+    @Test
+    fun `entry setValue after an external put of a new key writes the value and the following next throws`() {
+        val builder = persistentHashMapOf(1 to "a", 2 to "b").builder()
+        val iterator = builder.entries.iterator()
+        val entry = iterator.next()
+        val oldValue = entry.value
+
+        builder[3] = "c"
+
+        assertEquals(oldValue, entry.setValue("z"))
+        assertEquals("z", builder[entry.key])
+        assertEquals(3, builder.size)
+        assertFailsWith<ConcurrentModificationException> { iterator.next() }
+    }
+
+    @Test
+    fun `entry setValue after an external value overwrite of a different key writes the value and the following next throws`() {
+        val builder = persistentHashMapOf(1 to "a", 2 to "b", 3 to "c").builder()
+        val iterator = builder.entries.iterator()
+        val entry = iterator.next()
+        val oldValue = entry.value
+        val otherKey = (setOf(1, 2, 3) - entry.key).first()
+
+        builder[otherKey] = "overwritten"
+
+        assertEquals(oldValue, entry.setValue("z"))
+        assertEquals("z", builder[entry.key])
+        assertEquals("overwritten", builder[otherKey])
+        assertEquals(3, builder.size)
+        assertFailsWith<ConcurrentModificationException> { iterator.next() }
+    }
+
+    @Test
+    fun `entry setValue on the exhausted iterator of a single entry map after an external put writes the value and the following next throws`() {
+        val builder = persistentHashMapOf(1 to "a").builder()
+        val iterator = builder.entries.iterator()
+        val entry = iterator.next()
+
+        assertFalse(iterator.hasNext())
+        builder[2] = "b"
+
+        assertEquals("a", entry.setValue("z"))
+        assertEquals("z", builder[1])
+        assertEquals(2, builder.size)
+        assertFailsWith<ConcurrentModificationException> { iterator.next() }
+    }
+
+    @Test
+    fun `entry setValue after a remove of a colliding key writes the value and the following next throws`() {
+        val builder = persistentHashMapOf(
+            IntWrapper(1, 0) to "a",
+            IntWrapper(2, 0) to "b",
+            IntWrapper(3, 0) to "c"
+        ).builder()
+        val orderedKeys = builder.keys.toList()
+        val iterator = builder.entries.iterator()
+        val entry = iterator.next()
+        val oldValue = entry.value
+
+        builder.remove(orderedKeys[1])
+
+        assertEquals(oldValue, entry.setValue("z"))
+        assertEquals("z", builder[entry.key])
+        assertEquals(2, builder.size)
+        assertFailsWith<ConcurrentModificationException> { iterator.next() }
+    }
+
+    @Test
+    fun `entry setValue after a remove that shrinks the collision node writes the value and the following next throws`() {
+        val builder = persistentHashMapOf(
+            IntWrapper(1, 0) to "a",
+            IntWrapper(2, 0) to "b",
+            IntWrapper(3, 1) to "c"
+        ).builder()
+        val orderedKeys = builder.keys.toList()
+        val iterator = builder.entries.iterator()
+        val _ = iterator.next()
+        val entry = iterator.next()
+        val oldValue = entry.value
+
+        assertEquals(IntWrapper(3, 1), orderedKeys[0])
+        builder.remove(orderedKeys[2])
+
+        assertEquals(oldValue, entry.setValue("z"))
+        assertEquals("z", builder[entry.key])
+        assertEquals(2, builder.size)
+        assertFailsWith<ConcurrentModificationException> { iterator.next() }
+    }
+
+    @Test
+    fun `setting values through the iterator updates every entry and preserves the iteration order`() {
+        val builder = persistentHashMapOf(
+            IntWrapper(1, 0) to "a",
+            IntWrapper(2, 0) to "b",
+            IntWrapper(3, 1) to "c",
+            IntWrapper(4, 32) to "d"
+        ).builder()
+        val orderedKeys = builder.keys.toList()
+        val visited = mutableListOf<IntWrapper>()
+        val iterator = builder.entries.iterator()
+
+        while (iterator.hasNext()) {
+            val entry = iterator.next()
+            visited.add(entry.key)
+            val _ = entry.setValue(entry.value + "!")
+        }
+
+        assertEquals(orderedKeys, visited)
+        assertEquals(4, builder.size)
+        assertEquals("a!", builder[IntWrapper(1, 0)])
+        assertEquals("b!", builder[IntWrapper(2, 0)])
+        assertEquals("c!", builder[IntWrapper(3, 1)])
+        assertEquals("d!", builder[IntWrapper(4, 32)])
+    }
+
+    @Test
+    fun `setting the value of an earlier entry after a later one keeps the iterator valid`() {
+        val builder = persistentHashMapOf(1 to "a", 2 to "b", 3 to "c").builder()
+        val orderedKeys = builder.keys.toList()
+        val iterator = builder.entries.iterator()
+        val first = iterator.next()
+        val second = iterator.next()
+        val firstValue = first.value
+        val secondValue = second.value
+
+        assertEquals(secondValue, second.setValue("y"))
+        assertEquals(firstValue, first.setValue("x"))
+        assertEquals("x", first.setValue("xx"))
+
+        assertEquals("xx", builder[orderedKeys[0]])
+        assertEquals("y", builder[orderedKeys[1]])
+        assertEquals(3, builder.size)
+        assertEquals(orderedKeys[2], iterator.next().key)
+        assertFalse(iterator.hasNext())
+    }
 }

--- a/core/commonTest/src/contract/map/PersistentHashMapBuilderTest.kt
+++ b/core/commonTest/src/contract/map/PersistentHashMapBuilderTest.kt
@@ -746,7 +746,7 @@ class PersistentHashMapBuilderTest {
         while (iterator.hasNext()) {
             val entry = iterator.next()
             visited.add(entry.key)
-            val _ = entry.setValue(entry.value + "!")
+            entry.setValue(entry.value + "!")
         }
 
         assertEquals(orderedKeys, visited)

--- a/core/commonTest/src/contract/map/PersistentHashMapBuilderTest.kt
+++ b/core/commonTest/src/contract/map/PersistentHashMapBuilderTest.kt
@@ -14,6 +14,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
+import kotlin.test.assertNull
 import kotlin.test.assertSame
 import kotlin.test.assertTrue
 
@@ -1025,5 +1026,136 @@ class PersistentHashMapBuilderTest {
         assertEquals(listOf(orderedKeys[1] to "y", orderedKeys[2] to "z", orderedKeys[3] to "w"), List(3) { iterator.next().let { entry -> entry.key to entry.value } })
         assertFalse(iterator.hasNext())
         assertEquals(orderedKeys, builder.keys.toList())
+    }
+
+    @Test
+    fun `entry value and setValue follow an overwrite of its key whether the builder came from a map or from puts`() {
+        val fromMap = persistentHashMapOf(1 to "a").builder()
+        val fromPuts = persistentHashMapOf<Int, String>().builder()
+        fromPuts[1] = "a"
+
+        for ((flavour, builder) in listOf("from a map" to fromMap, "from puts" to fromPuts)) {
+            val entry = builder.entries.iterator().next()
+
+            builder[1] = "b"
+            assertEquals("b", entry.value, flavour)
+
+            builder[1] = "c"
+            assertEquals("c", entry.setValue("d"), flavour)
+            assertEquals("d", entry.value, flavour)
+            assertEquals("d", builder[1], flavour)
+        }
+    }
+
+    @Test
+    fun `entry value follows an overwrite of its key to null and of a null value to a string`() {
+        val builder = persistentHashMapOf<Int, String?>(1 to "a", 2 to null).builder()
+        val iterator = builder.entries.iterator()
+        val entryOfString = iterator.next()
+        val entryOfNull = iterator.next()
+        assertEquals(1, entryOfString.key)
+
+        builder[1] = null
+        builder[2] = "b"
+
+        assertNull(entryOfString.value)
+        assertEquals("b", entryOfNull.value)
+        assertNull(entryOfString.setValue("x"))
+        assertEquals("b", entryOfNull.setValue(null))
+        assertEquals("x", builder[1])
+        assertNull(builder[2])
+        assertTrue(builder.containsKey(2))
+    }
+
+    @Test
+    fun `entry value follows an overwrite of its key at every depth of the trie whether the builder came from a map or from puts`() {
+        // (1, 1) is a root entry, (3, 32) sits in a level-1 node, (5, 1024) in a level-2 node, (2, 0) and (4, 0) share a bottom-level collision node
+        val keys = listOf(IntWrapper(1, 1), IntWrapper(3, 32), IntWrapper(5, 1 shl 10), IntWrapper(2, 0), IntWrapper(4, 0))
+        val fromMap = persistentHashMapOf(*keys.map { it to "v${it.obj}" }.toTypedArray()).builder()
+        val fromPuts = persistentHashMapOf<IntWrapper, String>().builder()
+        for (key in keys) fromPuts[key] = "v${key.obj}"
+
+        for ((flavour, builder) in listOf("from a map" to fromMap, "from puts" to fromPuts)) {
+            val entries = builder.entries.toList()
+            assertEquals(keys.size, entries.size, flavour)
+
+            for (key in keys) builder[key] = "x${key.obj}"
+
+            for (entry in entries) {
+                assertEquals("x${entry.key.obj}", entry.value, "$flavour, key ${entry.key}")
+                assertEquals("x${entry.key.obj}", entry.setValue("y${entry.key.obj}"), "$flavour, key ${entry.key}")
+                assertEquals("y${entry.key.obj}", builder[entry.key], "$flavour, key ${entry.key}")
+            }
+        }
+    }
+
+    @Test
+    fun `entry after a remove of its key keeps the last value it observed and follows the value put back`() {
+        val builder = persistentHashMapOf(1 to "a", 2 to "b").builder()
+        val entry = builder.entries.iterator().next()
+        assertEquals(1, entry.key)
+        builder[1] = "x"
+        assertEquals("x", entry.value)
+
+        assertEquals("x", builder.remove(1))
+
+        assertEquals("x", entry.value)
+        assertEquals("x", entry.setValue("z"))
+        assertFalse(builder.containsKey(1))
+        assertEquals("z", entry.value)
+
+        assertNull(builder.put(1, "y"))
+
+        assertEquals("y", entry.value)
+        assertEquals("y", entry.setValue("w"))
+        assertEquals("w", builder[1])
+    }
+
+    @Test
+    fun `the entry's toString hashCode and membership in entries use the value after an overwrite of its key`() {
+        val builder = persistentHashMapOf(1 to "a", 2 to "b").builder()
+        val entry = builder.entries.iterator().next()
+        assertEquals(1, entry.key)
+
+        builder[1] = "x"
+
+        assertEquals("1=x", entry.toString())
+        assertEquals(1.hashCode() xor "x".hashCode(), entry.hashCode())
+        assertTrue(builder.entries.contains(entry))
+        assertTrue(builder.entries.remove(entry))
+        assertFalse(builder.containsKey(1))
+        assertEquals(1, builder.size)
+    }
+
+    @Test
+    fun `entry after a remove of its key stays detached when another key takes its slot`() {
+        val builder = persistentHashMapOf(1 to "a", 2 to "b").builder()
+        val entry = builder.entries.iterator().next()
+        assertEquals(1, entry.key)
+        builder[1] = "x"
+        assertEquals("x", entry.value)
+
+        assertEquals("x", builder.remove(1))
+        builder[33] = "c"
+
+        assertEquals("x", entry.value)
+        assertEquals("x", entry.setValue("z"))
+        assertFalse(builder.containsKey(1))
+        assertEquals("c", builder[33])
+        assertEquals(2, builder.size)
+    }
+
+    @Test
+    fun `entry after a remove of its key keeps the value it set itself`() {
+        val builder = persistentHashMapOf(1 to "a", 2 to "b").builder()
+        val entry = builder.entries.iterator().next()
+        assertEquals(1, entry.key)
+        assertEquals("a", entry.setValue("x"))
+
+        assertEquals("x", builder.remove(1))
+
+        assertEquals("x", entry.value)
+        assertEquals("x", entry.setValue("z"))
+        assertFalse(builder.containsKey(1))
     }
 }

--- a/core/commonTest/src/contract/map/PersistentHashMapBuilderTest.kt
+++ b/core/commonTest/src/contract/map/PersistentHashMapBuilderTest.kt
@@ -179,57 +179,62 @@ class PersistentHashMapBuilderTest {
     }
 
     @Test
-    fun `putAll that only replaces values should invalidate a live iterator`() {
+    fun `putAll that only replaces values should keep a live iterator valid and show it the new values`() {
         val builder = persistentHashMapOf(1 to "a", 2 to "b").builder()
 
         val iterator = builder.entries.iterator()
         builder.putAll(persistentHashMapOf(1 to "x", 2 to "y"))
 
         assertEquals("x", builder[1])
-        assertFailsWith<ConcurrentModificationException> { iterator.next() }
+        assertEquals(listOf("x", "y"), listOf(iterator.next().value, iterator.next().value).sorted())
+        assertFalse(iterator.hasNext())
     }
 
     @Test
-    fun `putAll that only replaces values in a bottom-level collision node should invalidate a live iterator`() {
+    fun `putAll that only replaces values in a bottom-level collision node should keep a live iterator valid and show it the new values`() {
         val builder = persistentHashMapOf(a1 to "a", a2 to "b").builder()
 
         val iterator = builder.entries.iterator()
         builder.putAll(persistentHashMapOf(a1 to "x", a2 to "y"))
 
         assertEquals("x", builder[a1])
-        assertFailsWith<ConcurrentModificationException> { iterator.next() }
+        assertEquals(listOf("x", "y"), listOf(iterator.next().value, iterator.next().value).sorted())
+        assertFalse(iterator.hasNext())
     }
 
     @Test
-    fun `putAll that only replaces values should invalidate an iterator that descended into the replaced node`() {
+    fun `putAll that only replaces values should keep an iterator that descended into the replaced node valid`() {
         val builder = persistentHashMapOf(1 to "a", 0 to "y", 32 to "z").builder()
         builder[1] = "A"
 
         val iterator = builder.entries.iterator()
-        val _ = iterator.next()
+        assertEquals(1, iterator.next().key)
         builder.putAll(persistentHashMapOf(0 to "Y", 32 to "Z"))
 
         assertEquals("Y", builder[0])
-        assertFailsWith<ConcurrentModificationException> { iterator.next() }
+        assertEquals(listOf("Y", "Z"), listOf(iterator.next().value, iterator.next().value).sorted())
+        assertFalse(iterator.hasNext())
     }
 
     @Test
-    fun `putAll that replaces values in an unowned collision node under an owned root should invalidate a live iterator`() {
+    fun `putAll that replaces values in an unowned collision node under an owned root should keep a live iterator valid`() {
         val builder = (persistentHashMapOf(a1 to "a", a2 to "b", sibling to "c")
                 as PersistentHashMap<IntWrapper, String>).builder()
         builder[sibling] = "C"
         val nodeBefore = builder.node
 
         val iterator = builder.entries.iterator()
+        assertEquals("C", iterator.next().value)
         builder.putAll(persistentHashMapOf(a1 to "x", a2 to "y"))
 
         assertSame(nodeBefore, builder.node)
         assertEquals("x", builder[a1])
-        assertFailsWith<ConcurrentModificationException> { iterator.next() }
+        assertEquals(listOf("x", "y"), listOf(iterator.next().value, iterator.next().value).sorted())
+        assertFalse(iterator.hasNext())
     }
 
     @Test
-    fun `putAll that replaces the value of a key stored in a two-entry node should invalidate a live iterator`() {
+    fun `putAll that replaces the value of a key stored in a two-entry node should keep a live iterator valid`() {
         val neighbor = IntWrapper(2, 32)
         val builder = persistentHashMapOf(a1 to "a", neighbor to "b").builder()
 
@@ -237,7 +242,8 @@ class PersistentHashMapBuilderTest {
         builder.putAll(persistentHashMapOf(a1 to "x"))
 
         assertEquals("x", builder[a1])
-        assertFailsWith<ConcurrentModificationException> { iterator.next() }
+        assertEquals(listOf("b", "x"), listOf(iterator.next().value, iterator.next().value).sorted())
+        assertFalse(iterator.hasNext())
     }
 
     @Test
@@ -658,7 +664,7 @@ class PersistentHashMapBuilderTest {
     }
 
     @Test
-    fun `entry setValue after an external value overwrite of a different key writes the value and the following next throws`() {
+    fun `entry setValue after an external value overwrite of a different key writes the value and the iterator continues`() {
         val builder = persistentHashMapOf(1 to "a", 2 to "b", 3 to "c").builder()
         val iterator = builder.entries.iterator()
         val entry = iterator.next()
@@ -671,7 +677,13 @@ class PersistentHashMapBuilderTest {
         assertEquals("z", builder[entry.key])
         assertEquals("overwritten", builder[otherKey])
         assertEquals(3, builder.size)
-        assertFailsWith<ConcurrentModificationException> { iterator.next() }
+        val thirdKey = (setOf(1, 2, 3) - entry.key - otherKey).single()
+        val remaining = mutableMapOf<Int, String>()
+        while (iterator.hasNext()) {
+            val next = iterator.next()
+            remaining[next.key] = next.value
+        }
+        assertEquals(mapOf(otherKey to "overwritten", thirdKey to mapOf(1 to "a", 2 to "b", 3 to "c").getValue(thirdKey)), remaining)
     }
 
     @Test
@@ -817,5 +829,201 @@ class PersistentHashMapBuilderTest {
 
         assertFailsWith<IllegalStateException> { iterator.remove() }
         assertEquals(1, builder.size)
+    }
+
+    @Test
+    fun `iterator remove after a value overwrite succeeds whether the builder came from a map or from puts`() {
+        val fromMap = persistentHashMapOf(1 to "a").builder()
+        val fromPuts = persistentHashMapOf<Int, String>().builder()
+        fromPuts[1] = "a"
+
+        for ((flavour, builder) in listOf("from a map" to fromMap, "from puts" to fromPuts)) {
+            val iterator = builder.entries.iterator()
+            assertEquals(1, iterator.next().key, flavour)
+
+            builder[1] = "b"
+
+            assertFalse(iterator.hasNext(), flavour)
+            iterator.remove()
+            assertTrue(builder.isEmpty(), flavour)
+        }
+    }
+
+    @Test
+    fun `iterator remove after an overwrite of the upcoming key removes the returned entry and returns the new value`() {
+        val builder = persistentHashMapOf(1 to "a", 2 to "b", 3 to "c", 0 to "y", 32 to "z").builder()
+        val iterator = builder.entries.iterator()
+        repeat(3) { val _ = iterator.next() }
+        assertEquals(0, iterator.next().key)
+
+        builder[32] = "Z"
+
+        iterator.remove()
+        assertEquals(4, builder.size)
+        assertFalse(builder.containsKey(0))
+        assertEquals("Z", iterator.next().value)
+        assertFalse(iterator.hasNext())
+    }
+
+    @Test
+    fun `next after an external overwrite of the upcoming key returns the new value`() {
+        val builder = persistentHashMapOf(1 to "a", 2 to "b").builder()
+        val iterator = builder.entries.iterator()
+        assertEquals(1, iterator.next().key)
+
+        builder[2] = "x"
+
+        assertTrue(iterator.hasNext())
+        assertEquals("x", iterator.next().value)
+        assertFalse(iterator.hasNext())
+    }
+
+    @Test
+    fun `next after an external overwrite of the upcoming key in a bottom-level collision node returns the new value`() {
+        val builder = persistentHashMapOf(a1 to "a", a2 to "b").builder()
+        val iterator = builder.entries.iterator()
+        val upcoming = if (iterator.next().key == a1) a2 else a1
+
+        builder[upcoming] = "x"
+
+        assertEquals("x", iterator.next().value)
+        assertFalse(iterator.hasNext())
+    }
+
+    @Test
+    fun `next after build and an overwrite of the key promoted by an iterator remove returns the new value and nothing else`() {
+        val builder = persistentHashMapOf<Int, String>().builder()
+        for (key in listOf(1, 2, 3, 0, 32)) {
+            builder[key] = "v$key"
+        }
+        val iterator = builder.entries.iterator()
+        repeat(3) { val _ = iterator.next() }
+        assertEquals(0, iterator.next().key)
+        iterator.remove()
+
+        val built = builder.build()
+        builder[32] = "Z"
+
+        assertEquals("Z", iterator.next().value)
+        assertFalse(iterator.hasNext())
+        assertEquals("v32", built[32])
+    }
+
+    @Test
+    fun `put of a new key and its remove cancel out in size but still invalidate the iterator`() {
+        val builder = persistentHashMapOf(1 to "a", 2 to "b").builder()
+        val iterator = builder.entries.iterator()
+        assertEquals(1, iterator.next().key)
+
+        builder[3] = "c"
+        assertEquals("c", builder.remove(3))
+
+        assertEquals(2, builder.size)
+        assertFailsWith<ConcurrentModificationException> { iterator.next() }
+    }
+
+    @Test
+    fun `next after a promoting remove returns the value written after the remove`() {
+        val builder = persistentHashMapOf(1 to "a", 2 to "b", 3 to "c", 0 to "y", 32 to "z").builder()
+        val iterator = builder.entries.iterator()
+        repeat(3) { val _ = iterator.next() }
+        assertEquals(0, iterator.next().key)
+        iterator.remove()
+
+        builder[32] = "Z"
+
+        assertEquals("Z", iterator.next().value)
+        assertFalse(iterator.hasNext())
+    }
+
+    @Test
+    fun `entry setValue after a promoting remove does not revisit the entries of the parent node`() {
+        val builder = persistentHashMapOf(1 to "a", 2 to "b", 3 to "c", 0 to "y", 32 to "z").builder()
+        val iterator = builder.entries.iterator()
+        val first = iterator.next()
+        assertEquals(1, first.key)
+        repeat(2) { val _ = iterator.next() }
+        assertEquals(0, iterator.next().key)
+        iterator.remove()
+
+        assertEquals("a", first.setValue("A"))
+
+        assertEquals("A", builder[1])
+        assertEquals(32, iterator.next().key)
+        assertFalse(iterator.hasNext())
+    }
+
+    @Test
+    fun `value overwrite in an unowned node after a promoting iterator remove keeps the iterator valid`() {
+        // root entries 10 and 11, nodes {7, 39}, {5, 37} and {0, 32} at the root positions 7, 5 and 0
+        val builder = persistentHashMapOf(
+            10 to "j", 11 to "k", 0 to "v0", 32 to "v32", 5 to "v5", 37 to "v37", 7 to "v7", 39 to "v39"
+        ).builder()
+        val iterator = builder.entries.iterator()
+        assertEquals(listOf(10, 11, 7, 39, 5), List(5) { iterator.next().key })
+        iterator.remove()
+
+        builder[0] = "Y"
+
+        val remaining = mutableListOf<String>()
+        while (iterator.hasNext()) {
+            remaining.add(iterator.next().toString())
+        }
+        assertEquals(listOf("37=v37", "0=Y", "32=v32"), remaining)
+        assertEquals(7, builder.size)
+    }
+
+    @Test
+    fun `value overwrites after build and a promoting iterator remove keep the iterator valid`() {
+        // 195 and 1219 share the root position 3 and the level-1 position 6, 67 and 1091 the root position 3
+        // and the level-1 position 2, 1 and 33 the root position 1
+        val builder = persistentHashMapOf(195 to "x", 1219 to "y", 67 to "p", 1091 to "q", 1 to "a", 33 to "b").builder()
+        val iterator = builder.entries.iterator()
+        assertEquals(195, iterator.next().key)
+        iterator.remove()
+
+        val _ = builder.build()
+        builder[67] = "P"
+        builder[1] = "A"
+
+        val remaining = mutableListOf<String>()
+        while (iterator.hasNext()) {
+            remaining.add(iterator.next().toString())
+        }
+        assertEquals(listOf("1219=y", "67=P", "1091=q", "1=A", "33=b"), remaining)
+        assertEquals(5, builder.size)
+    }
+
+    @Test
+    fun `value overwrite in a later node while the iterator is inside another node is seen by the iterator`() {
+        val builder = persistentHashMapOf(1 to "a", 2 to "b", 3 to "c", 0 to "y", 32 to "z", 5 to "e", 37 to "f").builder()
+        val iterator = builder.entries.iterator()
+        repeat(3) { val _ = iterator.next() }
+        assertEquals(5, iterator.next().key)
+
+        builder[0] = "Y"
+
+        val remaining = mutableListOf<String>()
+        while (iterator.hasNext()) {
+            remaining.add(iterator.next().toString())
+        }
+        assertEquals(listOf("37=f", "0=Y", "32=z"), remaining)
+    }
+
+    @Test
+    fun `putAll that only replaces values in a bottom-level collision node keeps the receiver's order under a live iterator`() {
+        val builder = persistentHashMapOf(a1 to "a", a2 to "b", IntWrapper(3, 0) to "c", IntWrapper(4, 0) to "d").builder()
+        val orderedKeys = builder.keys.toList()
+        // the argument holds the same key instances with the first two swapped, so its last key keeps its index and its first does not
+        val argument = persistentHashMapOf(orderedKeys[2] to "z", orderedKeys[3] to "w", orderedKeys[0] to "x", orderedKeys[1] to "y")
+        assertEquals(listOf(orderedKeys[1], orderedKeys[0], orderedKeys[2], orderedKeys[3]), argument.keys.toList())
+
+        val iterator = builder.entries.iterator()
+        assertEquals(orderedKeys[0], iterator.next().key)
+        builder.putAll(argument)
+
+        assertEquals(listOf(orderedKeys[1] to "y", orderedKeys[2] to "z", orderedKeys[3] to "w"), List(3) { iterator.next().let { entry -> entry.key to entry.value } })
+        assertFalse(iterator.hasNext())
+        assertEquals(orderedKeys, builder.keys.toList())
     }
 }

--- a/core/commonTest/src/contract/map/PersistentHashMapBuilderTest.kt
+++ b/core/commonTest/src/contract/map/PersistentHashMapBuilderTest.kt
@@ -777,4 +777,45 @@ class PersistentHashMapBuilderTest {
         assertEquals(orderedKeys[2], iterator.next().key)
         assertFalse(iterator.hasNext())
     }
+
+    @Test
+    fun `iterator remove after a remove of a different key throws ConcurrentModificationException`() {
+        val builder = persistentHashMapOf(1 to "a", 2 to "b").builder()
+        val orderedKeys = builder.keys.toList()
+        val iterator = builder.entries.iterator()
+        assertEquals(orderedKeys[0], iterator.next().key)
+
+        builder.remove(orderedKeys[1])
+
+        assertFailsWith<ConcurrentModificationException> { iterator.remove() }
+        assertEquals(1, builder.size)
+        assertTrue(builder.containsKey(orderedKeys[0]))
+        assertFailsWith<ConcurrentModificationException> { iterator.next() }
+    }
+
+    @Test
+    fun `iterator remove on the exhausted iterator of a single entry map after an external put throws ConcurrentModificationException`() {
+        val builder = persistentHashMapOf(1 to "a").builder()
+        val iterator = builder.entries.iterator()
+        val _ = iterator.next()
+        assertFalse(iterator.hasNext())
+
+        builder[2] = "b"
+
+        assertFailsWith<ConcurrentModificationException> { iterator.remove() }
+        assertEquals(2, builder.size)
+        assertEquals("a", builder[1])
+        assertFailsWith<ConcurrentModificationException> { iterator.next() }
+    }
+
+    @Test
+    fun `iterator remove without a preceding next after an external remove throws IllegalStateException`() {
+        val builder = persistentHashMapOf(1 to "a", 2 to "b").builder()
+        val iterator = builder.entries.iterator()
+
+        builder.remove(1)
+
+        assertFailsWith<IllegalStateException> { iterator.remove() }
+        assertEquals(1, builder.size)
+    }
 }

--- a/core/commonTest/src/contract/map/PersistentOrderedMapBuilderTest.kt
+++ b/core/commonTest/src/contract/map/PersistentOrderedMapBuilderTest.kt
@@ -166,7 +166,7 @@ class PersistentOrderedMapBuilderTest {
         assertEquals("a", builder.remove(1))
         assertNull(builder.put(1, null))
 
-        assertEquals("a", entry.setValue("z"))
+        assertNull(entry.setValue("z"))
 
         val built = builder.build()
         assertEquals(listOf(2, 3, 1), built.keys.toList())
@@ -182,7 +182,7 @@ class PersistentOrderedMapBuilderTest {
         val stored = builder[1]!!
         val snapshot = builder.build()
 
-        assertEquals("a", entry.setValue(stored))
+        assertEquals("x", entry.setValue(stored))
 
         assertSame(snapshot, builder.build())
     }
@@ -322,6 +322,61 @@ class PersistentOrderedMapBuilderTest {
         assertTrue(values.hasNext())
         assertFailsWith<ConcurrentModificationException> { keys.next() }
         assertFailsWith<ConcurrentModificationException> { values.next() }
+    }
+
+    @Test
+    fun `entry value and setValue follow an overwrite of its key whether the builder came from a map or from puts`() {
+        val fromMap = persistentMapOf(1 to "a").builder()
+        val fromPuts = persistentMapOf<Int, String>().builder()
+        fromPuts[1] = "a"
+
+        for ((flavour, builder) in listOf("from a map" to fromMap, "from puts" to fromPuts)) {
+            val entry = builder.entries.iterator().next()
+
+            builder[1] = "b"
+            assertEquals("b", entry.value, flavour)
+
+            builder[1] = "c"
+            assertEquals("c", entry.setValue("d"), flavour)
+            assertEquals("d", entry.value, flavour)
+            assertEquals("d", builder[1], flavour)
+        }
+    }
+
+    @Test
+    fun `entry setValue of an equal value that is not the stored instance writes the new instance`() {
+        val stored = TraceKey(1, hash = 1)
+        val equal = TraceKey(1, hash = 1)
+        val builder = persistentMapOf(1 to stored).builder()
+        val entry = builder.entries.iterator().next()
+
+        assertSame(stored, entry.setValue(equal))
+
+        assertSame(equal, builder[1])
+        assertSame(equal, entry.value)
+    }
+
+    @Test
+    fun `entry after a remove of its key keeps the last value it observed and follows the value put back`() {
+        val builder = persistentMapOf(1 to "a", 2 to "b").builder()
+        val entry = builder.entries.iterator().next()
+        builder[1] = "x"
+        assertEquals("x", entry.value)
+
+        assertEquals("x", builder.remove(1))
+
+        assertEquals("x", entry.value)
+        assertEquals("x", entry.setValue("z"))
+        assertEquals("z", entry.setValue("y"))
+        assertNull(builder[1])
+        assertEquals(1, builder.size)
+
+        assertNull(builder.put(1, "p"))
+
+        assertEquals("p", entry.value)
+        assertEquals("p", entry.setValue("q"))
+        assertEquals("q", builder[1])
+        assertEquals(listOf(2, 1), builder.build().keys.toList())
     }
 
     private class TraceKey(val value: Int, private val hash: Int) {

--- a/core/commonTest/src/contract/map/PersistentOrderedMapBuilderTest.kt
+++ b/core/commonTest/src/contract/map/PersistentOrderedMapBuilderTest.kt
@@ -11,6 +11,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertNull
 import kotlin.test.assertSame
+import kotlin.test.assertTrue
 
 class PersistentOrderedMapBuilderTest {
 
@@ -195,6 +196,74 @@ class PersistentOrderedMapBuilderTest {
 
         assertEquals(0, builder.size)
         assertEquals(persistentMapOf(), builder.build())
+    }
+
+    @Test
+    fun `iterator remove after a remove of a different key throws ConcurrentModificationException`() {
+        val builder = persistentMapOf(1 to "a", 2 to "b").builder()
+        val iterator = builder.entries.iterator()
+        assertEquals(1, iterator.next().key)
+
+        assertEquals("b", builder.remove(2))
+
+        assertFailsWith<ConcurrentModificationException> { iterator.remove() }
+        assertEquals(listOf(1), builder.build().keys.toList())
+        assertFailsWith<ConcurrentModificationException> { iterator.next() }
+    }
+
+    @Test
+    fun `iterator remove after a remove of an already visited key throws ConcurrentModificationException`() {
+        val builder = persistentMapOf(1 to "a", 2 to "b", 3 to "c").builder()
+        val iterator = builder.entries.iterator()
+        assertEquals(1, iterator.next().key)
+        assertEquals(2, iterator.next().key)
+
+        assertEquals("a", builder.remove(1))
+
+        assertFailsWith<ConcurrentModificationException> { iterator.remove() }
+        val built = builder.build()
+        assertEquals(listOf(2, 3), built.keys.toList())
+        assertEquals(listOf("b", "c"), built.values.toList())
+    }
+
+    @Test
+    fun `iterator remove after external changes that cancel out in size throws ConcurrentModificationException`() {
+        val builder = persistentMapOf(1 to "a", 2 to "b", 3 to "c").builder()
+        val iterator = builder.entries.iterator()
+        assertEquals(1, iterator.next().key)
+
+        assertEquals("c", builder.remove(3))
+        assertNull(builder.put(4, "d"))
+
+        assertTrue(iterator.hasNext())
+        assertFailsWith<ConcurrentModificationException> { iterator.remove() }
+        assertEquals(listOf(1, 2, 4), builder.build().keys.toList())
+    }
+
+    @Test
+    fun `iterator remove without a preceding next after an external remove throws IllegalStateException`() {
+        val builder = persistentMapOf(1 to "a", 2 to "b").builder()
+        val iterator = builder.entries.iterator()
+
+        assertEquals("b", builder.remove(2))
+
+        assertFailsWith<IllegalStateException> { iterator.remove() }
+        assertEquals(listOf(1), builder.build().keys.toList())
+    }
+
+    @Test
+    fun `keys and values iterator remove after a remove of a different key throws ConcurrentModificationException`() {
+        val builder = persistentMapOf(1 to "a", 2 to "b", 3 to "c").builder()
+        val keys = builder.keys.iterator()
+        val values = builder.values.iterator()
+        assertEquals(1, keys.next())
+        assertEquals("a", values.next())
+
+        assertEquals("c", builder.remove(3))
+
+        assertFailsWith<ConcurrentModificationException> { keys.remove() }
+        assertFailsWith<ConcurrentModificationException> { values.remove() }
+        assertEquals(listOf(1, 2), builder.build().keys.toList())
     }
 
     private class TraceKey(val value: Int, private val hash: Int) {

--- a/core/commonTest/src/contract/map/PersistentOrderedMapBuilderTest.kt
+++ b/core/commonTest/src/contract/map/PersistentOrderedMapBuilderTest.kt
@@ -9,6 +9,7 @@ import kotlinx.collections.immutable.persistentMapOf
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
 import kotlin.test.assertNull
 import kotlin.test.assertSame
 import kotlin.test.assertTrue
@@ -264,6 +265,63 @@ class PersistentOrderedMapBuilderTest {
         assertFailsWith<ConcurrentModificationException> { keys.remove() }
         assertFailsWith<ConcurrentModificationException> { values.remove() }
         assertEquals(listOf(1, 2), builder.build().keys.toList())
+    }
+
+    @Test
+    fun `hasNext after a remove of an already visited key and then of every remaining key stays true`() {
+        val builder = persistentMapOf(1 to "a", 2 to "b", 3 to "c").builder()
+        val iterator = builder.entries.iterator()
+        assertEquals(1, iterator.next().key)
+        assertEquals(2, iterator.next().key)
+
+        assertEquals("a", builder.remove(1))
+        assertTrue(iterator.hasNext())
+
+        assertEquals("b", builder.remove(2))
+        assertEquals("c", builder.remove(3))
+        assertTrue(iterator.hasNext())
+        assertFailsWith<ConcurrentModificationException> { iterator.next() }
+    }
+
+    @Test
+    fun `hasNext on an exhausted iterator after an external put of a new key stays false`() {
+        val builder = persistentMapOf(1 to "a", 2 to "b", 3 to "c").builder()
+        val iterator = builder.entries.iterator()
+        repeat(3) { val _ = iterator.next() }
+        assertFalse(iterator.hasNext())
+
+        assertNull(builder.put(9, "z"))
+
+        assertFalse(iterator.hasNext())
+        assertFailsWith<ConcurrentModificationException> { iterator.next() }
+    }
+
+    @Test
+    fun `hasNext on an iterator of an empty builder after an external put stays false`() {
+        val builder = persistentMapOf<Int, String>().builder()
+        val iterator = builder.entries.iterator()
+
+        assertNull(builder.put(1, "a"))
+
+        assertFalse(iterator.hasNext())
+    }
+
+    @Test
+    fun `keys and values iterator hasNext after a remove of an already visited key stays true`() {
+        val builder = persistentMapOf(1 to "a", 2 to "b", 3 to "c").builder()
+        val keys = builder.keys.iterator()
+        val values = builder.values.iterator()
+        assertEquals(1, keys.next())
+        assertEquals(2, keys.next())
+        assertEquals("a", values.next())
+        assertEquals("b", values.next())
+
+        assertEquals("a", builder.remove(1))
+
+        assertTrue(keys.hasNext())
+        assertTrue(values.hasNext())
+        assertFailsWith<ConcurrentModificationException> { keys.next() }
+        assertFailsWith<ConcurrentModificationException> { values.next() }
     }
 
     private class TraceKey(val value: Int, private val hash: Int) {

--- a/core/commonTest/src/contract/set/PersistentHashSetBuilderTest.kt
+++ b/core/commonTest/src/contract/set/PersistentHashSetBuilderTest.kt
@@ -489,4 +489,61 @@ class PersistentHashSetBuilderTest {
             }
         }
     }
+
+    @Test
+    fun `iterator remove after a remove of a different element throws ConcurrentModificationException`() {
+        val builder = persistentHashSetOf(1, 2).builder()
+        val orderedElements = builder.toList()
+        val iterator = builder.iterator()
+        assertEquals(orderedElements[0], iterator.next())
+
+        builder.remove(orderedElements[1])
+
+        assertFailsWith<ConcurrentModificationException> { iterator.remove() }
+        assertEquals(1, builder.size)
+        assertTrue(builder.contains(orderedElements[0]))
+        assertFailsWith<ConcurrentModificationException> { iterator.next() }
+    }
+
+    @Test
+    fun `iterator remove on the exhausted iterator of a single element set after an external add throws ConcurrentModificationException`() {
+        val builder = persistentHashSetOf(1).builder()
+        val iterator = builder.iterator()
+        assertEquals(1, iterator.next())
+        assertFalse(iterator.hasNext())
+
+        builder.add(2)
+
+        assertFailsWith<ConcurrentModificationException> { iterator.remove() }
+        assertEquals(2, builder.size)
+        assertTrue(builder.contains(1))
+        assertFailsWith<ConcurrentModificationException> { iterator.next() }
+    }
+
+    @Test
+    fun `iterator remove without a preceding next after an external remove throws IllegalStateException`() {
+        val builder = persistentHashSetOf(1, 2).builder()
+        val iterator = builder.iterator()
+
+        builder.remove(1)
+
+        assertFailsWith<IllegalStateException> { iterator.remove() }
+        assertEquals(1, builder.size)
+    }
+
+    @Test
+    fun `iterator remove after external changes that cancel out in size throws ConcurrentModificationException`() {
+        val builder = persistentHashSetOf(1, 2, 3, 4).builder()
+        val iterator = builder.iterator()
+        val _ = iterator.next()
+        iterator.remove()
+        val orderedElements = builder.toList()
+        assertEquals(orderedElements[0], iterator.next())
+
+        builder.remove(orderedElements[2])
+        builder.add(9)
+
+        assertEquals(3, builder.size)
+        assertFailsWith<ConcurrentModificationException> { iterator.remove() }
+    }
 }

--- a/core/commonTest/src/contract/set/PersistentHashSetBuilderTest.kt
+++ b/core/commonTest/src/contract/set/PersistentHashSetBuilderTest.kt
@@ -6,12 +6,15 @@
 package tests.contract.set
 
 import kotlinx.collections.immutable.implementations.immutableSet.PersistentHashSet
+import kotlinx.collections.immutable.implementations.immutableSet.PersistentHashSetBuilder
 import kotlinx.collections.immutable.persistentHashSetOf
 import tests.IntWrapper
+import kotlin.random.Random
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
+import kotlin.test.assertSame
 import kotlin.test.assertTrue
 
 class PersistentHashSetBuilderTest {
@@ -189,5 +192,185 @@ class PersistentHashSetBuilderTest {
         assertTrue(reversedBuilder.removeAll(persistentHashSetOf(a1, a2)))
         assertEquals(1, reversedBuilder.size)
         assertEquals(persistentHashSetOf(sibling), reversedBuilder.build())
+    }
+
+    @Test
+    fun `addAll should keep the stored element instance when the collision node is reached at the last level`() {
+        val storedElement = IntWrapper(1, 0)
+        val builder = persistentHashSetOf(storedElement, sibling).builder()
+
+        builder.addAll(persistentHashSetOf(IntWrapper(1, 0), IntWrapper(2, 0)))
+
+        assertEquals(3, builder.size)
+        assertSame(storedElement, builder.single { it == storedElement })
+        assertSame(sibling, builder.single { it == sibling })
+    }
+
+    @Test
+    fun `addAll should keep every stored instance when the receiver's collision node is an equality-subset of the argument's`() {
+        val storedElement1 = IntWrapper(1, 0)
+        val storedElement2 = IntWrapper(2, 0)
+        val builder = persistentHashSetOf(storedElement1, storedElement2).builder()
+
+        builder.addAll(persistentHashSetOf(IntWrapper(1, 0), IntWrapper(2, 0), IntWrapper(3, 0)))
+
+        assertEquals(3, builder.size)
+        assertSame(storedElement1, builder.single { it == storedElement1 })
+        assertSame(storedElement2, builder.single { it == storedElement2 })
+    }
+
+    @Test
+    fun `addAll should insert the element when the argument's subtree lacks it`() {
+        val storedElement = IntWrapper(1, 0)
+        val builder = persistentHashSetOf(storedElement).builder()
+
+        builder.addAll(persistentHashSetOf(IntWrapper(2, 32), IntWrapper(3, 64)))
+
+        assertEquals(3, builder.size)
+        assertTrue(builder.contains(IntWrapper(2, 32)))
+        assertTrue(builder.contains(IntWrapper(3, 64)))
+        assertSame(storedElement, builder.single { it == storedElement })
+    }
+
+    @Test
+    fun `addAll should push the element deeper when it collides with an argument element inside the subtree`() {
+        val storedElement = IntWrapper(1, 0)
+        val builder = persistentHashSetOf(storedElement).builder()
+
+        builder.addAll(persistentHashSetOf(IntWrapper(2, 1 shl 10), IntWrapper(3, 32)))
+
+        assertEquals(3, builder.size)
+        assertTrue(builder.contains(IntWrapper(2, 1 shl 10)))
+        assertTrue(builder.contains(IntWrapper(3, 32)))
+        assertSame(storedElement, builder.single { it == storedElement })
+    }
+
+    @Test
+    fun `addAll should reuse the argument's subtree when it holds the stored element instance`() {
+        val argument = persistentHashSetOf(a1, IntWrapper(2, 32)) as PersistentHashSet<IntWrapper>
+        val builder = (persistentHashSetOf(a1) as PersistentHashSet<IntWrapper>).builder() as PersistentHashSetBuilder<IntWrapper>
+
+        builder.addAll(argument)
+
+        assertEquals(2, builder.size)
+        assertSame(argument.node, builder.node)
+    }
+
+    @Test
+    fun `addAll should reuse the argument's collision node when its element is already the receiver's instance`() {
+        val argument = persistentHashSetOf(a1, a2) as PersistentHashSet<IntWrapper>
+        val builder = (persistentHashSetOf(a1) as PersistentHashSet<IntWrapper>).builder() as PersistentHashSetBuilder<IntWrapper>
+
+        builder.addAll(argument)
+
+        assertEquals(2, builder.size)
+        assertSame(argument.node, builder.node)
+    }
+
+    @Test
+    fun `addAll should reuse the argument's collision node when the receiver's elements are already its instances`() {
+        val argument = persistentHashSetOf(a1, a2, a3) as PersistentHashSet<IntWrapper>
+        val builder = (persistentHashSetOf(a1, a2) as PersistentHashSet<IntWrapper>).builder() as PersistentHashSetBuilder<IntWrapper>
+
+        builder.addAll(argument)
+
+        assertEquals(3, builder.size)
+        assertSame(argument.node, builder.node)
+    }
+
+    @Test
+    fun `addAll should not write the receiver's element into the argument's set`() {
+        val storedElement = IntWrapper(1, 0)
+        val argumentElement = IntWrapper(1, 0)
+        val argument = persistentHashSetOf(argumentElement, IntWrapper(2, 32))
+        val builder = persistentHashSetOf(storedElement).builder()
+
+        builder.addAll(argument)
+
+        assertSame(storedElement, builder.single { it == storedElement })
+        assertSame(argumentElement, argument.single { it == argumentElement })
+    }
+
+    @Test
+    fun `addAll should invalidate a live iterator when the argument holds the element in a subtree`() {
+        val builder = persistentHashSetOf(a1).builder()
+
+        val iterator = builder.iterator()
+        builder.addAll(persistentHashSetOf(IntWrapper(1, 0), IntWrapper(2, 32)))
+
+        assertTrue(builder.contains(a1))
+        assertFailsWith<ConcurrentModificationException> { iterator.next() }
+    }
+
+    @Test
+    fun `addAll of the stored elements should not invalidate an iterator`() {
+        val builder = persistentHashSetOf(a1, a2, sibling).builder()
+
+        val iterator = builder.iterator()
+        val visited = mutableListOf(iterator.next())
+        builder.addAll(persistentHashSetOf(a1, a2, sibling))
+        while (iterator.hasNext()) {
+            visited.add(iterator.next())
+        }
+
+        assertEquals(listOf(a1, a2, sibling), visited.sorted())
+    }
+
+    @Test
+    fun `addAll that merges an element into the argument's subtree should count one size change`() {
+        val overlapping = persistentHashSetOf(IntWrapper(1, 0)).builder() as PersistentHashSetBuilder<IntWrapper>
+        val modCount = overlapping.modCount
+        overlapping.addAll(persistentHashSetOf(IntWrapper(1, 0), IntWrapper(2, 32)))
+        assertEquals(modCount + 1, overlapping.modCount)
+
+        val disjoint = persistentHashSetOf(IntWrapper(1, 0)).builder() as PersistentHashSetBuilder<IntWrapper>
+        val disjointModCount = disjoint.modCount
+        disjoint.addAll(persistentHashSetOf(IntWrapper(2, 32), IntWrapper(3, 64)))
+        assertEquals(disjointModCount + 1, disjoint.modCount)
+
+        val collision =
+            persistentHashSetOf(IntWrapper(1, 0), sibling).builder() as PersistentHashSetBuilder<IntWrapper>
+        val collisionModCount = collision.modCount
+        collision.addAll(persistentHashSetOf(IntWrapper(2, 0), IntWrapper(4, 0)))
+        assertEquals(4, collision.size)
+        assertEquals(collisionModCount + 1, collision.modCount)
+    }
+
+    @Test
+    fun `addAll of random colliding sets should keep the stored element instances`() {
+        val hashes = intArrayOf(0, 1, 32, 33, 1 shl 10, 1 shl 30, (1 shl 30) or 32)
+        val random = Random(316)
+        repeat(200) { iteration ->
+            val receiverElements = mutableMapOf<Int, IntWrapper>()
+            val builder = persistentHashSetOf<IntWrapper>().builder()
+            for (id in 0..<14) {
+                if (random.nextBoolean()) {
+                    val element = IntWrapper(id, hashes[id % hashes.size])
+                    receiverElements[id] = element
+                    builder.add(element)
+                }
+            }
+            val argumentElements = mutableMapOf<Int, IntWrapper>()
+            val argumentBuilder = persistentHashSetOf<IntWrapper>().builder()
+            for (id in 0..<14) {
+                if (random.nextBoolean()) {
+                    val element = IntWrapper(id, hashes[id % hashes.size])
+                    argumentElements[id] = element
+                    argumentBuilder.add(element)
+                }
+            }
+
+            builder.addAll(argumentBuilder.build())
+
+            val shape = "iteration $iteration, receiver ${receiverElements.keys}, argument ${argumentElements.keys}"
+            assertEquals((receiverElements.keys + argumentElements.keys).size, builder.size, shape)
+            for ((id, element) in receiverElements) {
+                assertSame(element, builder.singleOrNull { it == element }, "$shape, id $id")
+            }
+            for ((id, element) in argumentElements) {
+                if (id in receiverElements) continue
+                assertSame(element, builder.singleOrNull { it == element }, "$shape, id $id")
+            }
+        }
     }
 }

--- a/core/commonTest/src/contract/set/PersistentHashSetBuilderTest.kt
+++ b/core/commonTest/src/contract/set/PersistentHashSetBuilderTest.kt
@@ -7,6 +7,7 @@ package tests.contract.set
 
 import kotlinx.collections.immutable.implementations.immutableSet.PersistentHashSet
 import kotlinx.collections.immutable.implementations.immutableSet.PersistentHashSetBuilder
+import kotlinx.collections.immutable.implementations.immutableSet.TrieNode
 import kotlinx.collections.immutable.persistentHashSetOf
 import tests.IntWrapper
 import kotlin.random.Random
@@ -369,6 +370,121 @@ class PersistentHashSetBuilderTest {
             }
             for ((id, element) in argumentElements) {
                 if (id in receiverElements) continue
+                assertSame(element, builder.singleOrNull { it == element }, "$shape, id $id")
+            }
+        }
+    }
+
+    @Test
+    fun `retainAll should keep the stored element instance when the collision node is reached at the last level`() {
+        val storedElement = IntWrapper(1, 0)
+        val builder = persistentHashSetOf(storedElement, IntWrapper(2, 0), sibling).builder()
+
+        assertTrue(builder.retainAll(persistentHashSetOf(IntWrapper(1, 0), IntWrapper(3, 1 shl 30))))
+
+        assertEquals(2, builder.size)
+        assertSame(storedElement, builder.single { it == storedElement })
+        assertSame(sibling, builder.single { it == sibling })
+    }
+
+    @Test
+    fun `retainAll should drop the argument's element when the receiver's subtree does not hold it`() {
+        val storedElement = IntWrapper(5, 1)
+
+        val leafMiss = persistentHashSetOf(IntWrapper(1, 0), IntWrapper(2, 32), storedElement).builder()
+        assertTrue(leafMiss.retainAll(persistentHashSetOf(IntWrapper(6, 0), IntWrapper(5, 1))))
+        assertEquals(1, leafMiss.size)
+        assertSame(storedElement, leafMiss.single())
+
+        val absentCell = persistentHashSetOf(IntWrapper(1, 0), IntWrapper(2, 32), storedElement).builder()
+        assertTrue(absentCell.retainAll(persistentHashSetOf(IntWrapper(7, 64), IntWrapper(5, 1))))
+        assertEquals(1, absentCell.size)
+        assertSame(storedElement, absentCell.single())
+
+        val collisionMiss = persistentHashSetOf(a1, a2, sibling).builder()
+        assertTrue(collisionMiss.retainAll(persistentHashSetOf(a3, sibling)))
+        assertEquals(1, collisionMiss.size)
+        assertSame(sibling, collisionMiss.single())
+    }
+
+    @Test
+    fun `retainAll should keep every stored instance when compacting a collision node the builder owns`() {
+        val builder = persistentHashSetOf<IntWrapper>().builder()
+        builder.add(a1)
+        builder.add(a2)
+        builder.add(a3)
+
+        assertTrue(builder.retainAll(persistentHashSetOf(IntWrapper(1, 0), IntWrapper(2, 0))))
+
+        assertEquals(2, builder.size)
+        assertSame(a1, builder.single { it == a1 })
+        assertSame(a2, builder.single { it == a2 })
+    }
+
+    @Test
+    fun `retainAll should reuse the argument's node when it already holds the receiver's element instance`() {
+        val argument = persistentHashSetOf(a1) as PersistentHashSet<IntWrapper>
+        val builder = (persistentHashSetOf(a1, IntWrapper(2, 32)) as PersistentHashSet<IntWrapper>)
+                .builder() as PersistentHashSetBuilder<IntWrapper>
+
+        builder.retainAll(argument)
+
+        assertEquals(1, builder.size)
+        assertSame(argument.node, builder.node)
+    }
+
+    @Test
+    fun `retainAll should reuse the argument's collision node when its elements are the receiver's instances`() {
+        val argument = persistentHashSetOf(a1, a2) as PersistentHashSet<IntWrapper>
+        val builder = (persistentHashSetOf(a1, a2, a3) as PersistentHashSet<IntWrapper>)
+                .builder() as PersistentHashSetBuilder<IntWrapper>
+
+        builder.retainAll(argument)
+
+        assertEquals(2, builder.size)
+        assertSame(collisionNodeOf(argument.node), collisionNodeOf(builder.node))
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun collisionNodeOf(node: TrieNode<IntWrapper>): TrieNode<IntWrapper> {
+        var current = node
+        while (current.bitmap != 0) {
+            current = current.buffer[0] as TrieNode<IntWrapper>
+        }
+        return current
+    }
+
+    @Test
+    fun `retainAll of random colliding sets should keep the stored element instances`() {
+        val hashes = intArrayOf(0, 1, 32, 33, 1 shl 10, 1 shl 30, (1 shl 30) or 32)
+        val random = Random(322)
+        repeat(200) { iteration ->
+            val receiverElements = mutableMapOf<Int, IntWrapper>()
+            val builder = persistentHashSetOf<IntWrapper>().builder()
+            for (id in 0..<21) {
+                if (random.nextBoolean()) {
+                    val element = IntWrapper(id, hashes[id % hashes.size])
+                    receiverElements[id] = element
+                    builder.add(element)
+                }
+            }
+            val argumentElements = mutableMapOf<Int, IntWrapper>()
+            val argumentBuilder = persistentHashSetOf<IntWrapper>().builder()
+            for (id in 0..<21) {
+                if (random.nextBoolean()) {
+                    val element = IntWrapper(id, hashes[id % hashes.size])
+                    argumentElements[id] = element
+                    argumentBuilder.add(element)
+                }
+            }
+
+            builder.retainAll(argumentBuilder.build())
+
+            val shape = "iteration $iteration, receiver ${receiverElements.keys}, argument ${argumentElements.keys}"
+            val retainedIds = receiverElements.keys intersect argumentElements.keys
+            assertEquals(retainedIds.size, builder.size, shape)
+            for (id in retainedIds) {
+                val element = receiverElements.getValue(id)
                 assertSame(element, builder.singleOrNull { it == element }, "$shape, id $id")
             }
         }

--- a/core/commonTest/src/contract/set/PersistentHashSetTest.kt
+++ b/core/commonTest/src/contract/set/PersistentHashSetTest.kt
@@ -15,6 +15,7 @@ import tests.IntWrapper
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertSame
 import kotlin.test.assertTrue
 
 class PersistentHashSetTest {
@@ -194,5 +195,16 @@ class PersistentHashSetTest {
         assertTrue(persistentHashSetOf(a1, a2, sibling).containsAll(persistentHashSetOf(a1, a2)))
         assertFalse(persistentHashSetOf(a1, sibling).containsAll(persistentHashSetOf(a1, a2)))
         assertFalse(persistentHashSetOf(a1, a2, sibling).containsAll(persistentHashSetOf(a3, sibling)))
+    }
+
+    @Test
+    fun `addingAll should keep the stored element instance when the argument holds it in a subtree`() {
+        val storedElement = IntWrapper(1, 0)
+        val set = persistentHashSetOf(storedElement)
+
+        val updated = set.addingAll(persistentHashSetOf(IntWrapper(1, 0), IntWrapper(2, 32)))
+
+        assertEquals(2, updated.size)
+        assertSame(storedElement, updated.single { it == storedElement })
     }
 }

--- a/core/commonTest/src/contract/set/PersistentHashSetTest.kt
+++ b/core/commonTest/src/contract/set/PersistentHashSetTest.kt
@@ -207,4 +207,28 @@ class PersistentHashSetTest {
         assertEquals(2, updated.size)
         assertSame(storedElement, updated.single { it == storedElement })
     }
+
+    @Test
+    fun `retainingAll should keep the stored element instance when the receiver holds it in a subtree`() {
+        val storedElement = IntWrapper(1, 0)
+        val set = persistentHashSetOf(storedElement, IntWrapper(2, 32))
+
+        val updated = set.retainingAll(persistentHashSetOf(IntWrapper(1, 0)))
+
+        assertEquals(1, updated.size)
+        assertSame(storedElement, updated.single { it == storedElement })
+    }
+
+    @Test
+    fun `retainingAll should keep every stored instance when the argument's collision node is an equality-subset`() {
+        val storedElement1 = IntWrapper(1, 0)
+        val storedElement2 = IntWrapper(2, 0)
+        val set = persistentHashSetOf(storedElement1, storedElement2, IntWrapper(3, 0))
+
+        val updated = set.retainingAll(persistentHashSetOf(IntWrapper(1, 0), IntWrapper(2, 0)))
+
+        assertEquals(2, updated.size)
+        assertSame(storedElement1, updated.single { it == storedElement1 })
+        assertSame(storedElement2, updated.single { it == storedElement2 })
+    }
 }

--- a/core/commonTest/src/contract/set/PersistentOrderedSetBuilderTest.kt
+++ b/core/commonTest/src/contract/set/PersistentOrderedSetBuilderTest.kt
@@ -210,6 +210,59 @@ class PersistentOrderedSetBuilderTest {
         assertEquals(listOf(2), builder.build().toList())
     }
 
+    @Test
+    fun `iterator remove keeps the iterator valid`() {
+        val builder = persistentSetOf(1, 2, 3).builder()
+        val iterator = builder.iterator()
+        assertEquals(1, iterator.next())
+        assertEquals(2, iterator.next())
+        iterator.remove()
+
+        assertTrue(iterator.hasNext())
+        assertEquals(3, iterator.next())
+        assertFalse(iterator.hasNext())
+        assertEquals(listOf(1, 3), builder.build().toList())
+    }
+
+    @Test
+    fun `hasNext after a remove of an already visited element and then of every remaining element stays true`() {
+        val builder = persistentSetOf(1, 2, 3).builder()
+        val iterator = builder.iterator()
+        assertEquals(1, iterator.next())
+        assertEquals(2, iterator.next())
+
+        assertTrue(builder.remove(1))
+        assertTrue(iterator.hasNext())
+
+        assertTrue(builder.remove(2))
+        assertTrue(builder.remove(3))
+        assertTrue(iterator.hasNext())
+        assertFailsWith<ConcurrentModificationException> { iterator.next() }
+    }
+
+    @Test
+    fun `hasNext on an exhausted iterator after an external add stays false`() {
+        val builder = persistentSetOf(1, 2, 3).builder()
+        val iterator = builder.iterator()
+        repeat(3) { val _ = iterator.next() }
+        assertFalse(iterator.hasNext())
+
+        assertTrue(builder.add(9))
+
+        assertFalse(iterator.hasNext())
+        assertFailsWith<ConcurrentModificationException> { iterator.next() }
+    }
+
+    @Test
+    fun `hasNext on an iterator of an empty builder after an external add stays false`() {
+        val builder = persistentSetOf<Int>().builder()
+        val iterator = builder.iterator()
+
+        assertTrue(builder.add(1))
+
+        assertFalse(iterator.hasNext())
+    }
+
     private fun key(value: Int): TraceKey = TraceKey(value, hashForValue(value))
 
     private fun keys(vararg values: Int): List<TraceKey> = values.map(::key)

--- a/core/commonTest/src/contract/set/PersistentOrderedSetBuilderTest.kt
+++ b/core/commonTest/src/contract/set/PersistentOrderedSetBuilderTest.kt
@@ -9,6 +9,9 @@ import kotlinx.collections.immutable.persistentSetOf
 import kotlin.collections.LinkedHashSet
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 class PersistentOrderedSetBuilderTest {
 
@@ -116,6 +119,95 @@ class PersistentOrderedSetBuilderTest {
         assertEquals(expectedPersistent, LinkedHashSet(persistent.toList()))
         assertEquals(expectedBuilder, LinkedHashSet(builder.build().toList()))
         assertEquals(expectedBuilder.toList(), builder.build().toList())
+    }
+
+    @Test
+    fun `iterator remove after a remove of a different element throws ConcurrentModificationException`() {
+        val builder = persistentSetOf(1, 2).builder()
+        val iterator = builder.iterator()
+        assertEquals(1, iterator.next())
+
+        assertTrue(builder.remove(2))
+
+        assertFailsWith<ConcurrentModificationException> { iterator.remove() }
+        assertEquals(listOf(1), builder.build().toList())
+        assertFailsWith<ConcurrentModificationException> { iterator.next() }
+    }
+
+    @Test
+    fun `iterator remove after a remove of an already visited element throws ConcurrentModificationException`() {
+        val builder = persistentSetOf(1, 2, 3).builder()
+        val iterator = builder.iterator()
+        assertEquals(1, iterator.next())
+        assertEquals(2, iterator.next())
+
+        assertTrue(builder.remove(1))
+
+        assertFailsWith<ConcurrentModificationException> { iterator.remove() }
+        assertEquals(listOf(2, 3), builder.build().toList())
+    }
+
+    @Test
+    fun `iterator remove after external changes that cancel out in size throws ConcurrentModificationException`() {
+        val builder = persistentSetOf(1, 2, 3).builder()
+        val iterator = builder.iterator()
+        assertEquals(1, iterator.next())
+
+        assertTrue(builder.remove(3))
+        assertTrue(builder.add(4))
+
+        assertTrue(iterator.hasNext())
+        assertFailsWith<ConcurrentModificationException> { iterator.remove() }
+        assertEquals(listOf(1, 2, 4), builder.build().toList())
+    }
+
+    @Test
+    fun `iterator remove on an exhausted iterator after an external add throws ConcurrentModificationException`() {
+        val builder = persistentSetOf(1).builder()
+        val iterator = builder.iterator()
+        assertEquals(1, iterator.next())
+        assertFalse(iterator.hasNext())
+
+        assertTrue(builder.add(2))
+
+        assertFailsWith<ConcurrentModificationException> { iterator.remove() }
+        assertEquals(listOf(1, 2), builder.build().toList())
+        assertFailsWith<ConcurrentModificationException> { iterator.next() }
+    }
+
+    @Test
+    fun `iterator remove after an external clear throws ConcurrentModificationException`() {
+        val builder = persistentSetOf(1, 2).builder()
+        val iterator = builder.iterator()
+        assertEquals(1, iterator.next())
+
+        builder.clear()
+
+        assertFailsWith<ConcurrentModificationException> { iterator.remove() }
+    }
+
+    @Test
+    fun `iterator remove without a preceding next after an external remove throws IllegalStateException`() {
+        val builder = persistentSetOf(1, 2).builder()
+        val iterator = builder.iterator()
+
+        assertTrue(builder.remove(2))
+
+        assertFailsWith<IllegalStateException> { iterator.remove() }
+        assertEquals(listOf(1), builder.build().toList())
+    }
+
+    @Test
+    fun `iterator remove after external calls that change nothing does not throw`() {
+        val builder = persistentSetOf(1, 2).builder()
+        val iterator = builder.iterator()
+        assertEquals(1, iterator.next())
+
+        assertFalse(builder.add(2))
+        assertFalse(builder.remove(3))
+
+        iterator.remove()
+        assertEquals(listOf(2), builder.build().toList())
     }
 
     private fun key(value: Int): TraceKey = TraceKey(value, hashForValue(value))

--- a/core/jvmTest/src/contract/GuavaImmutableCollectionBaseTest.kt
+++ b/core/jvmTest/src/contract/GuavaImmutableCollectionBaseTest.kt
@@ -12,18 +12,6 @@ import java.lang.IllegalArgumentException
 open class GuavaImmutableCollectionBaseTest: TestListener {
     override fun addFailure(test: Test, e: AssertionFailedError) = throw e
     override fun addError(test: Test, e: Throwable) {
-        if (e is ConcurrentModificationException
-                && test is ListSubListTester<*>
-                && test.testMethodName in listOf("testSubList_originalListSetAffectsSubList", "testSubList_originalListSetAffectsSubListLargeList")) {
-            // These test cases check that changes in sublist are reflected in backed list, and vice-versa.
-            // Backed list is structurally modified due to `set` function invocation,
-            // leading to CME when `sublist.listIterator()` gets invoked to iterate elements of sublist to make sure changes are reflected.
-            // The `sublist.listIterator()` method has the comodification check.
-            //
-            // The guava-testlib doesn't expect any exceptions to be thrown,
-            // despite `List.subList` javadoc statement "The semantics of the list returned by this method become undefined" is such case.
-            return
-        }
         if (e is NoSuchElementException
                 // Removing the only element from the sublist and calling `next()` on it's earlier created iterator throws NSEE.
                 && (test is ListRemoveAtIndexTester<*> && test.testMethodName == "testRemoveAtIndexConcurrentWithIteration"


### PR DESCRIPTION
`set` bumped `modCount` only when it had to copy a buffer the builder does not own, so whether a live iterator survived a `set` depended on where the builder came from. `modCount` now counts only size changes, as in the hash map builder since #339, and the iterator rebuilds its cached trie path after a `set` that copied a leaf, so `next()` and `previous()` return the new element in both flavours. On the JVM `subList` views read the same field and follow a `set` now too.

Fixes #340 
